### PR TITLE
fix: prevent undefined rpc chainId in account

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -1,4 +1,4 @@
-import { StarknetChainId, ZERO } from '../constants';
+import { ZERO } from '../constants';
 import { ProviderInterface, ProviderOptions } from '../provider';
 import { Provider } from '../provider/default';
 import { Signer, SignerInterface } from '../signer';
@@ -30,10 +30,6 @@ export class Account extends Provider implements AccountInterface {
     super(providerOrOptions);
     this.signer =
       'getPubKey' in keyPairOrSigner ? keyPairOrSigner : new Signer(keyPairOrSigner as KeyPair);
-  }
-
-  public async getChainId(): Promise<StarknetChainId> {
-    return this.getChainId();
   }
 
   public async getNonce(): Promise<string> {

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -1,4 +1,4 @@
-import { ZERO } from '../constants';
+import { StarknetChainId, ZERO } from '../constants';
 import { ProviderInterface, ProviderOptions } from '../provider';
 import { Provider } from '../provider/default';
 import { Signer, SignerInterface } from '../signer';
@@ -32,6 +32,10 @@ export class Account extends Provider implements AccountInterface {
       'getPubKey' in keyPairOrSigner ? keyPairOrSigner : new Signer(keyPairOrSigner as KeyPair);
   }
 
+  public async getChainId(): Promise<StarknetChainId> {
+    return this.getChainId();
+  }
+
   public async getNonce(): Promise<string> {
     const { result } = await this.callContract({
       contractAddress: this.address,
@@ -47,13 +51,14 @@ export class Account extends Provider implements AccountInterface {
     const transactions = Array.isArray(calls) ? calls : [calls];
     const nonce = providedNonce ?? (await this.getNonce());
     const version = toBN(feeTransactionVersion);
+    const chainId = await this.getChainId();
 
     const signerDetails: InvocationsSignerDetails = {
       walletAddress: this.address,
       nonce: toBN(nonce),
       maxFee: ZERO,
       version,
-      chainId: this.chainId,
+      chainId,
     };
 
     const signature = await this.signer.signTransaction(transactions, signerDetails);
@@ -99,13 +104,14 @@ export class Account extends Provider implements AccountInterface {
     }
 
     const version = toBN(transactionVersion);
+    const chainId = await this.getChainId();
 
     const signerDetails: InvocationsSignerDetails = {
       walletAddress: this.address,
       nonce,
       maxFee,
       version,
-      chainId: this.chainId,
+      chainId,
     };
 
     const signature = await this.signer.signTransaction(transactions, signerDetails, abis);

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -46,6 +46,10 @@ export class Provider implements ProviderInterface {
     return this.provider.chainId;
   }
 
+  public async getChainId(): Promise<StarknetChainId> {
+    return this.provider.getChainId();
+  }
+
   public async getBlock(blockIdentifier: BlockIdentifier = 'pending'): Promise<GetBlockResponse> {
     return this.provider.getBlock(blockIdentifier);
   }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -22,6 +22,11 @@ import { BlockIdentifier } from './utils';
 export abstract class ProviderInterface {
   public abstract chainId: StarknetChainId;
 
+  /**
+   * Gets the Starknet chain Id
+   *
+   * @returns the chain Id
+   */
   public abstract getChainId(): Promise<StarknetChainId>;
 
   /**

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -22,6 +22,8 @@ import { BlockIdentifier } from './utils';
 export abstract class ProviderInterface {
   public abstract chainId: StarknetChainId;
 
+  public abstract getChainId(): Promise<StarknetChainId>;
+
   /**
    * Calls a function on the StarkNet contract.
    *

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -207,6 +207,10 @@ export class SequencerProvider implements ProviderInterface {
     }
   }
 
+  public async getChainId(): Promise<StarknetChainId> {
+    return Promise.resolve(this.chainId);
+  }
+
   public async callContract(
     { contractAddress, entrypoint: entryPointSelector, calldata = [] }: Call,
     blockIdentifier: BlockIdentifier = 'pending'


### PR DESCRIPTION
## Motivation and Resolution
fix https://github.com/0xs34n/starknet.js/issues/284
1. Issue resolved
RPC constructor retrieves chainId by the async call so calling account estimateFee & execute imediatly after creation could result in failed signerDetails

2. Issue not resolved
This does not resolve issue when you use **provider.chainId** imediatly after construction:
```
    console.log('RpcProvider')
    const provider = new RpcProvider({
        nodeUrl: 'https://starknet-goerli.infura.io/v3/...',
      })
    console.log(`chainId: ${provider.chainId}`); // undefined
```

- One solution is RPC provider constructor return IIF promise and called with
```
let provider = await new RpcProvider({...})
```
- Second would be to use setter and getter, where getter return promise but both are loosely typed with as 'any'. This would require the sequencer Get also return Promise.resolve(this.chainId) for the common interface.
- Third one would be: to remove chaineId as a class attribute and only use getChainId, but the provider for the common interface relies on it to instantiate RPC or sequencer and I was unable to overcome typing limitations.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [x] All tests are passing
