### PR TITLE
feat: pending as success

### DIFF
--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -1,11 +1,13 @@
 import { AccountInterface } from '../account';
 import { ProviderInterface } from '../provider';
+import { BlockIdentifier } from '../provider/utils';
 import {
   Abi,
   AddTransactionResponse,
   AsyncContractFunction,
   ContractFunction,
   Invocation,
+  Overrides,
   Result,
 } from '../types';
 
@@ -57,7 +59,13 @@ export abstract class ContractInterface {
    * @param args Array of the arguments for the call
    * @returns Result of the call as an array with key value pars
    */
-  public abstract call(method: string, args?: Array<any>): Promise<Result>;
+  public abstract call(
+    method: string,
+    args?: Array<any>,
+    options?: {
+      blockIdentifier?: BlockIdentifier;
+    }
+  ): Promise<Result>;
 
   /**
    * Invokes a method on a contract
@@ -66,7 +74,11 @@ export abstract class ContractInterface {
    * @param args Array of the arguments for the invoke
    * @returns Add Transaction Response
    */
-  public abstract invoke(method: string, args?: Array<any>): Promise<AddTransactionResponse>;
+  public abstract invoke(
+    method: string,
+    args?: Array<any>,
+    options?: Overrides
+  ): Promise<AddTransactionResponse>;
 
   /**
    * Calls a method on a contract
@@ -74,7 +86,13 @@ export abstract class ContractInterface {
    * @param method name of the method
    * @param args Array of the arguments for the call
    */
-  public abstract estimate(method: string, args?: Array<any>): Promise<any>;
+  public abstract estimate(
+    method: string,
+    args?: Array<any>,
+    options?: {
+      blockIdentifier?: BlockIdentifier;
+    }
+  ): Promise<any>;
 
   /**
    * Calls a method on a contract

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -168,14 +168,18 @@ export class Provider implements ProviderInterface {
    */
   public async callContract(
     { contractAddress, entrypoint, calldata = [] }: Call,
-    options: { blockIdentifier: BlockIdentifier } = { blockIdentifier: null }
+    { blockIdentifier = 'pending' }: { blockIdentifier?: BlockIdentifier } = {}
   ): Promise<CallContractResponse> {
-    return this.fetchEndpoint('call_contract', options, {
-      signature: [],
-      contract_address: contractAddress,
-      entry_point_selector: getSelectorFromName(entrypoint),
-      calldata,
-    });
+    return this.fetchEndpoint(
+      'call_contract',
+      { blockIdentifier },
+      {
+        signature: [],
+        contract_address: contractAddress,
+        entry_point_selector: getSelectorFromName(entrypoint),
+        calldata,
+      }
+    );
   }
 
   /**
@@ -187,7 +191,7 @@ export class Provider implements ProviderInterface {
    * @param blockNumber
    * @returns the block object { block_number, previous_block_number, state_root, status, timestamp, transaction_receipts, transactions }
    */
-  public async getBlock(blockIdentifier: BlockIdentifier = null): Promise<GetBlockResponse> {
+  public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
     return this.fetchEndpoint('get_block', { blockIdentifier });
   }
 
@@ -203,7 +207,7 @@ export class Provider implements ProviderInterface {
    */
   public async getCode(
     contractAddress: string,
-    blockIdentifier: BlockIdentifier = null
+    blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<GetCodeResponse> {
     return this.fetchEndpoint('get_code', { blockIdentifier, contractAddress });
   }
@@ -223,7 +227,7 @@ export class Provider implements ProviderInterface {
   public async getStorageAt(
     contractAddress: string,
     key: number,
-    blockIdentifier: BlockIdentifier = null
+    blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<object> {
     return this.fetchEndpoint('get_storage_at', { blockIdentifier, contractAddress, key });
   }

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -348,9 +348,12 @@ export class Provider implements ProviderInterface {
       // eslint-disable-next-line no-await-in-loop
       const res = await this.getTransactionStatus(txHash);
 
-      if (res.tx_status === 'ACCEPTED_ON_L1' || res.tx_status === 'ACCEPTED_ON_L2') {
+      const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];
+      const errorStates = ['REJECTED', 'NOT_RECEIVED'];
+
+      if (successStates.includes(res.tx_status)) {
         onchain = true;
-      } else if (res.tx_status === 'REJECTED' || res.tx_status === 'NOT_RECEIVED') {
+      } else if (errorStates.includes(res.tx_status)) {
         const message = res.tx_failure_reason
           ? `${res.tx_status}: ${res.tx_failure_reason.code}\n${res.tx_failure_reason.error_message}`
           : res.tx_status;

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -344,7 +344,6 @@ export class Provider implements ProviderInterface {
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
     let onchain = false;
-    await wait(retryInterval);
 
     while (!onchain) {
       // eslint-disable-next-line no-await-in-loop

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -191,7 +191,7 @@ export class Provider implements ProviderInterface {
    * @param blockNumber
    * @returns the block object { block_number, previous_block_number, state_root, status, timestamp, transaction_receipts, transactions }
    */
-  public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
+  public async getBlock(blockIdentifier: BlockIdentifier = null): Promise<GetBlockResponse> {
     return this.fetchEndpoint('get_block', { blockIdentifier });
   }
 

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -43,6 +43,12 @@ type BlockIdentifierObject =
  * @returns block identifier object
  */
 export function getBlockIdentifier(blockIdentifier: BlockIdentifier): BlockIdentifierObject {
+  if (blockIdentifier === null) {
+    return { type: 'BLOCK_NUMBER', data: null };
+  }
+  if (blockIdentifier === 'pending') {
+    return { type: 'BLOCK_NUMBER', data: 'pending' };
+  }
   if (typeof blockIdentifier === 'number') {
     return { type: 'BLOCK_NUMBER', data: blockIdentifier };
   }
@@ -51,12 +57,6 @@ export function getBlockIdentifier(blockIdentifier: BlockIdentifier): BlockIdent
   }
   if (typeof blockIdentifier === 'string' && !Number.isNaN(parseInt(blockIdentifier, 10))) {
     return { type: 'BLOCK_NUMBER', data: parseInt(blockIdentifier, 10) };
-  }
-  if (blockIdentifier === null) {
-    return { type: 'BLOCK_NUMBER', data: null };
-  }
-  if (blockIdentifier === 'pending') {
-    return { type: 'BLOCK_NUMBER', data: 'pending' };
   }
   if (typeof blockIdentifier === 'string') {
     throw new Error(`Invalid block identifier: ${blockIdentifier}`);
@@ -69,8 +69,7 @@ export function getBlockIdentifier(blockIdentifier: BlockIdentifier): BlockIdent
  *
  * [Reference](https://github.com/starkware-libs/cairo-lang/blob/fc97bdd8322a7df043c87c371634b26c15ed6cee/src/starkware/starknet/services/api/feeder_gateway/feeder_gateway_client.py#L164-L173)
  *
- * @param blockNumber
- * @param blockHash
+ * @param blockIdentifier
  * @returns block identifier for API request
  */
 export function getFormattedBlockIdentifier(blockIdentifier: BlockIdentifier = null): string {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -75,7 +75,9 @@ export type Endpoints = {
     RESPONSE: CallContractResponse;
   };
   estimate_fee: {
-    QUERY: never;
+    QUERY: {
+      blockIdentifier: BlockIdentifier;
+    };
     REQUEST: CallContractTransaction;
     RESPONSE: EstimateFeeResponse;
   };


### PR DESCRIPTION
After speaking to starkware it turned out "PENDING" should already be used as a done state.
To reflect that in calls we need to query the pending block by default.