### PR TITLE
fix right side of a non 2**n merkle tree

### DIFF
--- a/__tests__/utils/merkle.test.ts
+++ b/__tests__/utils/merkle.test.ts
@@ -143,7 +143,7 @@ describe('MerkleTree class', () => {
       expect(proofMerklePath(root, leaf, proof)).toBe(false);
     });
   });
-  describe('data on the right', () => {
+  describe('data on the right with a 2-deep tree', () => {
     let tree: MerkleTree;
     beforeAll(() => {
       const leaves = ['0x1', '0x2', '0x3'];
@@ -156,6 +156,28 @@ describe('MerkleTree class', () => {
     });
     test('should check the previous proof is working fine', async () => {
       const manualMerkle = MerkleTree.hash('0x3', MerkleTree.hash('0x1', '0x2'));
+      expect(tree.root).toBe(manualMerkle);
+    });
+  });
+  describe('data on the right with a 3-deep tree', () => {
+    let tree: MerkleTree;
+    beforeAll(() => {
+      const leaves = ['0x1', '0x2', '0x3', '0x4', '0x5', '0x6'];
+      tree = new MerkleTree(leaves);
+    });
+    test('should return 1-length proof in a 2-length tree', async () => {
+      const proof = tree.getProof('0x5');
+      const manualProof = [
+        '0x6',
+        MerkleTree.hash(MerkleTree.hash('0x1', '0x2'), MerkleTree.hash('0x3', '0x4')),
+      ];
+      expect(proof).toEqual(manualProof);
+    });
+    test('should check the previous proof is working fine', async () => {
+      const manualMerkle = MerkleTree.hash(
+        MerkleTree.hash('0x5', '0x6'),
+        MerkleTree.hash(MerkleTree.hash('0x1', '0x2'), MerkleTree.hash('0x3', '0x4'))
+      );
       expect(tree.root).toBe(manualMerkle);
     });
   });

--- a/__tests__/utils/merkle.test.ts
+++ b/__tests__/utils/merkle.test.ts
@@ -143,7 +143,7 @@ describe('MerkleTree class', () => {
       expect(proofMerklePath(root, leaf, proof)).toBe(false);
     });
   });
-  describe('data on the right with a 2-deep tree', () => {
+  describe('verify 2-deep tree with empty data on the right', () => {
     let tree: MerkleTree;
     beforeAll(() => {
       const leaves = ['0x1', '0x2', '0x3'];
@@ -154,18 +154,18 @@ describe('MerkleTree class', () => {
       const manualProof = [MerkleTree.hash('0x1', '0x2')];
       expect(proof).toEqual(manualProof);
     });
-    test('should check the previous proof is working fine', async () => {
+    test('should check the previous proof works fine', async () => {
       const manualMerkle = MerkleTree.hash('0x3', MerkleTree.hash('0x1', '0x2'));
       expect(tree.root).toBe(manualMerkle);
     });
   });
-  describe('data on the right with a 3-deep tree', () => {
+  describe('verify 3-deep tree with empty data on the right', () => {
     let tree: MerkleTree;
     beforeAll(() => {
       const leaves = ['0x1', '0x2', '0x3', '0x4', '0x5', '0x6'];
       tree = new MerkleTree(leaves);
     });
-    test('should return 1-length proof in a 2-length tree', async () => {
+    test('should return 2-length proof with the 2nd place skipped', async () => {
       const proof = tree.getProof('0x5');
       const manualProof = [
         '0x6',
@@ -173,7 +173,7 @@ describe('MerkleTree class', () => {
       ];
       expect(proof).toEqual(manualProof);
     });
-    test('should check the previous proof is working fine', async () => {
+    test('should check the previous proof works fine', async () => {
       const manualMerkle = MerkleTree.hash(
         MerkleTree.hash('0x5', '0x6'),
         MerkleTree.hash(MerkleTree.hash('0x1', '0x2'), MerkleTree.hash('0x3', '0x4'))

--- a/__tests__/utils/merkle.test.ts
+++ b/__tests__/utils/merkle.test.ts
@@ -78,8 +78,8 @@ describe('MerkleTree class', () => {
     test('should return proof path for valid child', async () => {
       const proof = tree.getProof('0x7');
 
+      // tree can be shorther when exploring the right side of it
       const manualProof = [
-        '0x0', // proofs should always be as long as the tree is deep
         MerkleTree.hash('0x5', '0x6'),
         MerkleTree.hash(MerkleTree.hash('0x1', '0x2'), MerkleTree.hash('0x3', '0x4')),
       ];
@@ -141,6 +141,22 @@ describe('MerkleTree class', () => {
       const { root } = tree;
       proof[2] = '0x4';
       expect(proofMerklePath(root, leaf, proof)).toBe(false);
+    });
+  });
+  describe('data on the right', () => {
+    let tree: MerkleTree;
+    beforeAll(() => {
+      const leaves = ['0x1', '0x2', '0x3'];
+      tree = new MerkleTree(leaves);
+    });
+    test('should return 1-length proof in a 2-length tree', async () => {
+      const proof = tree.getProof('0x3');
+      const manualProof = [MerkleTree.hash('0x1', '0x2')];
+      expect(proof).toEqual(manualProof);
+    });
+    test('should check the previous proof is working fine', async () => {
+      const manualMerkle = MerkleTree.hash('0x3', MerkleTree.hash('0x1', '0x2'));
+      expect(tree.root).toBe(manualMerkle);
     });
   });
 });

--- a/src/utils/merkle.ts
+++ b/src/utils/merkle.ts
@@ -45,7 +45,7 @@ export class MerkleTree {
     }
     const isLeft = index % 2 === 0;
     const neededBranch = isLeft ? branch[index + 1] : branch[index - 1];
-    const newHashPath = hashPath.length > 0 || neededBranch ? [...hashPath, neededBranch] : [];
+    const newHashPath = neededBranch ? [...hashPath, neededBranch] : hashPath;
     const currentBranchLevelIndex =
       this.leaves.length === branch.length
         ? -1

--- a/src/utils/merkle.ts
+++ b/src/utils/merkle.ts
@@ -44,15 +44,15 @@ export class MerkleTree {
       return hashPath;
     }
     const isLeft = index % 2 === 0;
-    const neededBranch = (isLeft ? branch[index + 1] : branch[index - 1]) ?? '0x0';
-    const newHashPath = [...hashPath, neededBranch];
+    const neededBranch = isLeft ? branch[index + 1] : branch[index - 1];
+    const newHashPath = hashPath.length > 0 || neededBranch ? [...hashPath, neededBranch] : [];
     const currentBranchLevelIndex =
       this.leaves.length === branch.length
         ? -1
         : this.branches.findIndex((b) => b.length === branch.length);
     const nextBranch = this.branches[currentBranchLevelIndex + 1] ?? [this.root];
     return this.getProof(
-      neededBranch === '0x0'
+      !neededBranch
         ? leaf
         : MerkleTree.hash(isLeft ? leaf : neededBranch, isLeft ? neededBranch : leaf),
       nextBranch,


### PR DESCRIPTION
## Motivation and Resolution
The length of the proof does not have to be the depth of the tree. I have built a test case to show that is works fine with the corrected algorithm. This PR also corrects the test that was "succeeding" because it was actually a true-negative. I am guessing we will argue on this one so this is what you can do to get conviced:
- rollback the code so that it adds "0x0" as a first argument
- run the last/new test with the "0x0" in the proof: it should not match the merkle root

Another argument is that: [0x1, 0x2, 0x3] would have to have a different root than [0x1, 0x2, 0x3, 0x0] OR you would have to send the length of your data to the contract which you do not have to.

### RPC version (if applicable)
N/A

## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
