### PR TITLE
fix: RPC provider getEvents

### DIFF
--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -99,10 +99,10 @@ export namespace RPC {
     | boolean;
 
   export type EventFilter = {
-    fromBlock: string;
-    toBlock: string;
-    address: string;
-    keys: string[];
+    fromBlock: number;
+    toBlock: number;
+    address?: string;
+    keys?: string[];
     page_size: number;
     page_number: number;
   };

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -110,7 +110,7 @@ export namespace RPC {
   export type GetEventsResponse = {
     events: StarknetEmittedEvent[];
     page_number: number;
-    is_last_page: number;
+    is_last_page: boolean;
   };
 
   export type DeployContractResponse = {


### PR DESCRIPTION
The getEvents query on the Pathfinder RPC implementation has optional `address` and `keys` which is more valuable for many use cases. This does unfortunately differ from the RPC spec https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json BUT considering Pathfinder is the largest node implementation, we should support that. I will also be reaching out to Starkware to see if we can update the openrpc spec.

Also fromBlock and toBlock should be numbers and getEventResponse.islastpage should be a boolean 
```json
{
	"jsonrpc":"2.0",
	"method":"starknet_getEvents",
    "params": [
        {"fromBlock": 277645, "toBlock": 277700, "page_size": 1000, "page_number": 1}
    ],
	"id":1
}
```
