### PR TITLE
feat(account): introduce execute method

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -83,7 +83,7 @@ describe('deploy and test Wallet', () => {
     expect(number.toBN(res as string).toString()).toStrictEqual(number.toBN(1000).toString());
   });
   test('execute by wallet owner', async () => {
-    const { code, transaction_hash } = await account.invokeFunction({
+    const { code, transaction_hash } = await account.execute({
       contractAddress: erc20Address,
       entrypoint: 'transfer',
       calldata: [toBN(erc20Address).toString(), '10'],
@@ -105,12 +105,15 @@ describe('deploy and test Wallet', () => {
       entrypoint: 'get_nonce',
     });
     const nonce = toBN(result[0]).toNumber();
-    const { code, transaction_hash } = await account.invokeFunction({
-      contractAddress: erc20Address,
-      entrypoint: 'transfer',
-      calldata: [toBN(erc20Address).toString(), '10'],
-      nonce,
-    });
+    const { code, transaction_hash } = await account.execute(
+      {
+        contractAddress: erc20Address,
+        entrypoint: 'transfer',
+        calldata: [toBN(erc20Address).toString(), '10'],
+      },
+      undefined,
+      { nonce }
+    );
 
     expect(code).toBe('TRANSACTION_RECEIVED');
     await defaultProvider.waitForTx(transaction_hash);

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -34,7 +34,7 @@ export class Account extends Provider implements AccountInterface {
   }
 
   /**
-   * Invoke a function on the starknet contract
+   * Invoke execute function in account contract
    *
    * [Reference](https://github.com/starkware-libs/cairo-lang/blob/f464ec4797361b6be8989e36e02ec690e74ef285/src/starkware/starknet/services/api/gateway/gateway_client.py#L13-L17)
    *

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -4,6 +4,7 @@ import {
   AddTransactionResponse,
   DeployContractPayload,
   Invocation,
+  InvocationsDetails,
   Signature,
 } from '../types';
 import { BigNumberish } from '../utils/number';
@@ -30,7 +31,7 @@ export abstract class AccountInterface extends ProviderInterface {
   /**
    * Invokes a function on starknet
    *
-   * @param invocation the invocation object containing:
+   * @param transactions the invocation object or an array of them, containing:
    * - contractAddress - the address of the contract
    * - entrypoint - the entrypoint of the contract
    * - calldata - (defaults to []) the calldata
@@ -39,9 +40,10 @@ export abstract class AccountInterface extends ProviderInterface {
    *
    * @returns response from addTransaction
    */
-  public abstract override invokeFunction(
-    invocation: Invocation,
-    abi?: Abi
+  public abstract execute(
+    transactions: Invocation | Invocation[],
+    abis?: Abi[],
+    transactionsDetail?: InvocationsDetails
   ): Promise<AddTransactionResponse>;
 
   /**

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -3,7 +3,7 @@ import {
   Abi,
   AddTransactionResponse,
   DeployContractPayload,
-  Invocation,
+  ExecuteInvocation,
   InvocationsDetails,
   Signature,
 } from '../types';
@@ -41,7 +41,7 @@ export abstract class AccountInterface extends ProviderInterface {
    * @returns response from addTransaction
    */
   public abstract execute(
-    transactions: Invocation | Invocation[],
+    transactions: ExecuteInvocation | ExecuteInvocation[],
     abis?: Abi[],
     transactionsDetail?: InvocationsDetails
   ): Promise<AddTransactionResponse>;

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -29,7 +29,7 @@ export abstract class AccountInterface extends ProviderInterface {
   ): Promise<AddTransactionResponse>;
 
   /**
-   * Invokes a function on starknet
+   * Invoke execute function in account contract
    *
    * @param transactions the invocation object or an array of them, containing:
    * - contractAddress - the address of the contract

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -41,7 +41,7 @@ export function compileCalldata(args: Args): RawCalldata {
 export class Contract {
   connectedTo: string | null = null;
 
-  abi: Abi[];
+  abi: Abi;
 
   structs: { [name: string]: StructAbi };
 
@@ -53,7 +53,7 @@ export class Contract {
    * @param abi - Abi of the contract object
    * @param address (optional) - address to connect to
    */
-  constructor(abi: Abi[], address: string | null = null, provider: Provider = defaultProvider) {
+  constructor(abi: Abi, address: string | null = null, provider: Provider = defaultProvider) {
     this.connectedTo = address;
     this.provider = provider;
     this.abi = abi;

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -131,7 +131,6 @@ export abstract class ProviderInterface {
    * - entrypoint - the entrypoint of the contract
    * - calldata - (defaults to []) the calldata
    * - signature - (defaults to []) the signature
-   * @param abi (optional) the abi of the contract for better displaying
    *
    * @returns response from addTransaction
    */

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -1,5 +1,4 @@
 import type {
-  Abi,
   AddTransactionResponse,
   Call,
   CallContractResponse,
@@ -120,13 +119,9 @@ export abstract class ProviderInterface {
    * - compiled contract code
    * - constructor calldata
    * - address salt
-   * @param abi the abi of the contract
    * @returns a confirmation of sending a transaction on the starknet contract
    */
-  public abstract deployContract(
-    payload: DeployContractPayload,
-    abi?: Abi
-  ): Promise<AddTransactionResponse>;
+  public abstract deployContract(payload: DeployContractPayload): Promise<AddTransactionResponse>;
 
   /**
    * Invokes a function on starknet
@@ -140,10 +135,7 @@ export abstract class ProviderInterface {
    *
    * @returns response from addTransaction
    */
-  public abstract invokeFunction(
-    invocation: Invocation,
-    abi?: Abi
-  ): Promise<AddTransactionResponse>;
+  public abstract invokeFunction(invocation: Invocation): Promise<AddTransactionResponse>;
 
   public abstract waitForTx(txHash: BigNumberish, retryInterval?: number): Promise<void>;
 }

--- a/src/signer/default.ts
+++ b/src/signer/default.ts
@@ -1,4 +1,4 @@
-import { Abi, KeyPair, Signature, TransactionDetails } from '../types';
+import { Abi, Invocation, InvocationsSignerDetails, KeyPair, Signature } from '../types';
 import { getStarkKey, sign } from '../utils/ellipticCurve';
 import { addHexPrefix } from '../utils/encode';
 import { hashMessage } from '../utils/hash';
@@ -19,9 +19,21 @@ export class Signer implements SignerInterface {
   }
 
   public async signTransaction(
-    { contractAddress, entrypoint, calldata = [], nonce, walletAddress }: TransactionDetails,
-    _abi?: Abi
+    transactions: Invocation[],
+    transactionsDetail: InvocationsSignerDetails,
+    abis: Abi[] = []
   ): Promise<Signature> {
+    if (transactions.length !== 1) {
+      throw new Error('Only one transaction at a time is currently supported by this signer');
+    }
+    if (abis?.length !== 0 && abis.length !== transactions.length) {
+      throw new Error('ABI must be provided for each transaction or no transaction');
+    }
+    // now use abi to display decoded data somewhere, but as this signer is headless, we can't do that
+
+    const { contractAddress, entrypoint, calldata = [] } = transactions[0];
+    const { nonce, walletAddress } = transactionsDetail;
+
     const nonceBn = toBN(nonce);
     const entrypointSelector = getSelectorFromName(entrypoint);
     const calldataDecimal = bigNumberishArrayToDecimalStringArray(calldata);

--- a/src/signer/interface.ts
+++ b/src/signer/interface.ts
@@ -1,4 +1,4 @@
-import { Abi, Signature, TransactionDetails } from '../types';
+import { Abi, Invocation, InvocationsSignerDetails, Signature } from '../types';
 import { TypedData } from '../utils/typedData';
 
 export abstract class SignerInterface {
@@ -31,5 +31,9 @@ export abstract class SignerInterface {
    *
    * @returns signature
    */
-  public abstract signTransaction(transaction: TransactionDetails, abi?: Abi): Promise<Signature>;
+  public abstract signTransaction(
+    transactions: Invocation[],
+    transactionsDetail: InvocationsSignerDetails,
+    abis?: Abi[]
+  ): Promise<Signature>;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -131,7 +131,7 @@ export type GetBlockResponse = {
 
 export type GetCodeResponse = {
   bytecode: string[];
-  abi: Abi[];
+  abi: Abi;
 };
 
 export type GetTransactionStatusResponse = {

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -16,8 +16,11 @@ export type Invocation = {
   contractAddress: string;
   entrypoint: string;
   calldata?: RawCalldata;
-  nonce?: BigNumberish;
   signature?: Signature;
+};
+
+export type InvocationsDetails = {
+  nonce?: BigNumberish;
 };
 
 export type Call = Omit<Invocation, 'signature' | 'nonce'>;
@@ -51,14 +54,14 @@ export type StructAbi = {
   type: 'struct';
 };
 
-export type Abi = FunctionAbi | StructAbi;
+export type Abi = Array<FunctionAbi | StructAbi>;
 
 export type EntryPointsByType = object;
 export type Program = Record<any, any>;
 export type BlockNumber = 'pending' | null | number;
 
 export type CompiledContract = {
-  abi: Abi[];
+  abi: Abi;
   entry_points_by_type: EntryPointsByType;
   program: Program;
 };

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -19,6 +19,8 @@ export type Invocation = {
   signature?: Signature;
 };
 
+export type ExecuteInvocation = Omit<Invocation, 'signature'>;
+
 export type InvocationsDetails = {
   nonce?: BigNumberish;
 };

--- a/src/types/signer.ts
+++ b/src/types/signer.ts
@@ -1,7 +1,5 @@
-import { BigNumberish } from '../utils/number';
-import { Invocation } from './lib';
+import { InvocationsDetails } from './lib';
 
-export interface TransactionDetails extends Omit<Invocation, 'nonce' | 'signature'> {
+export interface InvocationsSignerDetails extends Required<InvocationsDetails> {
   walletAddress: string;
-  nonce: BigNumberish;
 }


### PR DESCRIPTION
This PR aims to support batch transactions natively. 

To archive this it's necessary to introduce a new method and not further inherit the interface of `invokeFunction` which is designed to always match the sequencers api, which in any case accepts one call only.