### PR TITLE
feat: support contract declaration API introduced at SN 0.9.0

### DIFF
--- a/__tests__/provider.test.ts
+++ b/__tests__/provider.test.ts
@@ -1,6 +1,6 @@
 import { defaultProvider, stark } from '../src';
 import { toBN } from '../src/utils/number';
-import { compiledArgentAccount } from './fixtures';
+import { compiledArgentAccount, compiledErc20 } from './fixtures';
 
 const { compileCalldata } = stark;
 
@@ -123,6 +123,16 @@ describe('defaultProvider', () => {
   });
 
   describe('addTransaction()', () => {
+    test('declareContract()', async () => {
+      const response = await defaultProvider.declareContract({
+        contract: compiledErc20,
+      });
+
+      expect(response.code).toBe('TRANSACTION_RECEIVED');
+      expect(response.transaction_hash).toBeDefined();
+      expect(response.class_hash).toBeDefined();
+    });
+
     test('deployContract()', async () => {
       const response = await defaultProvider.deployContract({
         contract: compiledArgentAccount,

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -143,6 +143,7 @@ export class Account extends Provider implements AccountInterface {
    */
   public async LEGACY_addTransaction(transaction: Transaction): Promise<AddTransactionResponse> {
     if (transaction.type === 'DEPLOY') throw new Error('No DEPLOYS');
+    if (transaction.type === 'DECLARE') throw new Error('No DECLARES');
 
     assert(
       !transaction.signature,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ export enum StarknetChainId {
   TESTNET = '0x534e5f474f45524c49', // encodeShortString('SN_GOERLI'),
 }
 export enum TransactionHashPrefix {
+  DECLARE = '0x6465636c617265', // encodeShortString('declare'),
   DEPLOY = '0x6465706c6f79', // encodeShortString('deploy'),
   INVOKE = '0x696e766f6b65', // encodeShortString('invoke'),
   L1_HANDLER = '0x6c315f68616e646c6572', // encodeShortString('l1_handler'),

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -316,10 +316,7 @@ export class Provider implements ProviderInterface {
    * @param contract - a json object containing the compiled contract
    * @returns a confirmation of sending a transaction on the starknet contract
    */
-  public declareContract(
-    payload: DeclareContractPayload,
-    _abi?: Abi
-  ): Promise<AddTransactionResponse> {
+  public declareContract(payload: DeclareContractPayload): Promise<AddTransactionResponse> {
     const parsedContract =
       typeof payload.contract === 'string'
         ? (parse(payload.contract) as CompiledContract)

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -97,6 +97,14 @@ export type GetContractAddressesResponse = {
   GpsStatementVerifier: string;
 };
 
+export type DeclareTransaction = {
+  type: 'DECLARE';
+  contract_class: CompressedCompiledContract;
+  nonce: BigNumberish;
+  sender_address: BigNumberish;
+  signature: Signature;
+};
+
 export type DeployTransaction = {
   type: 'DEPLOY';
   contract_definition: CompressedCompiledContract;
@@ -148,7 +156,7 @@ export type CallContractTransaction = Omit<
   'type' | 'entry_point_type' | 'nonce'
 >;
 
-export type Transaction = DeployTransaction | InvokeFunctionTransaction;
+export type Transaction = DeclareTransaction | DeployTransaction | InvokeFunctionTransaction;
 
 export type CallContractResponse = {
   result: string[];
@@ -224,6 +232,7 @@ export type AddTransactionResponse = {
   code: TransactionStatus;
   transaction_hash: string;
   address?: string;
+  class_hash?: string;
 };
 
 export type TransactionReceiptResponse = {

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -12,6 +12,10 @@ export type DeployContractPayload = {
   addressSalt?: BigNumberish;
 };
 
+export type DeclareContractPayload = {
+  contract: CompiledContract | string;
+};
+
 export type Invocation = {
   contractAddress: string;
   entrypoint: string;
@@ -35,7 +39,7 @@ export type Status =
   | 'ACCEPTED_ON_L1'
   | 'REJECTED';
 export type TransactionStatus = 'TRANSACTION_RECEIVED';
-export type Type = 'DEPLOY' | 'INVOKE_FUNCTION';
+export type Type = 'DECLARE' | 'DEPLOY' | 'INVOKE_FUNCTION';
 export type EntryPointType = 'EXTERNAL';
 export type CompressedProgram = string;
 

--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -198,9 +198,26 @@ Gets the transaction trace from a tx hash.
 
 <hr/>
 
+provider.**declareContract**(payload [ , abi ]) => _Promise < AddTransactionResponse >_
+
+Declares a contract on Starknet
+
+###### _AddTransactionResponse_
+
+```
+{
+  code: 'TRANSACTION_RECEIVED';
+  transaction_hash: string;
+  class_hash: string;
+};
+
+<hr/>
+
+```
+
 provider.**deployContract**(payload [ , abi ]) => _Promise < AddTransactionResponse >_
 
-Gets the transaction trace from a tx hash.
+Deploys a contract on Starknet
 
 ###### _AddTransactionResponse_
 

--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -198,7 +198,7 @@ Gets the transaction trace from a tx hash.
 
 <hr/>
 
-provider.**declareContract**(payload [ , abi ]) => _Promise < AddTransactionResponse >_
+provider.**declareContract**(payload) => _Promise < AddTransactionResponse >_
 
 Declares a contract on Starknet
 


### PR DESCRIPTION
This PR introduces support for the new 'declare' workflow introduced at Starknet's latest 0.9.0 upgrade.
[Starknet docs](https://docs.starknet.io/docs/Blocks/transactions/#declare-transaction)