### PR TITLE
fix(RpcProvider): update of RpcProvider methods to work with v0.3.0 of pathfinder

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -22,15 +22,14 @@ import { stringify } from '../utils/json';
 import {
   BigNumberish,
   bigNumberishArrayToDecimalStringArray,
-  isHex,
   toBN,
-  toHex,
-} from '../utils/number';
+  toHex
+  } from '../utils/number';
 import { parseCalldata, parseContract, wait } from '../utils/provider';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 import { randomAddress } from '../utils/stark';
 import { ProviderInterface } from './interface';
-import { BlockIdentifier } from './utils';
+import { BlockIdentifier, BlockIdentifierClass } from './utils';
 
 export type RpcProviderOptions = { nodeUrl: string };
 
@@ -90,41 +89,21 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
+    const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     const method = 'starknet_getBlockWithTxHashes';
-    if (typeof blockIdentifier === 'string' && isHex(blockIdentifier)) {
-      return this.fetchEndpoint(method, [{ block_hash: blockIdentifier }]).then(
-        this.responseParser.parseGetBlockResponse
-      );
-    }
-    else if (typeof blockIdentifier === 'number') {
-      return this.fetchEndpoint(method, [{ block_number: blockIdentifier }]).then(
-        this.responseParser.parseGetBlockResponse
-      );
-    }
-    else {
-      return this.fetchEndpoint(method, [blockIdentifier]).then(
-        this.responseParser.parseGetBlockResponse
-      );
-    }
+    return this.fetchEndpoint(method, [blockIdentifierGetter.getIdentifier()]).then(
+      this.responseParser.parseGetBlockResponse
+    );
   }
 
-  public async getBlockWithTxs(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
+  public async getBlockWithTxs(
+    blockIdentifier: BlockIdentifier = 'pending'
+  ): Promise<GetBlockResponse> {
+    const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     const method = 'starknet_getBlockWithTxs';
-    if (typeof blockIdentifier === 'string' && isHex(blockIdentifier)) {
-      return this.fetchEndpoint(method, [{ block_hash: blockIdentifier }]).then(
-        this.responseParser.parseGetBlockResponse
-      );
-    }
-    else if (typeof blockIdentifier === 'number') {
-      return this.fetchEndpoint(method, [{ block_number: blockIdentifier }]).then(
-        this.responseParser.parseGetBlockResponse
-      );
-    }
-    else {
-      return this.fetchEndpoint(method, [blockIdentifier]).then(
-        this.responseParser.parseGetBlockResponse
-      );
-    }
+    return this.fetchEndpoint(method, [blockIdentifierGetter.getIdentifier()]).then(
+      this.responseParser.parseGetBlockResponse
+    );
   }
 
   public async getNonce(contractAddress: string): Promise<any> {
@@ -248,9 +227,8 @@ export class RpcProvider implements ProviderInterface {
     contractAddress: string,
     _blockIdentifier?: BlockIdentifier
   ): Promise<RPC.GetCodeResponse> {
+    // console.log('WARNING: deprecated method, please wait for an update of starknet.js');
 
-    console.log('WARNING: deprecated method, please wait for an update of starknet.js');
-    
     const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
 
     return this.responseParser.parseGetCodeResponse(result);
@@ -304,16 +282,9 @@ export class RpcProvider implements ProviderInterface {
   public async getTransactionCount(
     blockIdentifier: BlockIdentifier
   ): Promise<RPC.GetTransactionCountResponse> {
+    const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     const method = 'starknet_getBlockTransactionCount';
-    if (typeof blockIdentifier === 'string' && isHex(blockIdentifier)) {
-      return this.fetchEndpoint(method, [{ block_hash: blockIdentifier }]);
-    }
-    else if (typeof blockIdentifier === 'number') {
-      return this.fetchEndpoint(method, [{ block_number: blockIdentifier }]);
-    }
-    else {
-      return this.fetchEndpoint(method, [blockIdentifier]);
-    }
+    return this.fetchEndpoint(method, [blockIdentifierGetter.getIdentifier()]);
   }
 
   /**

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -23,8 +23,8 @@ import {
   BigNumberish,
   bigNumberishArrayToDecimalStringArray,
   toBN,
-  toHex
-  } from '../utils/number';
+  toHex,
+} from '../utils/number';
 import { parseCalldata, parseContract, wait } from '../utils/provider';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 import { randomAddress } from '../utils/stark';
@@ -225,7 +225,7 @@ export class RpcProvider implements ProviderInterface {
     contractAddress: string,
     _blockIdentifier?: BlockIdentifier
   ): Promise<RPC.GetCodeResponse> {
-    console.log('WARNING: deprecated method, please wait for an update of starknet.js');
+    // deprecated method, please wait for an update of starknet.js
 
     const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
 

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -90,8 +90,7 @@ export class RpcProvider implements ProviderInterface {
 
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    const method = 'starknet_getBlockWithTxHashes';
-    return this.fetchEndpoint(method, [blockIdentifierGetter.getIdentifier()]).then(
+    return this.fetchEndpoint('starknet_getBlockWithTxHashes', [blockIdentifierGetter.getIdentifier()]).then(
       this.responseParser.parseGetBlockResponse
     );
   }
@@ -100,8 +99,7 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<GetBlockResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    const method = 'starknet_getBlockWithTxs';
-    return this.fetchEndpoint(method, [blockIdentifierGetter.getIdentifier()]).then(
+    return this.fetchEndpoint('starknet_getBlockWithTxs', [blockIdentifierGetter.getIdentifier()]).then(
       this.responseParser.parseGetBlockResponse
     );
   }
@@ -227,7 +225,7 @@ export class RpcProvider implements ProviderInterface {
     contractAddress: string,
     _blockIdentifier?: BlockIdentifier
   ): Promise<RPC.GetCodeResponse> {
-    // console.log('WARNING: deprecated method, please wait for an update of starknet.js');
+    console.log('WARNING: deprecated method, please wait for an update of starknet.js');
 
     const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
 
@@ -283,8 +281,7 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier: BlockIdentifier
   ): Promise<RPC.GetTransactionCountResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    const method = 'starknet_getBlockTransactionCount';
-    return this.fetchEndpoint(method, [blockIdentifierGetter.getIdentifier()]);
+    return this.fetchEndpoint('starknet_getBlockTransactionCount', [blockIdentifierGetter.getIdentifier()]);
   }
 
   /**

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -127,6 +127,10 @@ export class RpcProvider implements ProviderInterface {
     }
   }
 
+  public async getNonce(contractAddress: string): Promise<any> {
+    return this.fetchEndpoint('starknet_getNonce', [contractAddress]);
+  }
+
   public async getStorageAt(
     contractAddress: string,
     key: BigNumberish,

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -248,6 +248,9 @@ export class RpcProvider implements ProviderInterface {
     contractAddress: string,
     _blockIdentifier?: BlockIdentifier
   ): Promise<RPC.GetCodeResponse> {
+
+    console.log('WARNING: deprecated method, please wait for an update of starknet.js');
+    
     const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
 
     return this.responseParser.parseGetCodeResponse(result);

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -90,14 +90,17 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
-    const method =
-      typeof blockIdentifier === 'string' && isHex(blockIdentifier)
-        ? 'starknet_getBlockByHash'
-        : 'starknet_getBlockByNumber';
-
-    return this.fetchEndpoint(method, [blockIdentifier]).then(
-      this.responseParser.parseGetBlockResponse
-    );
+    const method = 'starknet_getBlockWithTxHashes';
+    if (typeof blockIdentifier === 'string' && isHex(blockIdentifier)) {
+      return this.fetchEndpoint(method, [{ block_hash: blockIdentifier }]).then(
+        this.responseParser.parseGetBlockResponse
+      );
+    }
+    else {
+      return this.fetchEndpoint(method, [{ block_number: blockIdentifier }]).then(
+        this.responseParser.parseGetBlockResponse
+      );
+    }
   }
 
   public async getStorageAt(

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -32,6 +32,12 @@ export function txIdentifier(txHash?: BigNumberish, txId?: BigNumberish): string
 // decimal string and number are detected as block numbers
 // null appends nothing to the request url
 
+export type BlockIdentifier = BlockNumber | BigNumberish;
+type BlockIdentifierObject =
+  | { type: 'BLOCK_NUMBER'; data: BlockNumber }
+  | { type: 'BLOCK_HASH'; data: BigNumberish };
+
+
 export class BlockIdentifierClass {
   blockIdentifier: BlockIdentifier;
 
@@ -51,11 +57,6 @@ export class BlockIdentifierClass {
     return this.blockIdentifier;
   }
 }
-
-export type BlockIdentifier = BlockNumber | BigNumberish;
-type BlockIdentifierObject =
-  | { type: 'BLOCK_NUMBER'; data: BlockNumber }
-  | { type: 'BLOCK_HASH'; data: BigNumberish };
 
 /**
  * Identifies the block to be queried.

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -1,5 +1,5 @@
 import type { BlockNumber } from '../types';
-import { BigNumberish, toBN, toHex } from '../utils/number';
+import { BigNumberish, isHex, toBN, toHex } from '../utils/number';
 
 /**
  *
@@ -31,6 +31,27 @@ export function txIdentifier(txHash?: BigNumberish, txId?: BigNumberish): string
 // hex string and BN are detected as block hashes
 // decimal string and number are detected as block numbers
 // null appends nothing to the request url
+
+export class BlockIdentifierClass {
+  blockIdentifier: BlockIdentifier;
+
+  constructor(blockIdentifier: BlockIdentifier) {
+    this.blockIdentifier = blockIdentifier;
+  }
+
+  getIdentifier() {
+    if (typeof this.blockIdentifier === 'string' && isHex(this.blockIdentifier)) {
+      return { block_hash: this.blockIdentifier };
+    }
+
+    if (typeof this.blockIdentifier === 'number') {
+      return { block_number: this.blockIdentifier };
+    }
+
+    return this.blockIdentifier;
+  }
+}
+
 export type BlockIdentifier = BlockNumber | BigNumberish;
 type BlockIdentifierObject =
   | { type: 'BLOCK_NUMBER'; data: BlockNumber }

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -143,12 +143,7 @@ export namespace RPC {
   };
 
   export type Methods = {
-    starknet_getBlockByHash: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetBlockResponse;
-    };
-    starknet_getBlockByNumber: {
+    starknet_getBlockWithTxHashes: {
       QUERY: never;
       REQUEST: any[];
       RESPONSE: GetBlockResponse;

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -154,6 +154,11 @@ export namespace RPC {
       REQUEST: any[];
       RESPONSE: GetBlockResponse;
     };
+    starknet_getNonce: {
+      QUERY: never;
+      REQUEST: any[];
+      RESPONSE: string;
+    };
     starknet_getStorageAt: {
       QUERY: never;
       REQUEST: any[];


### PR DESCRIPTION
with the recent [update of pathfinder](https://github.com/eqlabs/pathfinder/releases/tag/v0.3.0-alpha), some methods have been deleted, making starknet.js not working when trying to use them
e.g. `starknet_getBlockByHash` and `starknet_getBlockByNumber`, that are used in getBlock method of starknet.js RpcProvider Class
here is an update using new pathfinder `starknet_getBlockWithTxHashes` method instead of these ones