### PR TITLE
Fix GatewayError error path 

### DIFF
--- a/__tests__/provider.test.ts
+++ b/__tests__/provider.test.ts
@@ -1,4 +1,5 @@
 import { BlockNumber, stark } from '../src';
+import { GatewayError } from '../src/provider/utils';
 import { toBN } from '../src/utils/number';
 import {
   IS_DEVNET,
@@ -123,6 +124,7 @@ describe('defaultProvider', () => {
       try {
         await promise;
       } catch (e) {
+        expect(e).toBeInstanceOf(GatewayError);
         expect(e.errorCode).toMatchInlineSnapshot(
           IS_DEVNET ? `500n` : `"StarknetErrorCode.ENTRY_POINT_NOT_FOUND_IN_CONTRACT"`
         );

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -86,5 +86,6 @@ export function getFormattedBlockIdentifier(blockIdentifier: BlockIdentifier = n
 export class GatewayError extends Error {
   constructor(message: string, public errorCode: string) {
     super(message);
+    Object.setPrototypeOf(this, GatewayError.prototype);
   }
 }


### PR DESCRIPTION
In testing i found that the error might not be recognised properly with `instanceof` as per this issue:
https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work