### PR TITLE
fix: supply calldata as hexadecimal string array

### DIFF
--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -1,11 +1,23 @@
-import { RpcProvider } from '../src';
-import { describeIfRpc, getTestProvider } from './fixtures';
+import { Account, RpcProvider, ec } from '../src';
+import {
+  compiledOpenZeppelinAccount,
+  describeIfRpc,
+  getTestAccount,
+  getTestProvider,
+} from './fixtures';
 
 describeIfRpc('RPCProvider', () => {
   let rpcProvider: RpcProvider;
+  let accountPublicKey: string;
 
   beforeAll(async () => {
     rpcProvider = getTestProvider() as RpcProvider;
+    const account = getTestAccount(rpcProvider);
+
+    expect(account).toBeInstanceOf(Account);
+
+    const accountKeyPair = ec.genKeyPair();
+    accountPublicKey = ec.getStarkKey(accountKeyPair);
   });
 
   describe('RPC methods', () => {
@@ -13,5 +25,20 @@ describeIfRpc('RPCProvider', () => {
       const chainId = await rpcProvider.getChainId();
       expect(chainId).toBe('0x534e5f474f45524c49');
     });
+
+    test('deployContract', async () => {
+      const { contract_address, transaction_hash } = await rpcProvider.deployContract({
+        contract: compiledOpenZeppelinAccount,
+        constructorCalldata: [accountPublicKey],
+        addressSalt: accountPublicKey,
+      });
+      await rpcProvider.waitForTransaction(transaction_hash);
+      expect(contract_address).toBeTruthy();
+      expect(transaction_hash).toBeTruthy();
+    });
+
+    test.todo('getEstimateFee');
+
+    test.todo('invokeFunction');
   });
 });

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -19,7 +19,12 @@ import { RPC } from '../types/api';
 import fetch from '../utils/fetchPonyfill';
 import { getSelectorFromName } from '../utils/hash';
 import { stringify } from '../utils/json';
-import { BigNumberish, bigNumberishArrayToDecimalStringArray, toBN, toHex } from '../utils/number';
+import {
+  BigNumberish,
+  bigNumberishArrayToHexadecimalStringArray,
+  toBN,
+  toHex,
+} from '../utils/number';
 import { parseCalldata, parseContract, wait } from '../utils/provider';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 import { randomAddress } from '../utils/stark';
@@ -166,7 +171,7 @@ export class RpcProvider implements ProviderInterface {
         contract_address: invocation.contractAddress,
         entry_point_selector: getSelectorFromName(invocation.entrypoint),
         calldata: parseCalldata(invocation.calldata),
-        signature: bigNumberishArrayToDecimalStringArray(invocation.signature || []),
+        signature: bigNumberishArrayToHexadecimalStringArray(invocation.signature || []),
         version: toHex(toBN(invocationDetails?.version || 0)),
       },
       blockIdentifier,
@@ -197,7 +202,7 @@ export class RpcProvider implements ProviderInterface {
 
     return this.fetchEndpoint('starknet_addDeployTransaction', [
       addressSalt ?? randomAddress(),
-      bigNumberishArrayToDecimalStringArray(constructorCalldata ?? []),
+      bigNumberishArrayToHexadecimalStringArray(constructorCalldata ?? []),
       {
         program: contractDefinition.program,
         entry_points_by_type: contractDefinition.entry_points_by_type,
@@ -215,7 +220,7 @@ export class RpcProvider implements ProviderInterface {
         entry_point_selector: getSelectorFromName(functionInvocation.entrypoint),
         calldata: parseCalldata(functionInvocation.calldata),
       },
-      bigNumberishArrayToDecimalStringArray(functionInvocation.signature || []),
+      bigNumberishArrayToHexadecimalStringArray(functionInvocation.signature || []),
       toHex(toBN(details.maxFee || 0)),
       toHex(toBN(details.version || 0)),
     ]).then(this.responseParser.parseInvokeFunctionResponse);

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -57,3 +57,7 @@ export function assertInRange(
 export function bigNumberishArrayToDecimalStringArray(rawCalldata: BigNumberish[]): string[] {
   return rawCalldata.map((x) => toBN(x).toString(10));
 }
+
+export function bigNumberishArrayToHexadecimalStringArray(rawCalldata: BigNumberish[]): string[] {
+  return rawCalldata.map((x) => toHex(toBN(x)));
+}

--- a/www/docs/API/utils.md
+++ b/www/docs/API/utils.md
@@ -176,6 +176,12 @@ const signature = await this.signer.signTransaction(transactions, signerDetails)
 }
 ```
 
+### bigNumberishArrayToHexadecimalStringArray
+
+`bigNumberishArrayToHexadecimalStringArray(rawCalldata: BigNumberish[]): string[]`
+
+Convert BigNumberish array to hexadecimal string array. Used for signature conversion.
+
 <hr />
 
 ## **uint256**


### PR DESCRIPTION
Co-authored-by: dkillen <david@davidkillen.net>

## Motivation and Resolution
The StarkNet OpenRPC API spec defines a FELT as a "...field element. Represented as up to 63 hex digits and leading 4 bits zeroed." The RPC write api defines three methods which take an array of FELT as calldata. The RpcProvider has three methods which incorrectly converts an array of BigNumbersih values into a decimal string array rather than an hexadecimal string array to pass as call data. Those methods are:

getEstimateFee()
deployContract()
invokeFunction()
This is the cause of the error described in issue https://github.com/0xs34n/starknet.js/issues/285

Adds new utility method bigNumberishArrayToHexadecimalStringArray() in utils/number.ts to return an hexadecimal string array from an array of BigNumberish values
Replaces the use of bigNumberishArrayToDecimalStringArray() in the three methods mentioned with bigNumberishArrayToHexadecimalStringArray()
Adds two tests for the RpcProvider test suite rpcProvider.tests.ts
Acknowledging the notice that invokeFunction() is deprecated, I have not added a test for it to the test suite.

Please feel free to make any changes to this PR, including the addition of a test for invokeFucntion(), if you deem it necessary.

Fixes https://github.com/0xs34n/starknet.js/issues/285

### RPC version (if applicable)
...

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Change 1.
- ...

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- Added 1 new test to the RpcProvider test suite.

## Checklist:
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
