### PR TITLE
feat: support SN 0.9.1 estimate_fee response

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -83,10 +83,15 @@ export class Account extends Provider implements AccountInterface {
         signature: bigNumberishArrayToDecimalStringArray(signature),
       }
     );
-    const suggestedMaxFee = estimatedFeeToMaxFee(fetchedEstimate.amount);
+    const fee = fetchedEstimate.overall_fee ?? fetchedEstimate.amount;
+    if (fee === undefined) {
+      throw new Error('Expected either amount or overall_fee in estimate_fee response');
+    }
+    const suggestedMaxFee = estimatedFeeToMaxFee(fee);
 
     return {
-      ...fetchedEstimate,
+      amount: fee,
+      unit: fetchedEstimate.unit,
       suggestedMaxFee,
     };
   }

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -2,9 +2,10 @@ import BN from 'bn.js';
 
 import { BlockIdentifier } from '../provider/utils';
 import { BigNumberish } from '../utils/number';
-import { EstimateFeeResponse } from './api';
 
-export interface EstimateFee extends EstimateFeeResponse {
+export interface EstimateFee {
+  amount: BN;
+  unit: string;
   suggestedMaxFee: BN;
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -280,9 +280,13 @@ export type TransactionReceiptResponse =
   | SuccessfulTransactionReceiptResponse
   | FailedTransactionReceiptResponse;
 
+// Support 0.9.1 changes in a backward-compatible way
 export type EstimateFeeResponse = {
-  amount: BN;
+  overall_fee?: BN;
+  amount?: BN;
   unit: string;
+  gas_price?: BN;
+  gas_usage?: BigNumberish;
 };
 
 export type RawArgs = {


### PR DESCRIPTION
estimate_fee response was changed. namely 'amount'->'overall_fee'

Added support in a backward-compatible manner per @janek26 suggestion