### PR TITLE
fix: 'fetch is not defined' on node dev

### DIFF
--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -1,4 +1,5 @@
 import urljoin from 'url-join';
+import fetch from 'cross-fetch';
 
 import { ONE, StarknetChainId, ZERO } from '../constants';
 import {


### PR DESCRIPTION
Issue: 
Following error on `node` env in `v3.17.0`:
`fetch is not defined`

Solution: 
We should use the `fetch` function of `cross-fetch` (i.e. `import fetch from 'cross-fetch'`) instead of using the global fetch (on browsers `window.fetch`, on node `this.fetch`).