### PR TITLE
fix(sequenceProvider): feederGatewayUrl and gatewayUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,4 @@ export * as uint256 from './utils/uint256';
 export * as shortString from './utils/shortString';
 export * as typedData from './utils/typedData';
 export * from './utils/address';
+export * from './utils/url';

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -31,7 +31,7 @@ import { BigNumberish, bigNumberishArrayToDecimalStringArray, toBN, toHex } from
 import { parseContract, wait } from '../utils/provider';
 import { SequencerAPIResponseParser } from '../utils/responseParser/sequencer';
 import { randomAddress } from '../utils/stark';
-import { isUrl } from '../utils/url';
+import { buildUrl } from '../utils/url';
 import { GatewayError, HttpError } from './errors';
 import { ProviderInterface } from './interface';
 import { BlockIdentifier, getFormattedBlockIdentifier } from './utils';
@@ -75,12 +75,12 @@ export class SequencerProvider implements ProviderInterface {
       this.gatewayUrl = urljoin(this.baseUrl, 'gateway');
     } else {
       this.baseUrl = optionsOrProvider.baseUrl;
-      this.feederGatewayUrl = this.parseUrlOrPath(
+      this.feederGatewayUrl = buildUrl(
         this.baseUrl,
         'feeder_gateway',
         optionsOrProvider.feederGatewayUrl
       );
-      this.gatewayUrl = this.parseUrlOrPath(this.baseUrl, 'gateway', optionsOrProvider.gatewayUrl);
+      this.gatewayUrl = buildUrl(this.baseUrl, 'gateway', optionsOrProvider.gatewayUrl);
 
       this.chainId =
         optionsOrProvider.chainId ??
@@ -109,16 +109,6 @@ export class SequencerProvider implements ProviderInterface {
       console.error(`Could not parse baseUrl: ${baseUrl}`);
     }
     return StarknetChainId.TESTNET;
-  }
-
-  private parseUrlOrPath(baseUrl: string, defaultPath: string, urlOrPath?: string) {
-    if (urlOrPath) {
-      if (isUrl(urlOrPath)) {
-        return urlOrPath;
-      }
-      return urljoin(baseUrl, urlOrPath);
-    }
-    return urljoin(baseUrl, defaultPath);
   }
 
   private getFetchUrl(endpoint: keyof Sequencer.Endpoints) {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,44 @@
+/**
+ * RegExps.
+ * A URL must match #1 and then at least one of #2/#3.
+ * Use two levels of REs to avoid REDOS.
+ */
+
+/**
+ * Inspired from https://github.com/segmentio/is-url
+ */
+
+const protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
+
+const localhostDomainRE = /^localhost[:?\d]*(?:[^:?\d]\S*)?$/;
+const nonLocalhostDomainRE = /^[^\s.]+\.\S{2,}$/;
+
+/**
+ * Loosely validate a URL `string`.
+ * @param {String} s
+ * @return {Boolean}
+ */
+export function isUrl(s: string): boolean {
+  if (typeof s !== 'string') {
+    return false;
+  }
+
+  const match = s.match(protocolAndDomainRE);
+  if (!match) {
+    return false;
+  }
+
+  const everythingAfterProtocol = match[1];
+  if (!everythingAfterProtocol) {
+    return false;
+  }
+
+  if (
+    localhostDomainRE.test(everythingAfterProtocol) ||
+    nonLocalhostDomainRE.test(everythingAfterProtocol)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,13 +1,14 @@
-/**
- * RegExps.
- * A URL must match #1 and then at least one of #2/#3.
- * Use two levels of REs to avoid REDOS.
- */
+import urljoin from 'url-join';
 
 /**
  * Inspired from https://github.com/segmentio/is-url
  */
 
+/**
+ * RegExps.
+ * A URL must match #1 and then at least one of #2/#3.
+ * Use two levels of REs to avoid REDOS.
+ */
 const protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
 
 const localhostDomainRE = /^localhost[:?\d]*(?:[^:?\d]\S*)?$/;
@@ -18,7 +19,11 @@ const nonLocalhostDomainRE = /^[^\s.]+\.\S{2,}$/;
  * @param {String} s
  * @return {Boolean}
  */
-export function isUrl(s: string): boolean {
+export function isUrl(s?: string): boolean {
+  if (!s) {
+    return false;
+  }
+
   if (typeof s !== 'string') {
     return false;
   }
@@ -41,4 +46,8 @@ export function isUrl(s: string): boolean {
   }
 
   return false;
+}
+
+export function buildUrl(baseUrl: string, defaultPath: string, urlOrPath?: string) {
+  return isUrl(urlOrPath) ? urlOrPath! : urljoin(baseUrl, urlOrPath ?? defaultPath);
 }

--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -17,19 +17,40 @@ The options for the provider depends from the network. The structure of the opti
 - options.**sequencer** - Options for sequencer provider
 - options.**rpc** - Options for RPC provider
 
-Example:
+The easiest way to get started is:
 
+```typescript
+const provider = new starknet.Provider()
 ```
+
+The above snippet creates a Starknet Provider instance with `goerli-alpha` network.
+
+However, if you want to use `mainnet-alpha` or explicitly declare the network, you can use:
+
+```typescript
 const provider = new starknet.Provider({
   sequencer: {
-    baseUrl: 'https://alpha4.starknet.io',
-    feederGatewayUrl: 'feeder_gateway',
-    gatewayUrl: 'gateway',
+    network: 'mainnet-alpha' // or 'goerli-alpha'
   }
-})
+ })
 ```
 
-**This is also default options for the constructor for the **testnet\*\*\*
+If you want to more control:
+
+```typescript
+const provider = new starknet.Provider({
+  sequencer: {
+  baseUrl: 'https://alpha4.starknet.io',
+  feederGatewayUrl: 'feeder_gateway',
+  gatewayUrl: 'gateway',
+  }
+})
+
+```
+
+\*\*This is also default options for the Provider constructor with `network: 'goerli-alpha'`\*\*\*
+
+\*\*Note: `network` arguement should work in most cases. If you want to use sequencer arguement with `baseUrl`, you will not be able to use `network` field in the object.\*\*\*
 
 ## Methods
 
@@ -48,9 +69,11 @@ The call object structure:
 ###### CallContractResponse
 
 ```
+
 {
-    result: string[];
+result: string[];
 }
+
 ```
 
 <hr/>
@@ -62,19 +85,21 @@ Gets the block information.
 ###### _GetBlockResponse_
 
 ```
+
 {
-  accepted_time: number;
-  block_hash: string;
-  block_number: number;
-  gas_price: string;
-  new_root: string;
-  old_root?: string;
-  parent_hash: string;
-  sequencer: string;
-  status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
-  transactions: Array<string>;
-  starknet_version?: string;
+accepted_time: number;
+block_hash: string;
+block_number: number;
+gas_price: string;
+new_root: string;
+old_root?: string;
+parent_hash: string;
+sequencer: string;
+status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+transactions: Array<string>;
+starknet_version?: string;
 }
+
 ```
 
 <hr/>
@@ -86,11 +111,13 @@ Gets the contract class of the deployed contract.
 ###### _ContractClass_
 
 ```
+
 {
-  program: CompressedProgram;
-  entry_points_by_type: EntryPointsByType;
-  abi?: Abi;
+program: CompressedProgram;
+entry_points_by_type: EntryPointsByType;
+abi?: Abi;
 }
+
 ```
 
 <hr/>
@@ -108,15 +135,17 @@ Gets the status of a transaction.
 ###### _GetTransactionReceiptResponse_
 
 ```
+
 {
-  transaction_hash: string;
-  status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
-  actual_fee?: string;
-  status_data?: string;
-  messages_sent?: Array<MessageToL1>;
-  events?: Array<Event>;
-  l1_origin_message?: MessageToL2;
+transaction_hash: string;
+status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+actual_fee?: string;
+status_data?: string;
+messages_sent?: Array<MessageToL1>;
+events?: Array<Event>;
+l1_origin_message?: MessageToL2;
 }
+
 ```
 
 <hr/>
@@ -128,18 +157,20 @@ Gets the transaction information from a tx hash.
 ###### _GetTransactionResponse_
 
 ```
+
 {
-  transaction_hash: string;
-  version?: string;
-  signature?: Signature;
-  max_fee?: string;
-  nonce?: string;
-  contract_address?: string;
-  entry_point_selector?: string;
-  calldata?: RawCalldata;
-  contract_class?: ContractClass;
-  sender_address?: string;
+transaction_hash: string;
+version?: string;
+signature?: Signature;
+max_fee?: string;
+nonce?: string;
+contract_address?: string;
+entry_point_selector?: string;
+calldata?: RawCalldata;
+contract_class?: ContractClass;
+sender_address?: string;
 }
+
 ```
 
 <hr/>
@@ -151,9 +182,10 @@ Declares a contract on Starknet
 ###### _DeclareContractResponse_
 
 ```
+
 {
-  transaction_hash: string;
-  class_hash: string;
+transaction_hash: string;
+class_hash: string;
 };
 
 <hr/>
@@ -167,10 +199,12 @@ Deploys a contract on Starknet
 ###### _DeployContractResponse_
 
 ```
+
 {
-  transaction_hash: string;
-  contract_address?: string;
+transaction_hash: string;
+contract_address?: string;
 };
+
 ```
 
 <hr/>
@@ -198,11 +232,13 @@ or
 Example:
 
 ```
+
 const provider = new starknet.Provider({
-  baseUrl: 'https://alpha4.starknet.io',
-  feederGatewayUrl: 'feeder_gateway',
-  gatewayUrl: 'gateway',
+baseUrl: 'https://alpha4.starknet.io',
+feederGatewayUrl: 'feeder_gateway',
+gatewayUrl: 'gateway',
 })
+
 ```
 
 ## Methods
@@ -212,10 +248,12 @@ Gets the smart contract address on the network
 provider.**getContractAddresses**() => _Promise < GetContractAddressesResponse >_
 
 ```
+
 {
-  Starknet: string;
-  GpsStatementVerifier: string;
+Starknet: string;
+GpsStatementVerifier: string;
 }
+
 ```
 
 <hr/>
@@ -227,15 +265,17 @@ Gets the status of a transaction.
 ###### _GetTransactionStatusResponse_
 
 ```
+
 {
-  tx_status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
-  block_hash: string;
-  tx_failure_reason?: {
-    tx_id: number;
-    code: string;
-    error_message: string;
-  }
+tx_status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+block_hash: string;
+tx_failure_reason?: {
+tx_id: number;
+code: string;
+error_message: string;
 }
+}
+
 ```
 
 <hr/>
@@ -247,23 +287,25 @@ Gets the transaction trace from a tx hash.
 ###### _GetTransactionTraceResponse_
 
 ```
+
 {
-  function_invocation: {
-    caller_address: string;
-    contract_address: string;
-    code_address: string;
-    selector: string;
-    calldata: {
-        [inputName: string]: string | string[] | { type: 'struct'; [k: string]: BigNumberish };
-    };
-    result: Array<any>;
-    execution_resources: any;
-    internal_call: Array<any>;
-    events: Array<any>;
-    messages: Array<any>;
-  };
-  signature: Signature;
+function_invocation: {
+caller_address: string;
+contract_address: string;
+code_address: string;
+selector: string;
+calldata: {
+[inputName: string]: string | string[] | { type: 'struct'; [k: string]: BigNumberish };
+};
+result: Array<any>;
+execution_resources: any;
+internal_call: Array<any>;
+events: Array<any>;
+messages: Array<any>;
+};
+signature: Signature;
 }
+
 ```
 
 # RpcProvider
@@ -277,9 +319,11 @@ Gets the transaction trace from a tx hash.
 Example:
 
 ```
+
 const provider = new starknet.RpcProvider({
-  nodeUrl: 'URL_TO_STARKNET_RPC_NODE',
+nodeUrl: 'URL_TO_STARKNET_RPC_NODE',
 })
+
 ```
 
 ## Methods
@@ -303,15 +347,17 @@ Gets syncing status of the node
 ###### GetSyncingStatsResponse
 
 ```
+
 boolean |
 {
-  starting_block_hash: string;
-  starting_block_num: string;
-  current_block_hash: string;
-  current_block_num: string;
-  highest_block_hash: string;
-  highest_block_num: string;
+starting_block_hash: string;
+starting_block_num: string;
+current_block_hash: string;
+current_block_num: string;
+highest_block_hash: string;
+highest_block_num: string;
 }
+
 ```
 
 <hr/>
@@ -321,22 +367,34 @@ provider.**getEvents**(eventFilter) => _Promise < GetEventsResponse >_
 ##### EventFilter
 
 ```
+
 type EventFilter = {
-  fromBlock: string;
-  toBlock: string;
-  address: string;
-  keys: string[];
-  page_size: number;
-  page_number: number;
+fromBlock: string;
+toBlock: string;
+address: string;
+keys: string[];
+page_size: number;
+page_number: number;
 };
+
 ```
 
 ###### GetSyncingStatsResponse
 
 ```
+
 {
-  events: StarknetEmittedEvent[];
-  page_number: number;
-  is_last_page: number;
+events: StarknetEmittedEvent[];
+page_number: number;
+is_last_page: number;
 }
+
+```
+
+```
+
+```
+
+```
+
 ```

--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -68,10 +68,10 @@ The call object structure:
 
 ###### CallContractResponse
 
-```
+```typescript
 
 {
-result: string[];
+  result: string[];
 }
 
 ```
@@ -84,20 +84,20 @@ Gets the block information.
 
 ###### _GetBlockResponse_
 
-```
+```typescript
 
 {
-accepted_time: number;
-block_hash: string;
-block_number: number;
-gas_price: string;
-new_root: string;
-old_root?: string;
-parent_hash: string;
-sequencer: string;
-status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
-transactions: Array<string>;
-starknet_version?: string;
+  accepted_time: number;
+  block_hash: string;
+  block_number: number;
+  gas_price: string;
+  new_root: string;
+  old_root?: string;
+  parent_hash: string;
+  sequencer: string;
+  status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+  transactions: Array<string>;
+  starknet_version?: string;
 }
 
 ```
@@ -110,12 +110,12 @@ Gets the contract class of the deployed contract.
 
 ###### _ContractClass_
 
-```
+```typescript
 
 {
-program: CompressedProgram;
-entry_points_by_type: EntryPointsByType;
-abi?: Abi;
+  program: CompressedProgram;
+  entry_points_by_type: EntryPointsByType;
+  abi?: Abi;
 }
 
 ```
@@ -134,16 +134,16 @@ Gets the status of a transaction.
 
 ###### _GetTransactionReceiptResponse_
 
-```
+```typescript
 
 {
-transaction_hash: string;
-status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
-actual_fee?: string;
-status_data?: string;
-messages_sent?: Array<MessageToL1>;
-events?: Array<Event>;
-l1_origin_message?: MessageToL2;
+  transaction_hash: string;
+  status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+  actual_fee?: string;
+  status_data?: string;
+  messages_sent?: Array<MessageToL1>;
+  events?: Array<Event>;
+  l1_origin_message?: MessageToL2;
 }
 
 ```
@@ -156,19 +156,19 @@ Gets the transaction information from a tx hash.
 
 ###### _GetTransactionResponse_
 
-```
+```typescript
 
 {
-transaction_hash: string;
-version?: string;
-signature?: Signature;
-max_fee?: string;
-nonce?: string;
-contract_address?: string;
-entry_point_selector?: string;
-calldata?: RawCalldata;
-contract_class?: ContractClass;
-sender_address?: string;
+  transaction_hash: string;
+  version?: string;
+  signature?: Signature;
+  max_fee?: string;
+  nonce?: string;
+  contract_address?: string;
+  entry_point_selector?: string;
+  calldata?: RawCalldata;
+  contract_class?: ContractClass;
+  sender_address?: string;
 }
 
 ```
@@ -181,11 +181,11 @@ Declares a contract on Starknet
 
 ###### _DeclareContractResponse_
 
-```
+```typescript
 
 {
-transaction_hash: string;
-class_hash: string;
+  transaction_hash: string;
+  class_hash: string;
 };
 
 <hr/>
@@ -198,11 +198,11 @@ Deploys a contract on Starknet
 
 ###### _DeployContractResponse_
 
-```
+```typescript
 
 {
-transaction_hash: string;
-contract_address?: string;
+  transaction_hash: string;
+  contract_address?: string;
 };
 
 ```
@@ -231,12 +231,12 @@ or
 
 Example:
 
-```
+```typescript
 
 const provider = new starknet.Provider({
-baseUrl: 'https://alpha4.starknet.io',
-feederGatewayUrl: 'feeder_gateway',
-gatewayUrl: 'gateway',
+  baseUrl: 'https://alpha4.starknet.io',
+  feederGatewayUrl: 'feeder_gateway',
+  gatewayUrl: 'gateway',
 })
 
 ```
@@ -247,11 +247,11 @@ Gets the smart contract address on the network
 
 provider.**getContractAddresses**() => _Promise < GetContractAddressesResponse >_
 
-```
+```typescript
 
 {
-Starknet: string;
-GpsStatementVerifier: string;
+  Starknet: string;
+  GpsStatementVerifier: string;
 }
 
 ```
@@ -264,16 +264,16 @@ Gets the status of a transaction.
 
 ###### _GetTransactionStatusResponse_
 
-```
+```typescript
 
 {
-tx_status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
-block_hash: string;
-tx_failure_reason?: {
-tx_id: number;
-code: string;
-error_message: string;
-}
+  tx_status: 'NOT_RECEIVED' | 'RECEIVED' | 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+  block_hash: string;
+  tx_failure_reason?: {
+    tx_id: number;
+    code: string;
+    error_message: string;
+  }
 }
 
 ```
@@ -286,24 +286,23 @@ Gets the transaction trace from a tx hash.
 
 ###### _GetTransactionTraceResponse_
 
-```
-
+```typescript
 {
-function_invocation: {
-caller_address: string;
-contract_address: string;
-code_address: string;
-selector: string;
-calldata: {
-[inputName: string]: string | string[] | { type: 'struct'; [k: string]: BigNumberish };
-};
-result: Array<any>;
-execution_resources: any;
-internal_call: Array<any>;
-events: Array<any>;
-messages: Array<any>;
-};
-signature: Signature;
+  function_invocation: {
+    caller_address: string;
+    contract_address: string;
+    code_address: string;
+    selector: string;
+    calldata: {
+      [inputName: string]: string | string[] | { type: 'struct'; [k: string]: BigNumberish };
+    };
+    result: Array<any>;
+    execution_resources: any;
+    internal_call: Array<any>;
+    events: Array<any>;
+    messages: Array<any>;
+    };
+  signature: Signature;
 }
 
 ```
@@ -318,10 +317,10 @@ signature: Signature;
 
 Example:
 
-```
+```typescript
 
 const provider = new starknet.RpcProvider({
-nodeUrl: 'URL_TO_STARKNET_RPC_NODE',
+  nodeUrl: 'URL_TO_STARKNET_RPC_NODE',
 })
 
 ```
@@ -346,16 +345,16 @@ Gets syncing status of the node
 
 ###### GetSyncingStatsResponse
 
-```
+```typescript
 
 boolean |
 {
-starting_block_hash: string;
-starting_block_num: string;
-current_block_hash: string;
-current_block_num: string;
-highest_block_hash: string;
-highest_block_num: string;
+  starting_block_hash: string;
+  starting_block_num: string;
+  current_block_hash: string;
+  current_block_num: string;
+  highest_block_hash: string;
+  highest_block_num: string;
 }
 
 ```
@@ -366,27 +365,27 @@ provider.**getEvents**(eventFilter) => _Promise < GetEventsResponse >_
 
 ##### EventFilter
 
-```
+```typescript
 
 type EventFilter = {
-fromBlock: string;
-toBlock: string;
-address: string;
-keys: string[];
-page_size: number;
-page_number: number;
+  fromBlock: string;
+  toBlock: string;
+  address: string;
+  keys: string[];
+  page_size: number;
+  page_number: number;
 };
 
 ```
 
 ###### GetSyncingStatsResponse
 
-```
+```typescript
 
 {
-events: StarknetEmittedEvent[];
-page_number: number;
-is_last_page: number;
+  events: StarknetEmittedEvent[];
+  page_number: number;
+  is_last_page: number;
 }
 
 ```


### PR DESCRIPTION
Currently, the way feederGatewayUrl and gatewayUrl that are being assigned value is wrong.

```
this.feederGatewayUrl =
        optionsOrProvider.feederGatewayUrl ?? urljoin(this.baseUrl, 'feeder_gateway');
```

This won't work if `feederGatewayUrl='feeder_gateway'` as described in the [docs](https://www.starknetjs.com/docs/api/provider/#creating-an-instance)

It will fail with the following error when making contract calls:

```Error: Could not POST from endpoint `feeder_gateway/call_contract?blockNumber=pending`: Only absolute URLs are supported``` 

This PR aims to fix this bug by taking into account that feederGatewayUrl can be a url. for eg: `https://alpha4.starknet.io/feeder_gateway` or just a path which can be concatenated with baseUrl.. for eg: `feeder_gateway`