### PR TITLE
fix: allow starknet.js in service workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Guides can be found [here](https://www.starknetjs.com/guides/intro)
 ## 🚀 Powered by Starknet.js
 
 - [Argent X - the first StarkNet wallet](https://github.com/argentlabs/argent-x)
+- [Braavos - your new wallet on top of StarkNet](https://chrome.google.com/webstore/detail/braavos-wallet/jnlgamecbpmbajjfhmmmlhejkemejdma)
 - [React + Starknet.js boilerplate](https://github.com/fracek/starknet-react-example)
 - [AMM Demo](https://www.starknetswap.com/)
+- [mySwap - the first DeFi app to launch on StarkNet](myswap.xyz)
 
 ## ✏️ Contributing
 

--- a/__tests__/jest.setup.ts
+++ b/__tests__/jest.setup.ts
@@ -1,9 +1,28 @@
-import axios from 'axios';
-import * as AxiosLogger from 'axios-logger';
+/* eslint-disable no-console */
+import { register } from 'fetch-intercept';
 
 jest.setTimeout(50 * 60 * 1000);
 
 if (process.env.DEBUG === 'true') {
-  axios.interceptors.request.use(AxiosLogger.requestLogger, AxiosLogger.errorLogger);
-  axios.interceptors.response.use(AxiosLogger.responseLogger, AxiosLogger.errorLogger);
+  register({
+    request(url, config) {
+      console.log('[fetch.request]', [url, config]);
+      return [url, config];
+    },
+
+    requestError(error) {
+      console.log('[fetch.requestError]', error);
+      return Promise.reject(error);
+    },
+
+    response(response) {
+      console.log('[fetch.response]', response);
+      return response;
+    },
+
+    responseError(error) {
+      console.log('[fetch.responseError]', error);
+      return Promise.reject(error);
+    },
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
-        "axios": "^0.23.0",
         "bn.js": "^5.2.0",
+        "cross-fetch": "^3.1.5",
         "elliptic": "^6.5.4",
         "ethereum-cryptography": "^0.2.0",
+        "fetch-intercept": "^2.4.0",
         "hash.js": "^1.1.7",
         "json-bigint": "^1.0.0",
         "minimalistic-assert": "^1.0.1",
@@ -39,7 +40,6 @@
         "@types/url-join": "^4.0.1",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
-        "axios-logger": "^2.6.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-airbnb-typescript": "^14.0.1",
@@ -53,7 +53,8 @@
         "prettier": "^2.4.1",
         "prettier-plugin-import-sort": "^0.0.7",
         "typedoc": "^0.22.6",
-        "typescript": "^4.4.4"
+        "typescript": "^4.4.4",
+        "whatwg-fetch": "^3.6.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3144,12 +3145,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/dateformat": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
-      "integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==",
-      "dev": true
-    },
     "node_modules/@types/elliptic": {
       "version": "6.4.13",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.13.tgz",
@@ -3751,25 +3746,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/axios-logger": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/axios-logger/-/axios-logger-2.6.0.tgz",
-      "integrity": "sha512-ogDepYNCul91KWf+BV8tweB3gm4n2apA69L9aY5fUO2Pvck/gIK4Q+zs7avduyxaOn88ZzSWv0PeMZaxBt+YOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/dateformat": "^3.0.1",
-        "chalk": "^4.1.0",
-        "dateformat": "^3.0.3"
       }
     },
     "node_modules/babel-jest": {
@@ -4533,6 +4509,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5595,6 +5579,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-intercept": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fetch-intercept/-/fetch-intercept-2.4.0.tgz",
+      "integrity": "sha512-BPZ2LM9Dh1ua2ovQf03N6rhWg1qxdVD5qK/G4llvcemt6M+jjxCuIDxJ+6IiG+uz//3UQmgfKEv0gOGvYIxZ7g=="
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5703,25 +5692,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -8513,8 +8483,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8533,23 +8501,17 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true,
-      "peer": true
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true,
-      "peer": true
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -16594,6 +16556,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -19110,12 +19078,6 @@
         "@types/node": "*"
       }
     },
-    "@types/dateformat": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
-      "integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==",
-      "dev": true
-    },
     "@types/elliptic": {
       "version": "6.4.13",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.13.tgz",
@@ -19566,25 +19528,6 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "axios-logger": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/axios-logger/-/axios-logger-2.6.0.tgz",
-      "integrity": "sha512-ogDepYNCul91KWf+BV8tweB3gm4n2apA69L9aY5fUO2Pvck/gIK4Q+zs7avduyxaOn88ZzSWv0PeMZaxBt+YOw==",
-      "dev": true,
-      "requires": {
-        "@types/dateformat": "^3.0.1",
-        "chalk": "^4.1.0",
-        "dateformat": "^3.0.3"
-      }
     },
     "babel-jest": {
       "version": "27.3.0",
@@ -20182,6 +20125,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -21012,6 +20963,11 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-intercept": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fetch-intercept/-/fetch-intercept-2.4.0.tgz",
+      "integrity": "sha512-BPZ2LM9Dh1ua2ovQf03N6rhWg1qxdVD5qK/G4llvcemt6M+jjxCuIDxJ+6IiG+uz//3UQmgfKEv0gOGvYIxZ7g=="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -21095,11 +21051,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -23236,8 +23187,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -23245,23 +23194,17 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-          "dev": true,
-          "peer": true
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true,
-          "peer": true
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "dev": true,
-          "peer": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -29186,6 +29129,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/url-join": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "axios-logger": "^2.6.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^14.0.1",
@@ -58,14 +57,16 @@
     "prettier": "^2.4.1",
     "prettier-plugin-import-sort": "^0.0.7",
     "typedoc": "^0.22.6",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "whatwg-fetch": "^3.6.2"
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.6.1",
-    "axios": "^0.23.0",
     "bn.js": "^5.2.0",
+    "cross-fetch": "^3.1.5",
     "elliptic": "^6.5.4",
     "ethereum-cryptography": "^0.2.0",
+    "fetch-intercept": "^2.4.0",
     "hash.js": "^1.1.7",
     "json-bigint": "^1.0.0",
     "minimalistic-assert": "^1.0.1",


### PR DESCRIPTION
axios (which uses the `XMLHttpRequest` interface) isn't supported in service workers.
instead, we can use `cross-fetch` which supports single js code for node, browser and react-native