### PR TITLE
fix(provider): getBlock, replace blockId to blockHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.5.1](https://github.com/seanjameshan/starknet.js/compare/v2.5.0...v2.5.1) (2022-01-20)
+
+### Bug Fixes
+
+- **CONTRIBUTING:** wrong link ([2622a6c](https://github.com/seanjameshan/starknet.js/commit/2622a6c984259a6928e9ab02892b8de60b8c749e))
+
 # [2.5.0](https://github.com/seanjameshan/starknet.js/compare/v2.4.0...v2.5.0) (2021-12-13)
 
 ### Bug Fixes

--- a/__tests__/provider.test.ts
+++ b/__tests__/provider.test.ts
@@ -14,9 +14,10 @@ describe('defaultProvider', () => {
       expect(typeof Starknet).toBe('string');
     });
     test('getBlock()', () => {
-      return expect(defaultProvider.getBlock(870)).resolves.not.toThrow();
+      const blockHash = '0x46b3096a651285b10ca26b31140fdab702f862e0273dfe874385fde20d3ca2c';
+      return expect(defaultProvider.getBlock(blockHash)).resolves.not.toThrow();
     });
-    test('getBlock(blockId=null)', () => {
+    test('getBlock(blockHash=null)', () => {
       return expect(defaultProvider.getBlock()).resolves.not.toThrow();
     });
     test('getCode()', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "JavaScript library for StarkNet",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -108,12 +108,12 @@ export class Provider implements ProviderInterface {
    *
    * [Reference](https://github.com/starkware-libs/cairo-lang/blob/f464ec4797361b6be8989e36e02ec690e74ef285/src/starkware/starknet/services/api/feeder_gateway/feeder_gateway_client.py#L27-L31)
    *
-   * @param blockId
+   * @param blockHash
    * @returns the block object { block_id, previous_block_id, state_root, status, timestamp, transaction_receipts, transactions }
    */
-  public async getBlock(blockId?: number): Promise<GetBlockResponse> {
+  public async getBlock(blockHash?: string): Promise<GetBlockResponse> {
     const { data } = await axios.get<GetBlockResponse>(
-      urljoin(this.feederGatewayUrl, 'get_block', `?blockId=${blockId ?? 'null'}`)
+      urljoin(this.feederGatewayUrl, 'get_block', blockHash ? `?blockHash=${blockHash}` : '')
     );
     return data;
   }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -47,10 +47,10 @@ export abstract class ProviderInterface {
    *
    * [Reference](https://github.com/starkware-libs/cairo-lang/blob/f464ec4797361b6be8989e36e02ec690e74ef285/src/starkware/starknet/services/api/feeder_gateway/feeder_gateway_client.py#L27-L31)
    *
-   * @param blockId
+   * @param blockHash
    * @returns the block object { block_id, previous_block_id, state_root, status, timestamp, transaction_receipts, transactions }
    */
-  public abstract getBlock(blockId?: number): Promise<GetBlockResponse>;
+  public abstract getBlock(blockHash?: string): Promise<GetBlockResponse>;
 
   /**
    * Gets the code of the deployed contract.


### PR DESCRIPTION
The param blockId doesn't seem to be working anymore on the getBlock function, this PR replace it to blockHash.

Fix #120 