### PR TITLE
Correct minor error in documentation

### DIFF
--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -175,7 +175,7 @@ Deploys a contract on Starknet
 
 <hr/>
 
-provider.\*\*waitForTransaction(txHash [ , retryInterval]) => _Promise < void >_
+provider.**waitForTransaction**(txHash [ , retryInterval]) => _Promise < void >_
 
 Wait for the transaction to be accepted on L2 or L1.
 


### PR DESCRIPTION
A typo in the description of the waitForTransaction() method was preventing the method name from appearing in bold.