### PR TITLE
fix: estimateFee and call block id

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -198,6 +198,7 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier: BlockIdentifier = 'pending',
     invocationDetails: InvocationsDetails = {}
   ): Promise<EstimateFeeResponse> {
+    const block_id = new Block(blockIdentifier).identifier;
     return this.fetchEndpoint('starknet_estimateFee', [
       {
         contract_address: invocation.contractAddress,
@@ -206,7 +207,7 @@ export class RpcProvider implements ProviderInterface {
         signature: bigNumberishArrayToHexadecimalStringArray(invocation.signature || []),
         version: toHex(toBN(invocationDetails?.version || 0)),
       },
-      blockIdentifier,
+      block_id,
     ]).then(this.responseParser.parseFeeEstimateResponse);
   }
 
@@ -265,13 +266,14 @@ export class RpcProvider implements ProviderInterface {
     call: Call,
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<CallContractResponse> {
+    const block_id = new Block(blockIdentifier).identifier;
     const result = await this.fetchEndpoint('starknet_call', [
       {
         contract_address: call.contractAddress,
         entry_point_selector: getSelectorFromName(call.entrypoint),
         calldata: parseCalldata(call.calldata),
       },
-      blockIdentifier,
+      block_id,
     ]);
 
     return this.responseParser.parseCallContractResponse(result);

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -289,7 +289,7 @@ export class RpcProvider implements ProviderInterface {
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
     let onchain = false;
-    let retries = 100;
+    let retries = 200;
 
     while (!onchain) {
       const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];


### PR DESCRIPTION
## Motivation and Resolution
Fix block id on RPC methods getEstimateFee and callContract
Wait for the transaction retry 200 times instead of 100

### RPC version (if applicable)
0.1.0

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [ ] All tests are passing
