### PR TITLE
fix(RpcProvider): update of RpcProvider getBlock method to work with v0.3.0 of pathfinder

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -1,30 +1,30 @@
 import { StarknetChainId } from '../constants';
 import {
-  BlockTag,
-  Call,
-  CallContractResponse,
-  DeclareContractPayload,
-  DeclareContractResponse,
-  DeployContractPayload,
-  DeployContractResponse,
-  EstimateFeeResponse,
-  GetBlockResponse,
-  GetTransactionReceiptResponse,
-  GetTransactionResponse,
-  Invocation,
-  InvocationsDetails,
-  InvokeFunctionResponse,
+	BlockTag,
+	Call,
+	CallContractResponse,
+	DeclareContractPayload,
+	DeclareContractResponse,
+	DeployContractPayload,
+	DeployContractResponse,
+	EstimateFeeResponse,
+	GetBlockResponse,
+	GetTransactionReceiptResponse,
+	GetTransactionResponse,
+	Invocation,
+	InvocationsDetails,
+	InvokeFunctionResponse,
 } from '../types';
 import { RPC } from '../types/api';
 import fetch from '../utils/fetchPonyfill';
 import { getSelectorFromName } from '../utils/hash';
 import { stringify } from '../utils/json';
 import {
-  BigNumberish,
-  bigNumberishArrayToDecimalStringArray,
-  isHex,
-  toBN,
-  toHex,
+	BigNumberish,
+	bigNumberishArrayToDecimalStringArray,
+	isHex,
+	toBN,
+	toHex,
 } from '../utils/number';
 import { parseCalldata, parseContract, wait } from '../utils/provider';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
@@ -35,274 +35,277 @@ import { BlockIdentifier } from './utils';
 export type RpcProviderOptions = { nodeUrl: string };
 
 export class RpcProvider implements ProviderInterface {
-  public nodeUrl: string;
+	public nodeUrl: string;
 
-  public chainId!: StarknetChainId;
+	public chainId!: StarknetChainId;
 
-  private responseParser = new RPCResponseParser();
+	private responseParser = new RPCResponseParser();
 
-  constructor(optionsOrProvider: RpcProviderOptions) {
-    const { nodeUrl } = optionsOrProvider;
-    this.nodeUrl = nodeUrl;
+	constructor(optionsOrProvider: RpcProviderOptions) {
+		const { nodeUrl } = optionsOrProvider;
+		this.nodeUrl = nodeUrl;
 
-    this.getChainId().then((chainId) => {
-      this.chainId = chainId;
-    });
-  }
+		this.getChainId().then((chainId) => {
+			this.chainId = chainId;
+		});
+	}
 
-  protected async fetchEndpoint<T extends keyof RPC.Methods>(
-    method: T,
-    request?: RPC.Methods[T]['REQUEST']
-  ): Promise<RPC.Methods[T]['RESPONSE']> {
-    const requestData = {
-      method,
-      jsonrpc: '2.0',
-      params: request,
-      id: 0,
-    };
+	protected async fetchEndpoint<T extends keyof RPC.Methods>(
+		method: T,
+		request?: RPC.Methods[T]['REQUEST']
+	): Promise<RPC.Methods[T]['RESPONSE']> {
+		const requestData = {
+			method,
+			jsonrpc: '2.0',
+			params: request,
+			id: 0,
+		};
 
-    try {
-      const rawResult = await fetch(this.nodeUrl, {
-        method: 'POST',
-        body: stringify(requestData),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-      const { error, result } = await rawResult.json();
-      if (error) {
-        const { code, message } = error;
-        throw new Error(`${code}: ${message}`);
-      } else {
-        return result as RPC.Methods[T]['RESPONSE'];
-      }
-    } catch (error: any) {
-      const data = error?.response?.data;
-      if (data?.message) {
-        throw new Error(`${data.code}: ${data.message}`);
-      }
-      throw error;
-    }
-  }
+		try {
+			const rawResult = await fetch(this.nodeUrl, {
+				method: 'POST',
+				body: stringify(requestData),
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			});
+			const { error, result } = await rawResult.json();
+			if (error) {
+				const { code, message } = error;
+				throw new Error(`${code}: ${message}`);
+			} else {
+				return result as RPC.Methods[T]['RESPONSE'];
+			}
+		} catch (error: any) {
+			const data = error?.response?.data;
+			if (data?.message) {
+				throw new Error(`${data.code}: ${data.message}`);
+			}
+			throw error;
+		}
+	}
 
-  public async getChainId(): Promise<StarknetChainId> {
-    return this.fetchEndpoint('starknet_chainId');
-  }
+	public async getChainId(): Promise<StarknetChainId> {
+		return this.fetchEndpoint('starknet_chainId');
+	}
 
-  public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
-    const method =
-      typeof blockIdentifier === 'string' && isHex(blockIdentifier)
-        ? 'starknet_getBlockByHash'
-        : 'starknet_getBlockByNumber';
+	public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
+		const method = 'starknet_getBlockWithTxHashes';
+		if (typeof blockIdentifier === 'string' && isHex(blockIdentifier)) {
+			return this.fetchEndpoint(method, [{ block_hash: blockIdentifier }]).then(
+				this.responseParser.parseGetBlockResponse
+			);
+		}
+		else {
+			return this.fetchEndpoint(method, [{ block_number: blockIdentifier }]).then(
+				this.responseParser.parseGetBlockResponse
+			);
+		}
+	}
 
-    return this.fetchEndpoint(method, [blockIdentifier]).then(
-      this.responseParser.parseGetBlockResponse
-    );
-  }
+	public async getStorageAt(
+		contractAddress: string,
+		key: BigNumberish,
+		blockHashOrTag: BlockTag | BigNumberish = 'pending'
+	): Promise<BigNumberish> {
+		const parsedKey = toHex(toBN(key));
+		return this.fetchEndpoint('starknet_getStorageAt', [
+			contractAddress,
+			parsedKey,
+			blockHashOrTag,
+		]);
+	}
 
-  public async getStorageAt(
-    contractAddress: string,
-    key: BigNumberish,
-    blockHashOrTag: BlockTag | BigNumberish = 'pending'
-  ): Promise<BigNumberish> {
-    const parsedKey = toHex(toBN(key));
-    return this.fetchEndpoint('starknet_getStorageAt', [
-      contractAddress,
-      parsedKey,
-      blockHashOrTag,
-    ]);
-  }
+	public async getTransaction(txHash: BigNumberish): Promise<GetTransactionResponse> {
+		return this.fetchEndpoint('starknet_getTransactionByHash', [txHash]).then(
+			this.responseParser.parseGetTransactionResponse
+		);
+	}
 
-  public async getTransaction(txHash: BigNumberish): Promise<GetTransactionResponse> {
-    return this.fetchEndpoint('starknet_getTransactionByHash', [txHash]).then(
-      this.responseParser.parseGetTransactionResponse
-    );
-  }
+	public async getTransactionReceipt(txHash: BigNumberish): Promise<GetTransactionReceiptResponse> {
+		return this.fetchEndpoint('starknet_getTransactionReceipt', [txHash]).then(
+			this.responseParser.parseGetTransactionReceiptResponse
+		);
+	}
 
-  public async getTransactionReceipt(txHash: BigNumberish): Promise<GetTransactionReceiptResponse> {
-    return this.fetchEndpoint('starknet_getTransactionReceipt', [txHash]).then(
-      this.responseParser.parseGetTransactionReceiptResponse
-    );
-  }
+	public async getClassAt(
+		contractAddress: string,
+		_blockIdentifier: BlockIdentifier = 'pending'
+	): Promise<any> {
+		return this.fetchEndpoint('starknet_getClassAt', [contractAddress]);
+	}
 
-  public async getClassAt(
-    contractAddress: string,
-    _blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<any> {
-    return this.fetchEndpoint('starknet_getClassAt', [contractAddress]);
-  }
+	public async getEstimateFee(
+		invocation: Invocation,
+		blockIdentifier: BlockIdentifier = 'pending',
+		invocationDetails: InvocationsDetails = {}
+	): Promise<EstimateFeeResponse> {
+		return this.fetchEndpoint('starknet_estimateFee', [
+			{
+				contract_address: invocation.contractAddress,
+				entry_point_selector: getSelectorFromName(invocation.entrypoint),
+				calldata: parseCalldata(invocation.calldata),
+				signature: bigNumberishArrayToDecimalStringArray(invocation.signature || []),
+				version: toHex(toBN(invocationDetails?.version || 0)),
+			},
+			blockIdentifier,
+		]).then(this.responseParser.parseFeeEstimateResponse);
+	}
 
-  public async getEstimateFee(
-    invocation: Invocation,
-    blockIdentifier: BlockIdentifier = 'pending',
-    invocationDetails: InvocationsDetails = {}
-  ): Promise<EstimateFeeResponse> {
-    return this.fetchEndpoint('starknet_estimateFee', [
-      {
-        contract_address: invocation.contractAddress,
-        entry_point_selector: getSelectorFromName(invocation.entrypoint),
-        calldata: parseCalldata(invocation.calldata),
-        signature: bigNumberishArrayToDecimalStringArray(invocation.signature || []),
-        version: toHex(toBN(invocationDetails?.version || 0)),
-      },
-      blockIdentifier,
-    ]).then(this.responseParser.parseFeeEstimateResponse);
-  }
+	public async declareContract({
+		contract,
+		version,
+	}: DeclareContractPayload): Promise<DeclareContractResponse> {
+		const contractDefinition = parseContract(contract);
 
-  public async declareContract({
-    contract,
-    version,
-  }: DeclareContractPayload): Promise<DeclareContractResponse> {
-    const contractDefinition = parseContract(contract);
+		return this.fetchEndpoint('starknet_addDeclareTransaction', [
+			{
+				program: contractDefinition.program,
+				entry_points_by_type: contractDefinition.entry_points_by_type,
+			},
+			toHex(toBN(version || 0)),
+		]).then(this.responseParser.parseDeclareContractResponse);
+	}
 
-    return this.fetchEndpoint('starknet_addDeclareTransaction', [
-      {
-        program: contractDefinition.program,
-        entry_points_by_type: contractDefinition.entry_points_by_type,
-      },
-      toHex(toBN(version || 0)),
-    ]).then(this.responseParser.parseDeclareContractResponse);
-  }
+	public async deployContract({
+		contract,
+		constructorCalldata,
+		addressSalt,
+	}: DeployContractPayload): Promise<DeployContractResponse> {
+		const contractDefinition = parseContract(contract);
 
-  public async deployContract({
-    contract,
-    constructorCalldata,
-    addressSalt,
-  }: DeployContractPayload): Promise<DeployContractResponse> {
-    const contractDefinition = parseContract(contract);
+		return this.fetchEndpoint('starknet_addDeployTransaction', [
+			addressSalt ?? randomAddress(),
+			bigNumberishArrayToDecimalStringArray(constructorCalldata ?? []),
+			{
+				program: contractDefinition.program,
+				entry_points_by_type: contractDefinition.entry_points_by_type,
+			},
+		]).then(this.responseParser.parseDeployContractResponse);
+	}
 
-    return this.fetchEndpoint('starknet_addDeployTransaction', [
-      addressSalt ?? randomAddress(),
-      bigNumberishArrayToDecimalStringArray(constructorCalldata ?? []),
-      {
-        program: contractDefinition.program,
-        entry_points_by_type: contractDefinition.entry_points_by_type,
-      },
-    ]).then(this.responseParser.parseDeployContractResponse);
-  }
+	public async invokeFunction(
+		functionInvocation: Invocation,
+		details: InvocationsDetails
+	): Promise<InvokeFunctionResponse> {
+		return this.fetchEndpoint('starknet_addInvokeTransaction', [
+			{
+				contract_address: functionInvocation.contractAddress,
+				entry_point_selector: getSelectorFromName(functionInvocation.entrypoint),
+				calldata: parseCalldata(functionInvocation.calldata),
+			},
+			bigNumberishArrayToDecimalStringArray(functionInvocation.signature || []),
+			toHex(toBN(details.maxFee || 0)),
+			toHex(toBN(details.version || 0)),
+		]).then(this.responseParser.parseInvokeFunctionResponse);
+	}
 
-  public async invokeFunction(
-    functionInvocation: Invocation,
-    details: InvocationsDetails
-  ): Promise<InvokeFunctionResponse> {
-    return this.fetchEndpoint('starknet_addInvokeTransaction', [
-      {
-        contract_address: functionInvocation.contractAddress,
-        entry_point_selector: getSelectorFromName(functionInvocation.entrypoint),
-        calldata: parseCalldata(functionInvocation.calldata),
-      },
-      bigNumberishArrayToDecimalStringArray(functionInvocation.signature || []),
-      toHex(toBN(details.maxFee || 0)),
-      toHex(toBN(details.version || 0)),
-    ]).then(this.responseParser.parseInvokeFunctionResponse);
-  }
+	public async callContract(
+		call: Call,
+		blockIdentifier: BlockIdentifier = 'pending'
+	): Promise<CallContractResponse> {
+		const result = await this.fetchEndpoint('starknet_call', [
+			{
+				contract_address: call.contractAddress,
+				entry_point_selector: getSelectorFromName(call.entrypoint),
+				calldata: parseCalldata(call.calldata),
+			},
+			blockIdentifier,
+		]);
 
-  public async callContract(
-    call: Call,
-    blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<CallContractResponse> {
-    const result = await this.fetchEndpoint('starknet_call', [
-      {
-        contract_address: call.contractAddress,
-        entry_point_selector: getSelectorFromName(call.entrypoint),
-        calldata: parseCalldata(call.calldata),
-      },
-      blockIdentifier,
-    ]);
+		return this.responseParser.parseCallContractResponse(result);
+	}
 
-    return this.responseParser.parseCallContractResponse(result);
-  }
+	public async getCode(
+		contractAddress: string,
+		_blockIdentifier?: BlockIdentifier
+	): Promise<RPC.GetCodeResponse> {
+		const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
 
-  public async getCode(
-    contractAddress: string,
-    _blockIdentifier?: BlockIdentifier
-  ): Promise<RPC.GetCodeResponse> {
-    const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
+		return this.responseParser.parseGetCodeResponse(result);
+	}
 
-    return this.responseParser.parseGetCodeResponse(result);
-  }
+	public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
+		let onchain = false;
+		let retries = 100;
 
-  public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
-    let onchain = false;
-    let retries = 100;
+		while (!onchain) {
+			const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];
+			const errorStates = ['REJECTED', 'NOT_RECEIVED'];
 
-    while (!onchain) {
-      const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];
-      const errorStates = ['REJECTED', 'NOT_RECEIVED'];
+			// eslint-disable-next-line no-await-in-loop
+			await wait(retryInterval);
+			try {
+				// eslint-disable-next-line no-await-in-loop
+				const res = await this.getTransactionReceipt(txHash);
 
-      // eslint-disable-next-line no-await-in-loop
-      await wait(retryInterval);
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const res = await this.getTransactionReceipt(txHash);
+				if (successStates.includes(res.status)) {
+					onchain = true;
+				} else if (errorStates.includes(res.status)) {
+					const message = res.status;
+					const error = new Error(message) as Error & { response: any };
+					error.response = res;
+					throw error;
+				}
+			} catch (error: unknown) {
+				if (error instanceof Error && errorStates.includes(error.message)) {
+					throw error;
+				}
 
-        if (successStates.includes(res.status)) {
-          onchain = true;
-        } else if (errorStates.includes(res.status)) {
-          const message = res.status;
-          const error = new Error(message) as Error & { response: any };
-          error.response = res;
-          throw error;
-        }
-      } catch (error: unknown) {
-        if (error instanceof Error && errorStates.includes(error.message)) {
-          throw error;
-        }
+				if (retries === 0) {
+					throw error;
+				}
+			}
 
-        if (retries === 0) {
-          throw error;
-        }
-      }
+			retries -= 1;
+		}
 
-      retries -= 1;
-    }
+		await wait(retryInterval);
+	}
 
-    await wait(retryInterval);
-  }
+	/**
+	 * Gets the transaction count from a block.
+	 *
+	 *
+	 * @param blockIdentifier
+	 * @returns Number of transactions
+	 */
+	public async getTransactionCount(
+		blockIdentifier: BlockIdentifier
+	): Promise<RPC.GetTransactionCountResponse> {
+		if (typeof blockIdentifier === 'number') {
+			return this.fetchEndpoint('starknet_getBlockTransactionCountByNumber', [blockIdentifier]);
+		}
+		return this.fetchEndpoint('starknet_getBlockTransactionCountByHash', [blockIdentifier]);
+	}
 
-  /**
-   * Gets the transaction count from a block.
-   *
-   *
-   * @param blockIdentifier
-   * @returns Number of transactions
-   */
-  public async getTransactionCount(
-    blockIdentifier: BlockIdentifier
-  ): Promise<RPC.GetTransactionCountResponse> {
-    if (typeof blockIdentifier === 'number') {
-      return this.fetchEndpoint('starknet_getBlockTransactionCountByNumber', [blockIdentifier]);
-    }
-    return this.fetchEndpoint('starknet_getBlockTransactionCountByHash', [blockIdentifier]);
-  }
+	/**
+	 * Gets the latest block number
+	 *
+	 *
+	 * @returns Number of the latest block
+	 */
+	public async getBlockNumber(): Promise<RPC.GetBlockNumberResponse> {
+		return this.fetchEndpoint('starknet_blockNumber');
+	}
 
-  /**
-   * Gets the latest block number
-   *
-   *
-   * @returns Number of the latest block
-   */
-  public async getBlockNumber(): Promise<RPC.GetBlockNumberResponse> {
-    return this.fetchEndpoint('starknet_blockNumber');
-  }
+	/**
+	 * Gets syncing status of the node
+	 *
+	 *
+	 * @returns Object with the stats data
+	 */
+	public async getSyncingStats(): Promise<RPC.GetSyncingStatsResponse> {
+		return this.fetchEndpoint('starknet_syncing');
+	}
 
-  /**
-   * Gets syncing status of the node
-   *
-   *
-   * @returns Object with the stats data
-   */
-  public async getSyncingStats(): Promise<RPC.GetSyncingStatsResponse> {
-    return this.fetchEndpoint('starknet_syncing');
-  }
-
-  /**
-   * Gets all the events filtered
-   *
-   *
-   * @returns events and the pagination of the events
-   */
-  public async getEvents(eventFilter: RPC.EventFilter): Promise<RPC.GetEventsResponse> {
-    return this.fetchEndpoint('starknet_getEvents', [eventFilter]);
-  }
+	/**
+	 * Gets all the events filtered
+	 *
+	 *
+	 * @returns events and the pagination of the events
+	 */
+	public async getEvents(eventFilter: RPC.EventFilter): Promise<RPC.GetEventsResponse> {
+		return this.fetchEndpoint('starknet_getEvents', [eventFilter]);
+	}
 }

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -143,12 +143,7 @@ export namespace RPC {
   };
 
   export type Methods = {
-    starknet_getBlockByHash: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetBlockResponse;
-    };
-    starknet_getBlockByNumber: {
+    starknet_getBlockWithTxHashes: {
       QUERY: never;
       REQUEST: any[];
       RESPONSE: GetBlockResponse;


### PR DESCRIPTION
with the recent [update of pathfinder](https://github.com/eqlabs/pathfinder/releases/tag/v0.3.0-alpha), some methods have been deleted, making starknet.js not working when using them
e.g. `starknet_getBlockByHash` and `starknet_getBlockByNumber`, that are used in getBlock method of RpcProvider
here is an update using `starknet_getBlockWithTxHashes` instead