### PR TITLE
fix: throw error without formatting

### DIFF
--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -176,7 +176,7 @@ export class Provider implements ProviderInterface {
         return parse(res) as Endpoints[T]['RESPONSE'];
       })
       .catch((err) => {
-        throw Error(`Could not ${method} from endpoint \`${url}\`: ${err.message}`);
+        throw err;
       });
   }
 

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -174,9 +174,6 @@ export class Provider implements ProviderInterface {
           });
         }
         return parse(res) as Endpoints[T]['RESPONSE'];
-      })
-      .catch((err) => {
-        throw err;
       });
   }
 


### PR DESCRIPTION
The dapps should handle the error however they want if thrown by `fetchEndpoint` method