### PR TITLE
fix: supply calldata as hexadecimal string array

### DIFF
--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -1,11 +1,33 @@
-import { RpcProvider } from '../src';
-import { describeIfRpc, getTestProvider } from './fixtures';
+import { isBN } from 'bn.js';
+
+import { Account, RpcProvider, ec } from '../src';
+import {
+  compiledErc20,
+  compiledOpenZeppelinAccount,
+  describeIfRpc,
+  getTestAccount,
+  getTestProvider,
+} from './fixtures';
 
 describeIfRpc('RPCProvider', () => {
-  let provider: RpcProvider;
+  const provider = getTestProvider() as RpcProvider;
+  const account = getTestAccount(provider);
+  let erc20Address: string;
+  let accountPublicKey: string;
 
   beforeAll(async () => {
-    provider = getTestProvider() as RpcProvider;
+    expect(account).toBeInstanceOf(Account);
+
+    const erc20Response = await provider.deployContract({
+      contract: compiledErc20,
+    });
+
+    erc20Address = erc20Response.contract_address;
+
+    await provider.waitForTransaction(erc20Response.transaction_hash);
+
+    const accountKeyPair = ec.genKeyPair();
+    accountPublicKey = ec.getStarkKey(accountKeyPair);
   });
 
   describe('RPC methods', () => {
@@ -13,5 +35,27 @@ describeIfRpc('RPCProvider', () => {
       const chainId = await provider.getChainId();
       expect(chainId).toBe('0x534e5f474f45524c49');
     });
+
+    test('deployContract', async () => {
+      const { contract_address, transaction_hash } = await provider.deployContract({
+        contract: compiledOpenZeppelinAccount,
+        constructorCalldata: [accountPublicKey],
+        addressSalt: accountPublicKey,
+      });
+      await provider.waitForTransaction(transaction_hash);
+      expect(contract_address).toBeTruthy();
+      expect(transaction_hash).toBeTruthy();
+    });
+
+    test('getEstimateFee', async () => {
+      const { overall_fee } = await account.estimateFee({
+        contractAddress: erc20Address,
+        entrypoint: 'mint',
+        calldata: [account.address, '1000'],
+      });
+      expect(isBN(overall_fee)).toBe(true);
+    });
+
+    xtest('invokeFunction', async () => {});
   });
 });

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -56,6 +56,6 @@ describeIfRpc('RPCProvider', () => {
       expect(isBN(overall_fee)).toBe(true);
     });
 
-    xtest('invokeFunction', async () => {});
+    test.todo('invokeFunction');
   });
 });

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -21,7 +21,7 @@ import { getSelectorFromName } from '../utils/hash';
 import { stringify } from '../utils/json';
 import {
   BigNumberish,
-  bigNumberishArrayToDecimalStringArray,
+  bigNumberishArrayToHexadecimalStringArray,
   toBN,
   toHex,
 } from '../utils/number';
@@ -90,18 +90,18 @@ export class RpcProvider implements ProviderInterface {
 
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxHashes', [blockIdentifierGetter.getIdentifier()]).then(
-      this.responseParser.parseGetBlockResponse
-    );
+    return this.fetchEndpoint('starknet_getBlockWithTxHashes', [
+      blockIdentifierGetter.getIdentifier(),
+    ]).then(this.responseParser.parseGetBlockResponse);
   }
 
   public async getBlockWithTxs(
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<GetBlockResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxs', [blockIdentifierGetter.getIdentifier()]).then(
-      this.responseParser.parseGetBlockResponse
-    );
+    return this.fetchEndpoint('starknet_getBlockWithTxs', [
+      blockIdentifierGetter.getIdentifier(),
+    ]).then(this.responseParser.parseGetBlockResponse);
   }
 
   public async getNonce(contractAddress: string): Promise<any> {
@@ -150,7 +150,7 @@ export class RpcProvider implements ProviderInterface {
         contract_address: invocation.contractAddress,
         entry_point_selector: getSelectorFromName(invocation.entrypoint),
         calldata: parseCalldata(invocation.calldata),
-        signature: bigNumberishArrayToDecimalStringArray(invocation.signature || []),
+        signature: bigNumberishArrayToHexadecimalStringArray(invocation.signature || []),
         version: toHex(toBN(invocationDetails?.version || 0)),
       },
       blockIdentifier,
@@ -181,7 +181,7 @@ export class RpcProvider implements ProviderInterface {
 
     return this.fetchEndpoint('starknet_addDeployTransaction', [
       addressSalt ?? randomAddress(),
-      bigNumberishArrayToDecimalStringArray(constructorCalldata ?? []),
+      bigNumberishArrayToHexadecimalStringArray(constructorCalldata ?? []),
       {
         program: contractDefinition.program,
         entry_points_by_type: contractDefinition.entry_points_by_type,
@@ -199,7 +199,7 @@ export class RpcProvider implements ProviderInterface {
         entry_point_selector: getSelectorFromName(functionInvocation.entrypoint),
         calldata: parseCalldata(functionInvocation.calldata),
       },
-      bigNumberishArrayToDecimalStringArray(functionInvocation.signature || []),
+      bigNumberishArrayToHexadecimalStringArray(functionInvocation.signature || []),
       toHex(toBN(details.maxFee || 0)),
       toHex(toBN(details.version || 0)),
     ]).then(this.responseParser.parseInvokeFunctionResponse);
@@ -281,7 +281,9 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier: BlockIdentifier
   ): Promise<RPC.GetTransactionCountResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockTransactionCount', [blockIdentifierGetter.getIdentifier()]);
+    return this.fetchEndpoint('starknet_getBlockTransactionCount', [
+      blockIdentifierGetter.getIdentifier(),
+    ]);
   }
 
   /**

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -57,3 +57,7 @@ export function assertInRange(
 export function bigNumberishArrayToDecimalStringArray(rawCalldata: BigNumberish[]): string[] {
   return rawCalldata.map((x) => toBN(x).toString(10));
 }
+
+export function bigNumberishArrayToHexadecimalStringArray(rawCalldata: BigNumberish[]): string[] {
+  return rawCalldata.map((x) => toHex(toBN(x)));
+}


### PR DESCRIPTION
## Motivation and Resolution

The StarkNet OpenRPC API spec defines a FELT as a "...field element. Represented as up to 63 hex digits and leading 4 bits zeroed." The RPC write api defines three methods which take an array of FELT as calldata. The RpcProvider has three methods which incorrectly converts an array of BigNumbersih values into a decimal string array rather than an hexadecimal string array to pass as call data. Those methods are:

* getEstimateFee()
* deployContract()
* invokeFunction()

This is the cause of the error described in issue #285

* Adds new utility method bigNumberishArrayToHexadecimalStringArray() in utils/number.ts to return an hexadecimal string array from an array of BigNumberish values
* Replaces the use of bigNumberishArrayToDecimalStringArray() in the three methods mentioned with bigNumberishArrayToHexadecimalStringArray()
* Adds two tests for the RpcProvider test suite rpcProvider.tests.ts

Acknowledging the notice that invokeFunction() is deprecated, I have not added a test for it to the test suite.

Please feel free to make any changes to this PR, including the addition of a test for invokeFucntion(), if you deem it necessary.

Fixes #285

## Usage related changes

Changes should be transparent to users.

## Development related changes

- Added 2 new tests to the RpcProvider test suite.

## Checklist:
- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [X] Updated the tests
- [X] All tests are passing
