### PR TITLE
fix(encode): maximum call stack size exceeded for large compiled cair…

### DIFF
--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -4,7 +4,7 @@ export const IS_BROWSER = typeof window !== 'undefined';
 const STRING_ZERO = '0';
 
 export function arrayBufferToString(array: ArrayBuffer): string {
-  return new Uint8Array(array).reduce(function (data, byte) {
+  return new Uint8Array(array).reduce((data, byte) => {
     return data + String.fromCharCode(byte);
   }, '');
 }

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -4,7 +4,9 @@ export const IS_BROWSER = typeof window !== 'undefined';
 const STRING_ZERO = '0';
 
 export function arrayBufferToString(array: ArrayBuffer): string {
-  return String.fromCharCode.apply(null, array as unknown as number[]);
+  return new Uint8Array(array).reduce(function (data, byte) {
+    return data + String.fromCharCode(byte);
+  }, '');
 }
 
 export function btoaUniversal(b: ArrayBuffer): string {


### PR DESCRIPTION
maximum call stack size exceeded error when the cairo file size is larger than 8 mb. I have put in the fix.