### PR TITLE
fix(docs): account.address

### DIFF
--- a/www/docs/API/account.md
+++ b/www/docs/API/account.md
@@ -18,7 +18,7 @@ For creating new instance of Account, account contract must be deployed. Also th
 
 ## Account Properties
 
-contract.**address** => _string_
+account.**address** => _string_
 
 The address of the account contract
 


### PR DESCRIPTION
The structor of Account is:

src/account/default.ts:32
```
export class Account extends Provider implements AccountInterface {
  public address: string;
  ...
```

The address of Account should be get by `Account.address`, instead of `Contract.address`.