### PR TITLE
Rpc 0.1.0 incomplete - only test pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ npm-debug.log
 .env
 .DS_Store
 .eslintcache
+.vscode
 coverage
 yarn.lock

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -46,6 +46,16 @@ describe('defaultProvider', () => {
     test(`getBlock(blockHash=${exampleBlockHash}, blockNumber=undefined)`, () => {
       return expect(testProvider.getBlock(exampleBlockHash)).resolves.not.toThrow();
     });
+    test('getBlock(blockIdentifier=latest)', async () => {
+      expect(exampleBlock).not.toBeNull();
+
+      const { block_number, timestamp } = exampleBlock;
+
+      expect(typeof block_number).toEqual('number');
+
+      return expect(typeof timestamp).toEqual('number');
+    });
+
     test('getBlock() -> { blockNumber }', async () => {
       const block = await testProvider.getBlock();
       return expect(block).toHaveProperty('block_number');

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -46,6 +46,7 @@ describe('defaultProvider', () => {
     test(`getBlock(blockHash=${exampleBlockHash}, blockNumber=undefined)`, () => {
       return expect(testProvider.getBlock(exampleBlockHash)).resolves.not.toThrow();
     });
+
     test('getBlock(blockIdentifier=latest)', async () => {
       expect(exampleBlock).not.toBeNull();
 
@@ -250,13 +251,11 @@ describe('defaultProvider', () => {
       });
 
       describe('Contract methods', () => {
-        // let contractAddress: string;
         let deployResponse: DeployContractResponse;
         let declareResponse: DeclareContractResponse;
 
         beforeAll(async () => {
           deployResponse = await provider.deployContract({ contract: compiledErc20 });
-          // contractAddress = deployResponse.contract_address;
           declareResponse = await provider.declareContract({ contract: compiledErc20 });
           await Promise.all([
             provider.waitForTransaction(deployResponse.transaction_hash),

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -46,17 +46,6 @@ describe('defaultProvider', () => {
     test(`getBlock(blockHash=${exampleBlockHash}, blockNumber=undefined)`, () => {
       return expect(testProvider.getBlock(exampleBlockHash)).resolves.not.toThrow();
     });
-
-    test('getBlock(blockIdentifier=latest)', async () => {
-      expect(exampleBlock).not.toBeNull();
-
-      const { block_number, accepted_time } = exampleBlock;
-
-      expect(typeof block_number).toEqual('number');
-
-      return expect(typeof accepted_time).toEqual('number');
-    });
-
     test('getBlock() -> { blockNumber }', async () => {
       const block = await testProvider.getBlock();
       return expect(block).toHaveProperty('block_number');

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -251,16 +251,20 @@ describe('defaultProvider', () => {
       });
 
       describe('Contract methods', () => {
+        let contractAddress: string;
         let deployResponse: DeployContractResponse;
         let declareResponse: DeclareContractResponse;
+        let blockNumber: BlockNumber;
 
         beforeAll(async () => {
           deployResponse = await provider.deployContract({ contract: compiledErc20 });
+          contractAddress = deployResponse.contract_address;
           declareResponse = await provider.declareContract({ contract: compiledErc20 });
           await Promise.all([
             provider.waitForTransaction(deployResponse.transaction_hash),
             provider.waitForTransaction(declareResponse.transaction_hash),
           ]);
+          ({ block_number: blockNumber } = await provider.getBlock('latest'));
         });
 
         describe('deployContract', () => {
@@ -279,10 +283,7 @@ describe('defaultProvider', () => {
 
         describe('getClassAt', () => {
           test('response', async () => {
-            const classResponse = await provider.getClassAt(
-              '0x075c4CEe7e88010008c1aA8777D798073D5Db63B685A033140cE5AF144EA0283',
-              '0x673c337dd17b50628e7b2a070e2c599a4fed54a2e7c1ff10e84115325c5b37e'
-            );
+            const classResponse = await provider.getClassAt(contractAddress, blockNumber);
 
             expect(classResponse).toHaveProperty('program');
             expect(classResponse).toHaveProperty('entry_points_by_type');

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -61,11 +61,6 @@ describe('defaultProvider', () => {
       return expect(block).toHaveProperty('block_number');
     });
 
-    test('getCode() -> { bytecode }', async () => {
-      const code = await testProvider.getCode(exampleContractAddress);
-      return expect(Array.isArray(code.bytecode)).toBe(true);
-    });
-
     describe('getStorageAt', () => {
       test('with "key" type of number', () => {
         return expect(testProvider.getStorageAt(exampleContractAddress, 0)).resolves.not.toThrow();

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -146,11 +146,8 @@ describe('defaultProvider', () => {
           expect(latestBlock).toHaveProperty('parent_hash');
           expect(latestBlock).toHaveProperty('block_number');
           expect(latestBlock).toHaveProperty('status');
-          expect(latestBlock).toHaveProperty('sequencer');
           expect(latestBlock).toHaveProperty('new_root');
-          expect(latestBlock).toHaveProperty('old_root');
-          expect(latestBlock).toHaveProperty('accepted_time');
-          expect(latestBlock).toHaveProperty('gas_price');
+          expect(latestBlock).toHaveProperty('timestamp');
           expect(latestBlock).toHaveProperty('transactions');
           expect(Array.isArray(latestBlock.transactions)).toBe(true);
         });
@@ -164,11 +161,8 @@ describe('defaultProvider', () => {
           expect(block).toHaveProperty('parent_hash');
           expect(block).toHaveProperty('block_number');
           expect(block).toHaveProperty('status');
-          expect(block).toHaveProperty('sequencer');
           expect(block).toHaveProperty('new_root');
-          expect(block).toHaveProperty('old_root');
-          expect(block).toHaveProperty('accepted_time');
-          expect(block).toHaveProperty('gas_price');
+          expect(block).toHaveProperty('timestamp');
           expect(block).toHaveProperty('transactions');
           expect(Array.isArray(block.transactions)).toBe(true);
         });
@@ -179,11 +173,8 @@ describe('defaultProvider', () => {
           expect(block).toHaveProperty('parent_hash');
           expect(block).toHaveProperty('block_number');
           expect(block).toHaveProperty('status');
-          expect(block).toHaveProperty('sequencer');
           expect(block).toHaveProperty('new_root');
-          expect(block).toHaveProperty('old_root');
-          expect(block).toHaveProperty('accepted_time');
-          expect(block).toHaveProperty('gas_price');
+          expect(block).toHaveProperty('timestamp');
           expect(block).toHaveProperty('transactions');
           expect(Array.isArray(block.transactions)).toBe(true);
         });
@@ -193,7 +184,7 @@ describe('defaultProvider', () => {
         test('pending', async () => {
           const storage = await provider.getStorageAt(
             '0x01d1f307c073bb786a66e6e042ec2a9bdc385a3373bb3738d95b966d5ce56166',
-            0
+            '0'
           );
           expect(typeof storage).toBe('string');
         });
@@ -201,7 +192,7 @@ describe('defaultProvider', () => {
         test('Block Hash 0x7104702055c2a5773a870ceada9552ec659d69c18053b14078983f07527dea8', async () => {
           const storage = await provider.getStorageAt(
             '0x01d1f307c073bb786a66e6e042ec2a9bdc385a3373bb3738d95b966d5ce56166',
-            0,
+            '0',
             '0x7225762c7ff5e7e5f0867f0a8e73594df4f44f05a65375339a76398e8ae3e64'
           );
           expect(typeof storage).toBe('string');
@@ -239,7 +230,6 @@ describe('defaultProvider', () => {
           expect(transaction.max_fee).toBeTruthy();
           expect(transaction.transaction_hash).toBeTruthy();
           expect(transaction).toHaveProperty('nonce');
-          expect(transaction).toHaveProperty('sender_address');
           expect(transaction).toHaveProperty('version');
         });
       });
@@ -260,13 +250,13 @@ describe('defaultProvider', () => {
       });
 
       describe('Contract methods', () => {
-        let contractAddress: string;
+        // let contractAddress: string;
         let deployResponse: DeployContractResponse;
         let declareResponse: DeclareContractResponse;
 
         beforeAll(async () => {
           deployResponse = await provider.deployContract({ contract: compiledErc20 });
-          contractAddress = deployResponse.contract_address;
+          // contractAddress = deployResponse.contract_address;
           declareResponse = await provider.declareContract({ contract: compiledErc20 });
           await Promise.all([
             provider.waitForTransaction(deployResponse.transaction_hash),
@@ -290,7 +280,10 @@ describe('defaultProvider', () => {
 
         describe('getClassAt', () => {
           test('response', async () => {
-            const classResponse = await provider.getClassAt(contractAddress);
+            const classResponse = await provider.getClassAt(
+              '0x075c4CEe7e88010008c1aA8777D798073D5Db63B685A033140cE5AF144EA0283',
+              '0x673c337dd17b50628e7b2a070e2c599a4fed54a2e7c1ff10e84115325c5b37e'
+            );
 
             expect(classResponse).toHaveProperty('program');
             expect(classResponse).toHaveProperty('entry_points_by_type');

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -138,7 +138,7 @@ describe('defaultProvider', () => {
 
   describeIfNotDevnet('Provider', () => {
     const provider = getTestProvider();
-    describe(`Provider methods`, () => {
+    describe(`Provider methods if not devnet`, () => {
       describe('getBlock', () => {
         test('pending', async () => {
           const latestBlock = await provider.getBlock();

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -1,17 +1,32 @@
-import { RpcProvider } from '../src';
+import { GetBlockResponse, RpcProvider } from '../src';
 import { describeIfRpc, getTestProvider } from './fixtures';
 
 describeIfRpc('RPCProvider', () => {
-  let provider: RpcProvider;
+  let rpcProvider: RpcProvider;
 
   beforeAll(async () => {
-    provider = getTestProvider() as RpcProvider;
+    rpcProvider = getTestProvider() as RpcProvider;
   });
 
   describe('RPC methods', () => {
     test('getChainId', async () => {
-      const chainId = await provider.getChainId();
+      const chainId = await rpcProvider.getChainId();
       expect(chainId).toBe('0x534e5f474f45524c49');
+    });
+  });
+
+  describe('divergence from Provider methods', () => {
+    let exampleBlock: GetBlockResponse;
+
+    beforeAll(async () => {
+      exampleBlock = await rpcProvider.getBlock('latest');
+    });
+
+    test('getBlock(blockIdentifier=latest)', async () => {
+      expect(exampleBlock).not.toBeNull();
+      const { block_number, accepted_time } = exampleBlock;
+      expect(typeof block_number).toEqual('number');
+      return expect(typeof accepted_time).toEqual('number');
     });
   });
 });

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -1,4 +1,4 @@
-import { GetBlockResponse, RpcProvider } from '../src';
+import { RpcProvider } from '../src';
 import { describeIfRpc, getTestProvider } from './fixtures';
 
 describeIfRpc('RPCProvider', () => {
@@ -12,21 +12,6 @@ describeIfRpc('RPCProvider', () => {
     test('getChainId', async () => {
       const chainId = await rpcProvider.getChainId();
       expect(chainId).toBe('0x534e5f474f45524c49');
-    });
-  });
-
-  describe('divergence from Provider methods', () => {
-    let exampleBlock: GetBlockResponse;
-
-    beforeAll(async () => {
-      exampleBlock = await rpcProvider.getBlock('latest');
-    });
-
-    test('getBlock(blockIdentifier=latest)', async () => {
-      expect(exampleBlock).not.toBeNull();
-      const { block_number, accepted_time } = exampleBlock;
-      expect(typeof block_number).toEqual('number');
-      return expect(typeof accepted_time).toEqual('number');
     });
   });
 });

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -1,4 +1,4 @@
-import { Contract, GetBlockResponse, Provider, SequencerProvider, stark } from '../src';
+import { Contract, Provider, SequencerProvider, stark } from '../src';
 import { toBN } from '../src/utils/number';
 import {
   compiledErc20,
@@ -72,22 +72,5 @@ describeIfSequencer('SequencerProvider', () => {
       expect(res).toStrictEqual(toBN(0));
       expect(res).toStrictEqual(result.res);
     });
-  });
-});
-
-describe('divergence from Provider methods', () => {
-  let exampleBlock: GetBlockResponse;
-  let sequencerProvider: SequencerProvider;
-
-  beforeAll(async () => {
-    sequencerProvider = getTestProvider() as SequencerProvider;
-    exampleBlock = await sequencerProvider.getBlock('latest');
-  });
-
-  test('getBlock(blockIdentifier=latest)', async () => {
-    expect(exampleBlock).not.toBeNull();
-    const { block_number, accepted_time } = exampleBlock;
-    expect(typeof block_number).toEqual('number');
-    return expect(typeof accepted_time).toEqual('number');
   });
 });

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -7,7 +7,7 @@ import {
   getTestProvider,
 } from './fixtures';
 
-// This run only if Devnet Sequencer ?
+// Run only if Devnet Sequencer
 describeIfSequencer('SequencerProvider', () => {
   let provider: SequencerProvider;
   let customSequencerProvider: Provider;

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -1,4 +1,4 @@
-import { Contract, Provider, SequencerProvider, stark } from '../src';
+import { Contract, GetBlockResponse, Provider, SequencerProvider, stark } from '../src';
 import { toBN } from '../src/utils/number';
 import {
   compiledErc20,
@@ -7,6 +7,7 @@ import {
   getTestProvider,
 } from './fixtures';
 
+// This run only if Devnet Sequencer ?
 describeIfSequencer('SequencerProvider', () => {
   let provider: SequencerProvider;
   let customSequencerProvider: Provider;
@@ -71,5 +72,22 @@ describeIfSequencer('SequencerProvider', () => {
       expect(res).toStrictEqual(toBN(0));
       expect(res).toStrictEqual(result.res);
     });
+  });
+});
+
+describe('divergence from Provider methods', () => {
+  let exampleBlock: GetBlockResponse;
+  let sequencerProvider: SequencerProvider;
+
+  beforeAll(async () => {
+    sequencerProvider = getTestProvider() as SequencerProvider;
+    exampleBlock = await sequencerProvider.getBlock('latest');
+  });
+
+  test('getBlock(blockIdentifier=latest)', async () => {
+    expect(exampleBlock).not.toBeNull();
+    const { block_number, accepted_time } = exampleBlock;
+    expect(typeof block_number).toEqual('number');
+    return expect(typeof accepted_time).toEqual('number');
   });
 });

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -11,6 +11,7 @@ import {
 describeIfSequencer('SequencerProvider', () => {
   let provider: SequencerProvider;
   let customSequencerProvider: Provider;
+  let exampleContractAddress: string;
 
   beforeAll(async () => {
     provider = getTestProvider() as SequencerProvider;
@@ -27,11 +28,12 @@ describeIfSequencer('SequencerProvider', () => {
     let exampleTransactionHash: string;
 
     beforeAll(async () => {
-      const { transaction_hash } = await provider.deployContract({
+      const { transaction_hash, contract_address } = await provider.deployContract({
         contract: compiledErc20,
       });
       await provider.waitForTransaction(transaction_hash);
       exampleTransactionHash = transaction_hash;
+      exampleContractAddress = contract_address;
     });
 
     test('getTransactionStatus()', async () => {
@@ -42,6 +44,11 @@ describeIfSequencer('SequencerProvider', () => {
       const transactionTrace = await provider.getTransactionTrace(exampleTransactionHash);
       expect(transactionTrace).toHaveProperty('function_invocation');
       expect(transactionTrace).toHaveProperty('signature');
+    });
+
+    test('getCode() -> { bytecode }', async () => {
+      const code = await provider.getCode(exampleContractAddress);
+      return expect(Array.isArray(code.bytecode)).toBe(true);
     });
 
     describeIfNotDevnet('which are not available on devnet', () => {

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -9,6 +9,7 @@ import {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
+  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -100,6 +101,13 @@ export class Provider implements ProviderInterface {
 
   public async declareContract(payload: DeclareContractPayload): Promise<DeclareContractResponse> {
     return this.provider.declareContract(payload);
+  }
+
+  public async getCode(
+    contractAddress: string,
+    blockIdentifier?: BlockIdentifier
+  ): Promise<GetCodeResponse> {
+    return this.provider.getCode(contractAddress, blockIdentifier);
   }
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<void> {

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -10,7 +10,6 @@ import {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
-  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -102,13 +101,6 @@ export class Provider implements ProviderInterface {
 
   public async declareContract(payload: DeclareContractPayload): Promise<DeclareContractResponse> {
     return this.provider.declareContract(payload);
-  }
-
-  public async getCode(
-    contractAddress: string,
-    blockIdentifier?: BlockIdentifier
-  ): Promise<GetCodeResponse> {
-    return this.provider.getCode(contractAddress, blockIdentifier);
   }
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<void> {

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -1,6 +1,5 @@
 import { StarknetChainId } from '../constants';
 import {
-  BlockTag,
   Call,
   CallContractResponse,
   ContractClass,
@@ -68,9 +67,9 @@ export class Provider implements ProviderInterface {
   public async getStorageAt(
     contractAddress: string,
     key: BigNumberish,
-    blockTagOrHash: BlockTag | BigNumberish = 'pending'
+    blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<BigNumberish> {
-    return this.provider.getStorageAt(contractAddress, key, blockTagOrHash);
+    return this.provider.getStorageAt(contractAddress, key, blockIdentifier);
   }
 
   public async getTransaction(txHash: BigNumberish): Promise<GetTransactionResponse> {

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -1,6 +1,5 @@
 import { StarknetChainId } from '../constants';
 import type {
-  BlockTag,
   Call,
   CallContractResponse,
   ContractClass,
@@ -59,13 +58,13 @@ export abstract class ProviderInterface {
    *
    * @param contractAddress
    * @param key - from getStorageVarAddress('<STORAGE_VARIABLE_NAME>') (WIP)
-   * @param blockHashOrTag - block hash or tag (pending, latest)
+   * @param blockIdentifier - block identifier
    * @returns the value of the storage variable
    */
   public abstract getStorageAt(
     contractAddress: string,
     key: BigNumberish,
-    blockHashOrTag?: BlockTag | BigNumberish
+    blockIdentifier: BlockIdentifier
   ): Promise<BigNumberish>;
 
   /**

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -9,6 +9,7 @@ import type {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
+  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -40,6 +41,14 @@ export abstract class ProviderInterface {
    * @returns the block object
    */
   public abstract getBlock(blockIdentifier: BlockIdentifier): Promise<GetBlockResponse>;
+
+  /**
+   * @deprecated The method should not be used
+   */
+  public abstract getCode(
+    contractAddress: string,
+    blockIdentifier?: BlockIdentifier
+  ): Promise<GetCodeResponse>;
 
   /**
    * Gets the contract class of the deployed contract.

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -10,7 +10,6 @@ import type {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
-  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -42,11 +41,6 @@ export abstract class ProviderInterface {
    * @returns the block object
    */
   public abstract getBlock(blockIdentifier: BlockIdentifier): Promise<GetBlockResponse>;
-
-  public abstract getCode(
-    contractAddress: string,
-    blockIdentifier?: BlockIdentifier
-  ): Promise<GetCodeResponse>;
 
   /**
    * Gets the contract class of the deployed contract.

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -123,10 +123,22 @@ export class RpcProvider implements ProviderInterface {
     ]);
   }
 
+  // common interface
   public async getTransaction(txHash: BigNumberish): Promise<GetTransactionResponse> {
-    return this.fetchEndpoint('starknet_getTransactionByHash', [txHash]).then(
-      this.responseParser.parseGetTransactionResponse
-    );
+    return this.getTransactionByHash(txHash).then(this.responseParser.parseGetTransactionResponse);
+  }
+
+  public async getTransactionByHash(
+    txHash: BigNumberish
+  ): Promise<RPC.GetTransactionByHashResponse> {
+    return this.fetchEndpoint('starknet_getTransactionByHash', [txHash]);
+  }
+
+  public async getTransactionByBlockIdAndIndex(
+    blockIdentifier: BlockIdentifier,
+    index: number
+  ): Promise<RPC.GetTransactionByBlockIdAndIndex> {
+    return this.fetchEndpoint('starknet_getTransactionByHash', [blockIdentifier, index]);
   }
 
   public async getTransactionReceipt(txHash: BigNumberish): Promise<GetTransactionReceiptResponse> {
@@ -135,11 +147,12 @@ export class RpcProvider implements ProviderInterface {
     );
   }
 
-  public async getClassAt(
-    contractAddress: string,
-    _blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<any> {
-    return this.fetchEndpoint('starknet_getClassAt', [contractAddress]);
+  public async getClassAt(contractAddress: string, blockIdentifier: BlockIdentifier): Promise<any> {
+    const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
+    return this.fetchEndpoint('starknet_getClassAt', [
+      blockIdentifierGetter.getIdentifier(),
+      contractAddress,
+    ]);
   }
 
   public async getEstimateFee(

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -223,17 +223,6 @@ export class RpcProvider implements ProviderInterface {
     return this.responseParser.parseCallContractResponse(result);
   }
 
-  public async getCode(
-    contractAddress: string,
-    _blockIdentifier?: BlockIdentifier
-  ): Promise<RPC.GetCodeResponse> {
-    // deprecated method, please wait for an update of starknet.js
-
-    const result = await this.fetchEndpoint('starknet_getCode', [contractAddress]);
-
-    return this.responseParser.parseGetCodeResponse(result);
-  }
-
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
     let onchain = false;
     let retries = 100;

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -8,6 +8,7 @@ import {
   DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
+  GetCodeResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
   Invocation,
@@ -91,7 +92,7 @@ export class RpcProvider implements ProviderInterface {
 
   public async getBlockWithTxHashes(
     blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<RPC.getBlockWithTxHashesResponse> {
+  ): Promise<RPC.GetBlockWithTxHashesResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     return this.fetchEndpoint('starknet_getBlockWithTxHashes', [
       blockIdentifierGetter.getIdentifier(),
@@ -100,7 +101,7 @@ export class RpcProvider implements ProviderInterface {
 
   public async getBlockWithTxs(
     blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<RPC.getBlockWithTxs> {
+  ): Promise<RPC.GetBlockWithTxs> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     return this.fetchEndpoint('starknet_getBlockWithTxs', [blockIdentifierGetter.getIdentifier()]);
   }
@@ -234,6 +235,13 @@ export class RpcProvider implements ProviderInterface {
     ]);
 
     return this.responseParser.parseCallContractResponse(result);
+  }
+
+  public async getCode(
+    _contractAddress: string,
+    _blockIdentifier?: BlockIdentifier
+  ): Promise<GetCodeResponse> {
+    throw new Error('RPC 0.1.0 does not implement getCode function');
   }
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -83,20 +83,27 @@ export class RpcProvider implements ProviderInterface {
     return this.fetchEndpoint('starknet_chainId');
   }
 
+  // Common Interface
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
+    return this.getBlockWithTxHashes(blockIdentifier).then(
+      this.responseParser.parseGetBlockResponse
+    );
+  }
+
+  public async getBlockWithTxHashes(
+    blockIdentifier: BlockIdentifier = 'pending'
+  ): Promise<RPC.getBlockWithTxHashesResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     return this.fetchEndpoint('starknet_getBlockWithTxHashes', [
       blockIdentifierGetter.getIdentifier(),
-    ]).then(this.responseParser.parseGetBlockResponse);
+    ]);
   }
 
   public async getBlockWithTxs(
     blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<GetBlockResponse> {
+  ): Promise<RPC.getBlockWithTxs> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxs', [
-      blockIdentifierGetter.getIdentifier(),
-    ]).then(this.responseParser.parseGetBlockResponse);
+    return this.fetchEndpoint('starknet_getBlockWithTxs', [blockIdentifierGetter.getIdentifier()]);
   }
 
   public async getNonce(contractAddress: string): Promise<any> {

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -1,6 +1,5 @@
 import { StarknetChainId } from '../constants';
 import {
-  BlockTag,
   Call,
   CallContractResponse,
   DeclareContractPayload,
@@ -113,13 +112,14 @@ export class RpcProvider implements ProviderInterface {
   public async getStorageAt(
     contractAddress: string,
     key: BigNumberish,
-    blockHashOrTag: BlockTag | BigNumberish = 'pending'
+    blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<BigNumberish> {
     const parsedKey = toHex(toBN(key));
+    const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
     return this.fetchEndpoint('starknet_getStorageAt', [
       contractAddress,
       parsedKey,
-      blockHashOrTag,
+      blockIdentifierGetter.getIdentifier(),
     ]);
   }
 

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -19,12 +19,7 @@ import { RPC } from '../types/api';
 import fetch from '../utils/fetchPonyfill';
 import { getSelectorFromName } from '../utils/hash';
 import { stringify } from '../utils/json';
-import {
-  BigNumberish,
-  bigNumberishArrayToDecimalStringArray,
-  toBN,
-  toHex,
-} from '../utils/number';
+import { BigNumberish, bigNumberishArrayToDecimalStringArray, toBN, toHex } from '../utils/number';
 import { parseCalldata, parseContract, wait } from '../utils/provider';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 import { randomAddress } from '../utils/stark';
@@ -90,18 +85,18 @@ export class RpcProvider implements ProviderInterface {
 
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxHashes', [blockIdentifierGetter.getIdentifier()]).then(
-      this.responseParser.parseGetBlockResponse
-    );
+    return this.fetchEndpoint('starknet_getBlockWithTxHashes', [
+      blockIdentifierGetter.getIdentifier(),
+    ]).then(this.responseParser.parseGetBlockResponse);
   }
 
   public async getBlockWithTxs(
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<GetBlockResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxs', [blockIdentifierGetter.getIdentifier()]).then(
-      this.responseParser.parseGetBlockResponse
-    );
+    return this.fetchEndpoint('starknet_getBlockWithTxs', [
+      blockIdentifierGetter.getIdentifier(),
+    ]).then(this.responseParser.parseGetBlockResponse);
   }
 
   public async getNonce(contractAddress: string): Promise<any> {
@@ -281,7 +276,9 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier: BlockIdentifier
   ): Promise<RPC.GetTransactionCountResponse> {
     const blockIdentifierGetter = new BlockIdentifierClass(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockTransactionCount', [blockIdentifierGetter.getIdentifier()]);
+    return this.fetchEndpoint('starknet_getBlockTransactionCount', [
+      blockIdentifierGetter.getIdentifier(),
+    ]);
   }
 
   /**

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -2,7 +2,6 @@ import urljoin from 'url-join';
 
 import { ONE, StarknetChainId, ZERO } from '../constants';
 import {
-  BlockTag,
   Call,
   CallContractResponse,
   ContractClass,
@@ -233,11 +232,11 @@ export class SequencerProvider implements ProviderInterface {
   public async getStorageAt(
     contractAddress: string,
     key: BigNumberish,
-    blockHashOrTag: BlockTag | BigNumberish = 'pending'
+    blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<BigNumberish> {
     const parsedKey = toBN(key).toString(10);
     return this.fetchEndpoint('get_storage_at', {
-      blockIdentifier: blockHashOrTag,
+      blockIdentifier,
       contractAddress,
       key: parsedKey,
     });

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -332,9 +332,7 @@ export class SequencerProvider implements ProviderInterface {
     contractAddress: string,
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<Sequencer.GetCodeResponse> {
-    return this.fetchEndpoint('get_code', { contractAddress, blockIdentifier }).then(
-      this.responseParser.parseGetCodeResponse
-    );
+    return this.fetchEndpoint('get_code', { contractAddress, blockIdentifier });
   }
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -37,7 +37,6 @@ type BlockIdentifierObject =
   | { type: 'BLOCK_NUMBER'; data: BlockNumber }
   | { type: 'BLOCK_HASH'; data: BigNumberish };
 
-
 export class BlockIdentifierClass {
   blockIdentifier: BlockIdentifier;
 

--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -1,0 +1,148 @@
+/**
+ * Starknet RPC version 0.1.0
+ * starknet_api_openrpc version 0.31.0
+ *
+ * TypeScript Representation of OpenRpc protocol types
+ */
+
+/**
+ * "type": "string",
+ * "title": "Field element",
+ * "$comment": "A field element, represented as a string of hex digits",
+ * "description": "A field element. Represented as up to 63 hex digits and leading 4 bits zeroed.",
+ * "pattern": "^0x0[a-fA-F0-9]{1,63}$"
+ */
+type FELT = string;
+type BLOCK_NUMBER = number;
+type BLOCK_HASH = FELT;
+type TXN_HASH = FELT;
+type TXN_STATUS = 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+type TXN_TYPE = 'DECLARE' | 'DEPLOY' | 'INVOKE' | 'L1_HANDLER';
+type MSG_TO_L1 = {
+  to_address: FELT;
+  payload: Array<FELT>;
+};
+type EVENT = {
+  from_address: FELT;
+  keys: Array<FELT>;
+  data: Array<FELT>;
+};
+type COMMON_RECEIPT_PROPERTIES = {
+  transaction_hash: TXN_HASH;
+  actual_fee: FELT;
+  status: TXN_STATUS;
+  block_hash: BLOCK_HASH;
+  block_number: BLOCK_NUMBER;
+  type?: TXN_TYPE;
+};
+type INVOKE_TXN_RECEIPT_PROPERTIES = {
+  messages_sent: MSG_TO_L1;
+  events: EVENT;
+};
+type PENDING_COMMON_RECEIPT_PROPERTIES = {
+  transaction_hash: TXN_HASH;
+  actual_fee: FELT;
+  type?: TXN_TYPE;
+};
+type INVOKE_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES & INVOKE_TXN_RECEIPT_PROPERTIES;
+type L1_HANDLER_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES;
+type DECLARE_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES;
+type DEPLOY_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES;
+type PENDING_INVOKE_TXN_RECEIPT = PENDING_COMMON_RECEIPT_PROPERTIES & INVOKE_TXN_RECEIPT_PROPERTIES;
+type PENDING_TXN_RECEIPT = PENDING_INVOKE_TXN_RECEIPT | PENDING_COMMON_RECEIPT_PROPERTIES;
+type TXN_RECEIPT =
+  | INVOKE_TXN_RECEIPT
+  | L1_HANDLER_TXN_RECEIPT
+  | DECLARE_TXN_RECEIPT
+  | DEPLOY_TXN_RECEIPT
+  | PENDING_TXN_RECEIPT;
+
+export namespace RPC_1 {
+  export type GetTransactionReceiptResponse = TXN_RECEIPT;
+
+  export type Methods = {
+    starknet_getTransactionReceipt: {
+      QUERY: never;
+      REQUEST: any[];
+      RESPONSE: GetTransactionReceiptResponse;
+    };
+  };
+}
+
+// starknet_getBlockWithTxHashes
+type BLOCK_HEADER = {
+  block_hash: BLOCK_HASH;
+  parent_hash: BLOCK_HASH;
+  block_number: BLOCK_NUMBER;
+  new_root: FELT;
+  timestamp: number;
+  sequencer_address: FELT;
+};
+type BLOCK_BODY_WITH_TX_HASHES = {
+  transactions: Array<TXN_HASH>;
+};
+type BLOCK_WITH_TX_HASHES = {
+  status: TXN_STATUS;
+} & BLOCK_HEADER &
+  BLOCK_BODY_WITH_TX_HASHES;
+type PENDING_BLOCK_WITH_TX_HASHES = BLOCK_BODY_WITH_TX_HASHES & {
+  timestamp: number;
+  sequencer_address: FELT;
+  parent_hash: BLOCK_HASH;
+};
+
+// starknet_getBlockWithTx
+type BLOCK_STATUS = 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
+/**
+ * "title": "An integer number in hex format (0x...)",
+ * "pattern": "^0x[a-fA-F0-9]+$"
+ */
+type NUM_AS_HEX = string;
+type SIGNATURE = Array<FELT>;
+type COMMON_TXN_PROPERTIES = {
+  transaction_hash: TXN_HASH;
+  max_fee: FELT;
+  version: NUM_AS_HEX;
+  signature: SIGNATURE;
+  nonce: FELT;
+  type: TXN_TYPE;
+};
+type ADDRESS = FELT;
+type FUNCTION_CALL = {
+  contract_address: ADDRESS;
+  entry_point_selector: FELT;
+  calldata: Array<FELT>;
+};
+type INVOKE_TXN = COMMON_TXN_PROPERTIES & FUNCTION_CALL;
+type DECLARE_TXN = COMMON_TXN_PROPERTIES & {
+  class_hash: FELT;
+  sender_address: ADDRESS;
+};
+type DEPLOY_TXN = {
+  transaction_hash: TXN_HASH;
+  class_hash: FELT;
+  version: NUM_AS_HEX;
+  type: TXN_TYPE;
+  contract_address: FELT;
+  contract_address_salt: FELT;
+  constructor_calldata: Array<FELT>;
+};
+type TXN = INVOKE_TXN | DECLARE_TXN | DEPLOY_TXN;
+type BLOCK_BODY_WITH_TXS = {
+  transactions: Array<TXN>;
+};
+type BLOCK_WITH_TXS = {
+  status: BLOCK_STATUS;
+} & BLOCK_HEADER &
+  BLOCK_BODY_WITH_TXS;
+
+type PENDING_BLOCK_WITH_TXS = BLOCK_BODY_WITH_TXS & {
+  timestamp: number;
+  sequencer_address: FELT;
+  parent_hash: BLOCK_HASH;
+};
+
+export namespace OPENRPC {
+  export type getBlockWithTxHashesResponse = BLOCK_WITH_TX_HASHES | PENDING_BLOCK_WITH_TX_HASHES;
+  export type getBlockWithTxs = BLOCK_WITH_TXS | PENDING_BLOCK_WITH_TXS;
+}

--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -2,7 +2,7 @@
  * Starknet RPC version 0.1.0
  * starknet_api_openrpc version 0.31.0
  *
- * TypeScript Representation of OpenRpc protocol types
+ * TypeScript Representation of OpenRpc protocol types | responses
  */
 
 /**
@@ -145,4 +145,5 @@ type PENDING_BLOCK_WITH_TXS = BLOCK_BODY_WITH_TXS & {
 export namespace OPENRPC {
   export type getBlockWithTxHashesResponse = BLOCK_WITH_TX_HASHES | PENDING_BLOCK_WITH_TX_HASHES;
   export type getBlockWithTxs = BLOCK_WITH_TXS | PENDING_BLOCK_WITH_TXS;
+  export type GetStorageAtResponse = FELT;
 }

--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -2,7 +2,8 @@
  * Starknet RPC version 0.1.0
  * starknet_api_openrpc version 0.31.0
  *
- * TypeScript Representation of OpenRpc protocol types | responses
+ * TypeScript Representation of OpenRpc protocol types | results
+ * errors are not implemented here only results
  */
 
 /**
@@ -142,8 +143,26 @@ type PENDING_BLOCK_WITH_TXS = BLOCK_BODY_WITH_TXS & {
   parent_hash: BLOCK_HASH;
 };
 
+type CONTRACT_CLASS = {
+  program: string; // A base64 representation of the compressed program code
+  entry_points_by_type: {
+    CONSTRUCTOR: CONTRACT_ENTRY_POINT_LIST;
+    EXTERNAL: CONTRACT_ENTRY_POINT_LIST;
+    L1_HANDLER: CONTRACT_ENTRY_POINT_LIST;
+  };
+};
+
+type CONTRACT_ENTRY_POINT_LIST = Array<CONTRACT_ENTRY_POINT>;
+type CONTRACT_ENTRY_POINT = {
+  offset: NUM_AS_HEX;
+  selector: FELT;
+};
+
 export namespace OPENRPC {
-  export type getBlockWithTxHashesResponse = BLOCK_WITH_TX_HASHES | PENDING_BLOCK_WITH_TX_HASHES;
-  export type getBlockWithTxs = BLOCK_WITH_TXS | PENDING_BLOCK_WITH_TXS;
+  export type GetBlockWithTxHashesResponse = BLOCK_WITH_TX_HASHES | PENDING_BLOCK_WITH_TX_HASHES;
+  export type GetBlockWithTxs = BLOCK_WITH_TXS | PENDING_BLOCK_WITH_TXS;
   export type GetStorageAtResponse = FELT;
+  export type GetTransactionByHashResponse = TXN;
+  export type GetTransactionByBlockIdAndIndex = TXN;
+  export type GetClassResponse = CONTRACT_CLASS;
 }

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -1,6 +1,6 @@
 import { StarknetChainId } from '../../constants';
-import { Status } from '../lib';
 import { BlockIdentifier } from '../../provider/utils';
+import { Status } from '../lib';
 
 export namespace RPC {
   export type Response = {
@@ -41,7 +41,7 @@ export namespace RPC {
     sequencer: string;
     new_root: string;
     old_root: string;
-    accepted_time: number;
+    timestamp: number;
     gas_price: string;
     transactions: string[];
   };

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -34,21 +34,8 @@ export namespace RPC {
     gas_price: number;
   };
 
-  export type getBlockWithTxHashesResponse = OPENRPC.getBlockWithTxHashesResponse;
-  export type getBlockWithTxs = OPENRPC.getBlockWithTxs;
-  /*   {
-    block_hash: string;
-    parent_hash: string;
-    block_number: number;
-    status: Status;
-    sequencer: string;
-    new_root: string;
-    old_root: string;
-    timestamp: number;
-    gas_price: string;
-    transactions: string[];
-  }; */
-
+  export type getBlockWithTxHashesResponse = OPENRPC.GetBlockWithTxHashesResponse;
+  export type getBlockWithTxs = OPENRPC.GetBlockWithTxs;
   export type GetStorageAtResponse = OPENRPC.GetStorageAtResponse;
 
   export type GetTransactionReceiptResponse = {
@@ -80,7 +67,8 @@ export namespace RPC {
     sender_address?: string;
   }
 
-  export type GetTransactionResponse = InvokeTransactionResponse & DeclareTransactionResponse;
+  export type GetTransactionByHashResponse = OPENRPC.GetTransactionByHashResponse;
+  export type GetTransactionByBlockIdAndIndex = OPENRPC.GetTransactionByBlockIdAndIndex;
 
   export type GetTransactionCountResponse = number;
 
@@ -165,17 +153,12 @@ export namespace RPC {
     starknet_getTransactionByHash: {
       QUERY: never;
       REQUEST: any[];
-      RESPONSE: GetTransactionResponse;
+      RESPONSE: GetTransactionByHashResponse;
     };
-    starknet_getTransactionByBlockHashAndIndex: {
+    starknet_getTransactionByBlockIdAndIndex: {
       QUERY: never;
       REQUEST: any[];
-      RESPONSE: GetTransactionResponse;
-    };
-    starknet_getTransactionByBlockNumberAndIndex: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetTransactionResponse;
+      RESPONSE: GetTransactionByBlockIdAndIndex;
     };
     starknet_getTransactionReceipt: {
       QUERY: never;

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -49,11 +49,6 @@ export namespace RPC {
     transactions: string[];
   }; */
 
-  export type GetCodeResponse = {
-    bytecode: string[];
-    abi: string;
-  };
-
   export type GetStorageAtResponse = string;
 
   export type GetTransactionReceiptResponse = {
@@ -191,11 +186,6 @@ export namespace RPC {
       QUERY: never;
       REQUEST: any[];
       RESPONSE: GetTransactionCountResponse;
-    };
-    starknet_getCode: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetCodeResponse;
     };
     starknet_call: {
       QUERY: never;

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -49,7 +49,7 @@ export namespace RPC {
     transactions: string[];
   }; */
 
-  export type GetStorageAtResponse = string;
+  export type GetStorageAtResponse = OPENRPC.GetStorageAtResponse;
 
   export type GetTransactionReceiptResponse = {
     txn_hash: string;

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -1,6 +1,7 @@
 import { StarknetChainId } from '../../constants';
 import { BlockIdentifier } from '../../provider/utils';
 import { Status } from '../lib';
+import { OPENRPC } from './openrpc';
 
 export namespace RPC {
   export type Response = {
@@ -33,7 +34,9 @@ export namespace RPC {
     gas_price: number;
   };
 
-  export type GetBlockResponse = {
+  export type getBlockWithTxHashesResponse = OPENRPC.getBlockWithTxHashesResponse;
+  export type getBlockWithTxs = OPENRPC.getBlockWithTxs;
+  /*   {
     block_hash: string;
     parent_hash: string;
     block_number: number;
@@ -44,7 +47,7 @@ export namespace RPC {
     timestamp: number;
     gas_price: string;
     transactions: string[];
-  };
+  }; */
 
   export type GetCodeResponse = {
     bytecode: string[];
@@ -147,12 +150,12 @@ export namespace RPC {
     starknet_getBlockWithTxHashes: {
       QUERY: never;
       REQUEST: any[];
-      RESPONSE: GetBlockResponse;
+      RESPONSE: getBlockWithTxHashesResponse;
     };
     starknet_getBlockWithTxs: {
       QUERY: never;
       REQUEST: any[];
-      RESPONSE: GetBlockResponse;
+      RESPONSE: getBlockWithTxs;
     };
     starknet_getNonce: {
       QUERY: never;

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -34,8 +34,8 @@ export namespace RPC {
     gas_price: number;
   };
 
-  export type getBlockWithTxHashesResponse = OPENRPC.GetBlockWithTxHashesResponse;
-  export type getBlockWithTxs = OPENRPC.GetBlockWithTxs;
+  export type GetBlockWithTxHashesResponse = OPENRPC.GetBlockWithTxHashesResponse;
+  export type GetBlockWithTxs = OPENRPC.GetBlockWithTxs;
   export type GetStorageAtResponse = OPENRPC.GetStorageAtResponse;
 
   export type GetTransactionReceiptResponse = {
@@ -133,12 +133,12 @@ export namespace RPC {
     starknet_getBlockWithTxHashes: {
       QUERY: never;
       REQUEST: any[];
-      RESPONSE: getBlockWithTxHashesResponse;
+      RESPONSE: GetBlockWithTxHashesResponse;
     };
     starknet_getBlockWithTxs: {
       QUERY: never;
       REQUEST: any[];
-      RESPONSE: getBlockWithTxs;
+      RESPONSE: GetBlockWithTxs;
     };
     starknet_getNonce: {
       QUERY: never;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -16,11 +16,6 @@ export interface GetBlockResponse {
   transactions: Array<string>;
 }
 
-export interface GetCodeResponse {
-  bytecode: string[];
-  // abi: string; // is not consistent between rpc and sequencer (is it?), therefore not included in the provider interface
-}
-
 export type GetTransactionResponse = InvokeTransactionResponse & DeclareTransactionResponse;
 
 export interface CommonTransactionResponse {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -3,7 +3,8 @@ import BN from 'bn.js';
 import { Abi, CompressedProgram, EntryPointsByType, RawCalldata, Signature, Status } from './lib';
 
 export interface GetBlockResponse {
-  accepted_time: number;
+  accepted_time?: number;
+  timestamp?: number;
   block_hash: string;
   block_number: number;
   gas_price: string;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,20 +1,19 @@
+/**
+ * Common interface response
+ * Intersection (sequencer response ∩ (∪ rpc responses))
+ */
 import BN from 'bn.js';
 
 import { Abi, CompressedProgram, EntryPointsByType, RawCalldata, Signature, Status } from './lib';
 
 export interface GetBlockResponse {
-  accepted_time?: number;
-  timestamp?: number;
+  timestamp: number;
   block_hash: string;
   block_number: number;
-  gas_price: string;
   new_root: string;
-  old_root?: string;
   parent_hash: string;
-  sequencer: string;
   status: Status;
   transactions: Array<string>;
-  starknet_version?: string;
 }
 
 export interface GetCodeResponse {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -16,6 +16,11 @@ export interface GetBlockResponse {
   transactions: Array<string>;
 }
 
+export interface GetCodeResponse {
+  bytecode: string[];
+  // abi: string; // is not consistent between rpc and sequencer (is it?), therefore not included in the provider interface
+}
+
 export type GetTransactionResponse = InvokeTransactionResponse & DeclareTransactionResponse;
 
 export interface CommonTransactionResponse {

--- a/src/utils/ellipticCurve.ts
+++ b/src/utils/ellipticCurve.ts
@@ -25,7 +25,7 @@ export const ec = new EC(
  * The function _truncateToN in lib/elliptic/ec/index.js does a shift-right of 4 bits
  * in some cases. This function does the opposite operation so that
  * _truncateToN(fixMessage(msg)) == msg.
- * 
+ *
  * @param msg
  */
 function fixMessage(msg: string) {
@@ -68,7 +68,7 @@ export function getKeyPairFromPublicKey(publicKey: BigNumberish): KeyPair {
 
 /**
  * Signs a message using the provided key.
- * 
+ *
  * @param keyPair should be an KeyPair with a valid private key.
  * @returns an Signature.
  */
@@ -94,7 +94,7 @@ function chunkArray(arr: any[], n: number): any[][] {
 
 /**
  * Verifies a message using the provided key.
- * 
+ *
  * @param keyPair should be an KeyPair with a valid public key.
  * @param sig should be an Signature.
  * @returns true if the verification succeeds.

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -62,10 +62,6 @@ export class RPCResponseParser extends ResponseParser {
     };
   }
 
-  public parseGetCodeResponse(res: RPC.GetCodeResponse): RPC.GetCodeResponse {
-    return res;
-  }
-
   public parseFeeEstimateResponse(res: RPC.EstimateFeeResponse): EstimateFeeResponse {
     return {
       overall_fee: toBN(res.overall_fee),

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -15,7 +15,7 @@ import { ResponseParser } from '.';
 export class RPCResponseParser extends ResponseParser {
   public parseGetBlockResponse(res: RPC.GetBlockResponse): GetBlockResponse {
     return {
-      accepted_time: res.accepted_time,
+      timestamp: res.timestamp,
       block_hash: res.block_hash,
       block_number: res.block_number,
       gas_price: res.gas_price,

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -16,7 +16,7 @@ import { RPC } from '../../types/api';
 import { toBN } from '../number';
 import { ResponseParser } from '.';
 
-type RpcGetBlockResponse = RPC.getBlockWithTxHashesResponse & {
+type RpcGetBlockResponse = RPC.GetBlockWithTxHashesResponse & {
   [key: string]: any;
 };
 

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -1,3 +1,7 @@
+/**
+ * Map RPC Response to common interface response
+ * Intersection (sequencer response ∩ (∪ rpc responses))
+ */
 import {
   CallContractResponse,
   DeclareContractResponse,
@@ -12,17 +16,18 @@ import { RPC } from '../../types/api';
 import { toBN } from '../number';
 import { ResponseParser } from '.';
 
+type RpcGetBlockResponse = RPC.getBlockWithTxHashesResponse & {
+  [key: string]: any;
+};
+
 export class RPCResponseParser extends ResponseParser {
-  public parseGetBlockResponse(res: RPC.GetBlockResponse): GetBlockResponse {
+  public parseGetBlockResponse(res: RpcGetBlockResponse): GetBlockResponse {
     return {
       timestamp: res.timestamp,
       block_hash: res.block_hash,
       block_number: res.block_number,
-      gas_price: res.gas_price,
       new_root: res.new_root,
-      old_root: res.old_root,
       parent_hash: res.parent_hash,
-      sequencer: res.sequencer,
       status: res.status,
       transactions: res.transactions,
     };

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -20,6 +20,10 @@ type RpcGetBlockResponse = RPC.getBlockWithTxHashesResponse & {
   [key: string]: any;
 };
 
+type GetTransactionByHashResponse = RPC.GetTransactionByHashResponse & {
+  [key: string]: any;
+};
+
 export class RPCResponseParser extends ResponseParser {
   public parseGetBlockResponse(res: RpcGetBlockResponse): GetBlockResponse {
     return {
@@ -33,17 +37,15 @@ export class RPCResponseParser extends ResponseParser {
     };
   }
 
-  public parseGetTransactionResponse(res: RPC.GetTransactionResponse): GetTransactionResponse {
+  public parseGetTransactionResponse(res: GetTransactionByHashResponse): GetTransactionResponse {
     return {
       calldata: res.calldata || [],
       contract_address: res.contract_address,
-      contract_class: res.contract_class,
       entry_point_selector: res.entry_point_selector,
       max_fee: res.max_fee,
       nonce: res.nonce,
-      sender_address: res.sender_address,
       signature: res.signature || [],
-      transaction_hash: res.txn_hash,
+      transaction_hash: res.transaction_hash,
       version: res.version,
     };
   }

--- a/src/utils/responseParser/sequencer.ts
+++ b/src/utils/responseParser/sequencer.ts
@@ -71,10 +71,6 @@ export class SequencerAPIResponseParser extends ResponseParser {
     };
   }
 
-  public parseGetCodeResponse(res: Sequencer.GetCodeResponse): Sequencer.GetCodeResponse {
-    return res;
-  }
-
   public parseFeeEstimateResponse(res: Sequencer.EstimateFeeResponse): EstimateFeeResponse {
     if ('overall_fee' in res) {
       let gasInfo = {};

--- a/src/utils/responseParser/sequencer.ts
+++ b/src/utils/responseParser/sequencer.ts
@@ -1,3 +1,7 @@
+/**
+ * Map Sequencer Response to common interface response
+ * Intersection (sequencer response ∩ (∪ rpc responses))
+ */
 import {
   CallContractResponse,
   DeclareContractResponse,
@@ -15,14 +19,11 @@ import { ResponseParser } from '.';
 export class SequencerAPIResponseParser extends ResponseParser {
   public parseGetBlockResponse(res: Sequencer.GetBlockResponse): GetBlockResponse {
     return {
-      accepted_time: res.timestamp,
+      timestamp: res.timestamp,
       block_hash: res.block_hash,
       block_number: res.block_number,
-      gas_price: res.gas_price,
       new_root: res.state_root,
-      old_root: undefined,
       parent_hash: res.parent_block_hash,
-      sequencer: res.sequencer_address,
       status: res.status,
       transactions: Object.values(res.transactions)
         .map((value) => 'transaction_hash' in value && value.transaction_hash)

--- a/www/docs/API/account.md
+++ b/www/docs/API/account.md
@@ -93,7 +93,7 @@ account.**verifyMessageHash**(hash, signature) => _Promise < boolean >_
 
 Verify a signature of a given hash.
 
-> **WARNING** 
+> **WARNING**
 >
 > This method is not recommended, use `verifyMessage` instead
 

--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -49,8 +49,8 @@ const provider = new starknet.Provider({
 
 These are also default options for the Provider constructor with `network: 'goerli-alpha'`.
 
-> **Note** 
-> 
+> **Note**
+>
 > `network` arguement should work in most cases. If you want to use sequencer arguement with `baseUrl`, you will not be able to use `network` field in the object.
 
 ## Methods
@@ -117,7 +117,7 @@ Gets the contract class of the deployed contract.
 
 <hr/>
 
-provider.**getStorageAt**(contractAddress, key, blockHashOrTag) => _Promise < string >_
+provider.**getStorageAt**(contractAddress, key, blockIdentifier) => _Promise < string >_
 
 Gets the contract's storage variable at a specific key.
 


### PR DESCRIPTION
## Motivation and Resolution
Fix breaking Tests and open release pipeline

### RPC version (if applicable)
0.1.0

## Usage-related changes
RPC Fixes related to:
- getBlock
- getCode removed
- getStorageAt
- getClassAt


## Development related changes
RPC Provider has:
- getBlockWithTxHashes
- getBlockWithTxs
- getTransactionByHash
- getTransactionByBlockIdAndIndex

getClassAt now has 2 parameters for RPC also same as sequencer (contractAddress, blockIdentifier)

openrpc.ts specify mapping of open RPC spec to TS types (work in progress)

## Checklist:
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
