### PR TITLE
feat: get-code

### DIFF
--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -62,6 +62,11 @@ describe('defaultProvider', () => {
       return expect(block).toHaveProperty('block_number');
     });
 
+    test('getCode() -> { bytecode }', async () => {
+      const code = await testProvider.getCode(exampleContractAddress);
+      return expect(Array.isArray(code.bytecode)).toBe(true);
+    });
+
     describe('getStorageAt', () => {
       test('with "key" type of number', () => {
         return expect(testProvider.getStorageAt(exampleContractAddress, 0)).resolves.not.toThrow();

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/minimalistic-assert": "^1.0.1",
         "@types/pako": "^2.0.0",
         "@types/url-join": "^4.0.1",
-        "@types/whatwg-fetch": "^0.0.33",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "eslint": "^8.17.0",
@@ -56,8 +55,7 @@
         "prettier": "^2.7.0",
         "prettier-plugin-import-sort": "^0.0.7",
         "typedoc": "^0.22.17",
-        "typescript": "^4.7.3",
-        "whatwg-fetch": "^3.6.2"
+        "typescript": "^4.7.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3788,26 +3786,6 @@
       "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==",
       "dev": true
     },
-    "node_modules/@types/whatwg-fetch": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-fetch/-/whatwg-fetch-0.0.33.tgz",
-      "integrity": "sha512-XSWTlUwpjUyLiDu50HhtpUyhvt7QND1ANfyFfiw/TH63GC1ngZMl2rgxuH5SQKfPjMoKRXv94r7crWnJ3mg5tA==",
-      "deprecated": "fetch types are now provided by '--lib dom'",
-      "dev": true,
-      "dependencies": {
-        "@types/whatwg-streams": "*"
-      }
-    },
-    "node_modules/@types/whatwg-streams": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-3.2.1.tgz",
-      "integrity": "sha512-Syv05sRL25b8cC8tqgXSQgLZZmqGq2GO+NafrtHbjPJccP6gWBXmHvo2Trw3AWXQ4QLIkVuOB7uStCuhzswyiw==",
-      "deprecated": "This is a stub types definition. whatwg-streams provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "whatwg-streams": "*"
-      }
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
@@ -4525,12 +4503,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.8.tgz",
-      "integrity": "sha512-e8rlJcByuxPdMiiwU3lGtENflMtUncAblzSlN7rBAZ9ygb75D/rng3Xt5FbZpYqVCzK+sFHVIMht4G6fbfUfbA==",
-      "dev": true
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -5298,12 +5270,6 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
-    "node_modules/deep-equal": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
-      "integrity": "sha512-rUCt39nKM7s6qUyYgp/reJmtXjgkOS/JbLO24DioMZaBNkD3b7C7cD3zJjSyjclEElNTpetAIRD6fMIbBIbX1Q==",
-      "dev": true
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5343,12 +5309,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/defined": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
-      "dev": true
     },
     "node_modules/del": {
       "version": "6.1.1",
@@ -9514,15 +9474,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -10792,8 +10743,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-4.1.0.tgz",
-      "integrity": "sha512-cPQmIQ2Q0vuOfrenrA3isikdMFMAHgzlXV+EmvZ8f2JeJsU5xTU2bG7ipXECiMvPF9nM+QDnMLuIg8QLw9H4xg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10827,8 +10776,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.0.tgz",
-      "integrity": "sha512-DmfBvNXGaetMxj9LTp8NAN9vEidXURrf5ZTslQzEAi/6GbW+4yjaLFQc6Tue5cpZ9Frlk4OBo/Snf1Bh/S7qTQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10882,8 +10829,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-2.0.3.tgz",
-      "integrity": "sha512-X6suAun5QyupNM8iHkNPh0AHdRC2rb1W+MTdMvvA/2ixgmqZwlq5cGUBgmKHUHT2LgrkKJMAXbfAoTxOigpK8Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11099,8 +11044,6 @@
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
-      "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11522,8 +11465,6 @@
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -11817,8 +11758,6 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -13017,8 +12956,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14402,15 +14339,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
-      "dev": true,
-      "dependencies": {
-        "through": "~2.3.4"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15128,23 +15056,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/tape": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
-      "integrity": "sha512-V3tQqlti/JJm577hhDdoCOw1xl4aPcDjTY6PesnFjWDcUYzB6fz39ETXFQuPr9piaoHPfc65sjAehTgbfXOvxQ==",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": "~0.1.0",
-        "defined": "~0.0.0",
-        "inherits": "~2.0.1",
-        "jsonify": "~0.0.0",
-        "resumer": "~0.0.0",
-        "through": "~2.3.4"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      }
-    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -15798,16 +15709,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-streams": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-streams/-/whatwg-streams-0.1.1.tgz",
-      "integrity": "sha512-+UIxdkkbcbhhmcDJIdgVtGTJ7sxV81MY1K++LIWufM8BnIXek3andXURjVs8rV8h2MEFLQbH6YPPZOZATIkZiw==",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "~1.0.0",
-        "tape": "~2.3.2"
       }
     },
     "node_modules/whatwg-url": {
@@ -18916,24 +18817,6 @@
       "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==",
       "dev": true
     },
-    "@types/whatwg-fetch": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-fetch/-/whatwg-fetch-0.0.33.tgz",
-      "integrity": "sha512-XSWTlUwpjUyLiDu50HhtpUyhvt7QND1ANfyFfiw/TH63GC1ngZMl2rgxuH5SQKfPjMoKRXv94r7crWnJ3mg5tA==",
-      "dev": true,
-      "requires": {
-        "@types/whatwg-streams": "*"
-      }
-    },
-    "@types/whatwg-streams": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-3.2.1.tgz",
-      "integrity": "sha512-Syv05sRL25b8cC8tqgXSQgLZZmqGq2GO+NafrtHbjPJccP6gWBXmHvo2Trw3AWXQ4QLIkVuOB7uStCuhzswyiw==",
-      "dev": true,
-      "requires": {
-        "whatwg-streams": "*"
-      }
-    },
     "@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
@@ -19438,12 +19321,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
       "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-    },
-    "bluebird": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.8.tgz",
-      "integrity": "sha512-e8rlJcByuxPdMiiwU3lGtENflMtUncAblzSlN7rBAZ9ygb75D/rng3Xt5FbZpYqVCzK+sFHVIMht4G6fbfUfbA==",
-      "dev": true
     },
     "bn.js": {
       "version": "5.2.1",
@@ -20040,12 +19917,6 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
-    "deep-equal": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
-      "integrity": "sha512-rUCt39nKM7s6qUyYgp/reJmtXjgkOS/JbLO24DioMZaBNkD3b7C7cD3zJjSyjclEElNTpetAIRD6fMIbBIbX1Q==",
-      "dev": true
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -20073,12 +19944,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "defined": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
-      "dev": true
     },
     "del": {
       "version": "6.1.1",
@@ -23198,12 +23063,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
-      "dev": true
-    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -24101,8 +23960,6 @@
         },
         "@npmcli/config": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-4.1.0.tgz",
-          "integrity": "sha512-cPQmIQ2Q0vuOfrenrA3isikdMFMAHgzlXV+EmvZ8f2JeJsU5xTU2bG7ipXECiMvPF9nM+QDnMLuIg8QLw9H4xg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24128,8 +23985,6 @@
         },
         "@npmcli/fs": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.0.tgz",
-          "integrity": "sha512-DmfBvNXGaetMxj9LTp8NAN9vEidXURrf5ZTslQzEAi/6GbW+4yjaLFQc6Tue5cpZ9Frlk4OBo/Snf1Bh/S7qTQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24168,8 +24023,6 @@
         },
         "@npmcli/map-workspaces": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-2.0.3.tgz",
-          "integrity": "sha512-X6suAun5QyupNM8iHkNPh0AHdRC2rb1W+MTdMvvA/2ixgmqZwlq5cGUBgmKHUHT2LgrkKJMAXbfAoTxOigpK8Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24326,8 +24179,6 @@
         },
         "are-we-there-yet": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
-          "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24646,8 +24497,6 @@
         },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-          "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
           "bundled": true,
           "dev": true
         },
@@ -24872,8 +24721,6 @@
         },
         "ip": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-          "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
           "bundled": true,
           "dev": true
         },
@@ -25750,8 +25597,6 @@
         },
         "socks": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-          "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26801,15 +26646,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
-      "dev": true,
-      "requires": {
-        "through": "~2.3.4"
-      }
-    },
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -27367,20 +27203,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "tape": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
-      "integrity": "sha512-V3tQqlti/JJm577hhDdoCOw1xl4aPcDjTY6PesnFjWDcUYzB6fz39ETXFQuPr9piaoHPfc65sjAehTgbfXOvxQ==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "~0.1.0",
-        "defined": "~0.0.0",
-        "inherits": "~2.0.1",
-        "jsonify": "~0.0.0",
-        "resumer": "~0.0.0",
-        "through": "~2.3.4"
-      }
-    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -27882,16 +27704,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true
-    },
-    "whatwg-streams": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-streams/-/whatwg-streams-0.1.1.tgz",
-      "integrity": "sha512-+UIxdkkbcbhhmcDJIdgVtGTJ7sxV81MY1K++LIWufM8BnIXek3andXURjVs8rV8h2MEFLQbH6YPPZOZATIkZiw==",
-      "dev": true,
-      "requires": {
-        "bluebird": "~1.0.0",
-        "tape": "~2.3.2"
-      }
     },
     "whatwg-url": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/minimalistic-assert": "^1.0.1",
     "@types/pako": "^2.0.0",
     "@types/url-join": "^4.0.1",
-    "@types/whatwg-fetch": "^0.0.33",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "eslint": "^8.17.0",
@@ -61,8 +60,7 @@
     "prettier": "^2.7.0",
     "prettier-plugin-import-sort": "^0.0.7",
     "typedoc": "^0.22.17",
-    "typescript": "^4.7.3",
-    "whatwg-fetch": "^3.6.2"
+    "typescript": "^4.7.3"
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.6.1",

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -10,6 +10,7 @@ import {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
+  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -101,6 +102,13 @@ export class Provider implements ProviderInterface {
 
   public async declareContract(payload: DeclareContractPayload): Promise<DeclareContractResponse> {
     return this.provider.declareContract(payload);
+  }
+
+  public async getCode(
+    contractAddress: string,
+    blockIdentifier?: BlockIdentifier
+  ): Promise<GetCodeResponse> {
+    return this.provider.getCode(contractAddress, blockIdentifier);
   }
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<void> {

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -10,6 +10,7 @@ import type {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
+  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -41,6 +42,11 @@ export abstract class ProviderInterface {
    * @returns the block object
    */
   public abstract getBlock(blockIdentifier: BlockIdentifier): Promise<GetBlockResponse>;
+
+  public abstract getCode(
+    contractAddress: string,
+    blockIdentifier?: BlockIdentifier
+  ): Promise<GetCodeResponse>;
 
   /**
    * Gets the contract class of the deployed contract.

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -213,6 +213,15 @@ export class RpcProvider implements ProviderInterface {
     return this.responseParser.parseCallContractResponse(result);
   }
 
+  public async getCode(
+    contractAddress: string,
+    _blockIdentifier?: BlockIdentifier
+  ): Promise<RPC.GetCodeResponse> {
+    const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
+
+    return this.responseParser.parseGetCodeResponse(result);
+  }
+
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
     let onchain = false;
     let retries = 100;

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -323,6 +323,15 @@ export class SequencerProvider implements ProviderInterface {
     ).then(this.responseParser.parseFeeEstimateResponse);
   }
 
+  public async getCode(
+    contractAddress: string,
+    blockIdentifier: BlockIdentifier = 'pending'
+  ): Promise<Sequencer.GetCodeResponse> {
+    return this.fetchEndpoint('get_code', { contractAddress, blockIdentifier }).then(
+      this.responseParser.parseGetCodeResponse
+    );
+  }
+
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
     let onchain = false;
 

--- a/src/types/api/sequencer.ts
+++ b/src/types/api/sequencer.ts
@@ -53,11 +53,6 @@ export type ExecutionResources = {
   n_memory_holes: number;
 };
 
-export type GetCodeResponse = {
-  bytecode: string[];
-  abi: Abi;
-};
-
 export type GetTransactionTraceResponse = {
   function_invocation: {
     caller_address: string;
@@ -114,6 +109,11 @@ export namespace Sequencer {
     code?: TransactionStatus;
     address?: string;
     class_hash?: string;
+  };
+
+  export type GetCodeResponse = {
+    bytecode: string[];
+    abi: Abi;
   };
 
   export interface InvokeFunctionTransactionResponse extends InvokeFunctionTransaction {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -16,6 +16,11 @@ export interface GetBlockResponse {
   starknet_version?: string;
 }
 
+export interface GetCodeResponse {
+  bytecode: string[];
+  // abi: string; // is not consistent between rpc and sequencer (is it?), therefore not included in the provider interface
+}
+
 export type GetTransactionResponse = InvokeTransactionResponse & DeclareTransactionResponse;
 
 export interface CommonTransactionResponse {

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -57,6 +57,10 @@ export class RPCResponseParser extends ResponseParser {
     };
   }
 
+  public parseGetCodeResponse(res: RPC.GetCodeResponse): RPC.GetCodeResponse {
+    return res;
+  }
+
   public parseFeeEstimateResponse(res: RPC.EstimateFeeResponse): EstimateFeeResponse {
     return {
       overall_fee: toBN(res.overall_fee),

--- a/src/utils/responseParser/sequencer.ts
+++ b/src/utils/responseParser/sequencer.ts
@@ -70,6 +70,10 @@ export class SequencerAPIResponseParser extends ResponseParser {
     };
   }
 
+  public parseGetCodeResponse(res: Sequencer.GetCodeResponse): Sequencer.GetCodeResponse {
+    return res;
+  }
+
   public parseFeeEstimateResponse(res: Sequencer.EstimateFeeResponse): EstimateFeeResponse {
     if ('overall_fee' in res) {
       let gasInfo = {};


### PR DESCRIPTION
adds the currently supported `getCode` endpoint for rpc and sequencer
In the future this will be replaced by contract class calls, but that's not supported right now while get_code is supported by sequencer and rpc