### PR TITLE
feat: rpc options, methods, fetch with prop types, imp. types, clenup…

### DIFF
--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -221,7 +221,6 @@ describe('defaultProvider', () => {
           expect(transaction.transaction_hash).toBeTruthy();
           expect(transaction.contract_address).toBeTruthy();
           expect(Array.isArray(transaction.calldata)).toBe(true);
-          expect(transaction.entry_point_selector).toBeTruthy();
           expect(Array.isArray(transaction.signature)).toBe(true);
           expect(transaction.max_fee).toBeTruthy();
         });

--- a/src/contract/contractFactory.ts
+++ b/src/contract/contractFactory.ts
@@ -3,7 +3,6 @@ import assert from 'minimalistic-assert';
 import { AccountInterface } from '../account';
 import { ProviderInterface, defaultProvider } from '../provider';
 import { Abi, CompiledContract, RawCalldata } from '../types';
-import { BigNumberish } from '../utils/number';
 import { Contract } from './default';
 
 export class ContractFactory {
@@ -32,7 +31,7 @@ export class ContractFactory {
    */
   public async deploy(
     constructorCalldata?: RawCalldata,
-    addressSalt?: BigNumberish
+    addressSalt?: string | undefined
   ): Promise<Contract> {
     const { contract_address, transaction_hash } = await this.providerOrAccount.deployContract({
       contract: this.compiledContract,

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -105,24 +105,24 @@ export class RpcProvider implements ProviderInterface {
   public async getBlockWithTxHashes(
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<RPC.GetBlockWithTxHashesResponse> {
-    const block = new Block(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxHashes', { block_id: block.identifier });
+    const block_id = new Block(blockIdentifier).identifier;
+    return this.fetchEndpoint('starknet_getBlockWithTxHashes', { block_id });
   }
 
   public async getBlockWithTxs(
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<RPC.GetBlockWithTxs> {
-    const block = new Block(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockWithTxs', { block_id: block.identifier });
+    const block_id = new Block(blockIdentifier).identifier;
+    return this.fetchEndpoint('starknet_getBlockWithTxs', { block_id });
   }
 
   public async getClassHashAt(
     blockIdentifier: BlockIdentifier,
     contractAddress: RPC.ContractAddress
   ): Promise<RPC.Felt> {
-    const block = new Block(blockIdentifier);
+    const block_id = new Block(blockIdentifier).identifier;
     return this.fetchEndpoint('starknet_getClassHashAt', {
-      block_id: block.identifier,
+      block_id,
       contract_address: contractAddress,
     });
   }
@@ -147,8 +147,8 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getStateUpdate(blockIdentifier: BlockIdentifier): Promise<RPC.StateUpdate> {
-    const block = new Block(blockIdentifier);
-    return this.fetchEndpoint('starknet_getStateUpdate', { block_id: block.identifier });
+    const block_id = new Block(blockIdentifier).identifier;
+    return this.fetchEndpoint('starknet_getStateUpdate', { block_id });
   }
 
   public async getStorageAt(
@@ -157,11 +157,11 @@ export class RpcProvider implements ProviderInterface {
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<BigNumberish> {
     const parsedKey = toHex(toBN(key));
-    const block = new Block(blockIdentifier);
+    const block_id = new Block(blockIdentifier).identifier;
     return this.fetchEndpoint('starknet_getStorageAt', {
       contract_address: contractAddress,
       key: parsedKey,
-      block_id: block.identifier,
+      block_id,
     });
   }
 
@@ -171,8 +171,7 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getTransactionByHash(txHash: string): Promise<RPC.GetTransactionByHashResponse> {
-    const transaction_hash = txHash;
-    return this.fetchEndpoint('starknet_getTransactionByHash', { transaction_hash });
+    return this.fetchEndpoint('starknet_getTransactionByHash', { transaction_hash: txHash });
   }
 
   public async getTransactionByBlockIdAndIndex(
@@ -352,8 +351,8 @@ export class RpcProvider implements ProviderInterface {
   public async getTransactionCount(
     blockIdentifier: BlockIdentifier
   ): Promise<RPC.GetTransactionCountResponse> {
-    const block = new Block(blockIdentifier);
-    return this.fetchEndpoint('starknet_getBlockTransactionCount', { block_id: block.identifier });
+    const block_id = new Block(blockIdentifier).identifier;
+    return this.fetchEndpoint('starknet_getBlockTransactionCount', { block_id });
   }
 
   /**

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -31,8 +31,10 @@ import { randomAddress } from '../utils/stark';
 import { ProviderInterface } from './interface';
 import { Block, BlockIdentifier } from './utils';
 
-export type RpcProviderOptions = { nodeUrl: string };
-type Options = { retries: number };
+export type RpcProviderOptions = {
+  nodeUrl: string;
+  retries?: number;
+};
 
 export class RpcProvider implements ProviderInterface {
   public nodeUrl: string;
@@ -42,12 +44,12 @@ export class RpcProvider implements ProviderInterface {
 
   private responseParser = new RPCResponseParser();
 
-  private options: Options;
+  private retries: number;
 
-  constructor(optionsOrProvider: RpcProviderOptions, options: Options) {
-    const { nodeUrl } = optionsOrProvider;
+  constructor(optionsOrProvider: RpcProviderOptions) {
+    const { nodeUrl, retries } = optionsOrProvider;
     this.nodeUrl = nodeUrl;
-    this.options = options;
+    this.retries = retries || 200;
 
     this.getChainId().then((chainId) => {
       this.chainId = chainId;
@@ -298,7 +300,7 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async waitForTransaction(txHash: string, retryInterval: number = 8000) {
-    let retries = this.options?.retries || 200;
+    let { retries } = this;
     let onchain = false;
 
     while (!onchain) {

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -130,12 +130,12 @@ export class RpcProvider implements ProviderInterface {
   public async getNonce(
     contractAddress: string,
     blockIdentifier: BlockIdentifier = 'pending'
-  ): Promise<BigNumberish> {
-    const blockIdentifierGetter = new Block(blockIdentifier);
-    return this.fetchEndpoint('starknet_getNonce', [
-      contractAddress,
-      blockIdentifierGetter.identifier(),
-    ]);
+  ): Promise<RPC.Nonce> {
+    const block_id = new Block(blockIdentifier).identifier;
+    return this.fetchEndpoint('starknet_getNonce', {
+      contract_address: contractAddress,
+      block_id,
+    });
   }
 
   public async getPendingTransactions(): Promise<RPC.PendingTransactions> {

--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -8,26 +8,14 @@
  * TypeScript Representation of OpenRpc protocol types
  */
 
-/**
- * "type": "string",
- * "title": "Field element",
- * "$comment": "A field element, represented as a string of hex digits",
- * "description": "A field element. Represented as up to 63 hex digits and leading 4 bits zeroed.",
- * "pattern": "^0x0[a-fA-F0-9]{1,63}$"
- */
 export type FELT = string;
 export type ADDRESS = FELT;
-/**
- * "title": "An integer number in hex format (0x...)",
- * "pattern": "^0x[a-fA-F0-9]+$"
- */
 type NUM_AS_HEX = string;
 type SIGNATURE = Array<FELT>;
 type ETH_ADDRESS = string;
 type BLOCK_NUMBER = number;
 type BLOCK_HASH = FELT;
 type TXN_HASH = FELT;
-type CHAIN_ID = string;
 type PROTOCOL_VERSION = string;
 type TXN_STATUS = 'PENDING' | 'ACCEPTED_ON_L2' | 'ACCEPTED_ON_L1' | 'REJECTED';
 type TXN_TYPE = 'DECLARE' | 'DEPLOY' | 'INVOKE' | 'L1_HANDLER';
@@ -68,7 +56,6 @@ type PENDING_COMMON_RECEIPT_PROPERTIES = {
   actual_fee: FELT;
 };
 type INVOKE_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES & INVOKE_TXN_RECEIPT_PROPERTIES;
-// type L1_HANDLER_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES;
 type DECLARE_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES;
 type DEPLOY_TXN_RECEIPT = COMMON_RECEIPT_PROPERTIES;
 type PENDING_INVOKE_TXN_RECEIPT = PENDING_COMMON_RECEIPT_PROPERTIES & INVOKE_TXN_RECEIPT_PROPERTIES;
@@ -98,13 +85,14 @@ type PENDING_BLOCK_WITH_TX_HASHES = BLOCK_BODY_WITH_TX_HASHES & {
   sequencer_address: FELT;
   parent_hash: BLOCK_HASH;
 };
+// transaction_hash, nonce, type optional because of pathfinder not implemented
 type COMMON_TXN_PROPERTIES = {
-  transaction_hash: TXN_HASH;
+  transaction_hash?: TXN_HASH;
   max_fee: FELT;
   version: NUM_AS_HEX;
   signature: SIGNATURE;
-  nonce: FELT;
-  type: TXN_TYPE;
+  nonce?: FELT;
+  type?: TXN_TYPE;
 };
 type FUNCTION_CALL = {
   contract_address: ADDRESS;
@@ -138,6 +126,7 @@ type PENDING_BLOCK_WITH_TXS = BLOCK_BODY_WITH_TXS & {
   sequencer_address: FELT;
   parent_hash: BLOCK_HASH;
 };
+
 type CONTRACT_CLASS = {
   program: string; // A base64 representation of the compressed program code
   entry_points_by_type: {
@@ -234,6 +223,7 @@ type TRACE_ROOT = {
 };
 
 export namespace OPENRPC {
+  export type Nonce = FELT;
   export type BlockWithTxHashes = BLOCK_WITH_TX_HASHES | PENDING_BLOCK_WITH_TX_HASHES;
   export type BlockWithTxs = BLOCK_WITH_TXS | PENDING_BLOCK_WITH_TXS;
   export type StateUpdate = STATE_UPDATE;
@@ -248,7 +238,7 @@ export namespace OPENRPC {
     block_hash: BLOCK_HASH;
     block_number: BLOCK_NUMBER;
   };
-  export type ChainId = CHAIN_ID;
+  export type CHAIN_ID = string;
   export type PendingTransactions = Array<TXN>;
   export type ProtocolVersion = PROTOCOL_VERSION;
   export type SyncingStatus = false | SYNC_STATUS;
@@ -257,7 +247,6 @@ export namespace OPENRPC {
     page_number: number;
     is_last_page: boolean;
   };
-  export type Nonce = FELT;
   export type Trace = TRACE_ROOT;
   export type Traces = Array<{
     transaction_hash: FELT;
@@ -265,7 +254,7 @@ export namespace OPENRPC {
   }>;
   export type TransactionHash = TXN_HASH;
   export type BlockHash = BLOCK_HASH;
-  export type EventFilter = EVENT_FILTER;
+  export type EventFilter = EVENT_FILTER & RESULT_PAGE_REQUEST;
   export type InvokedTransaction = { transaction_hash: TXN_HASH };
   export type DeclaredTransaction = { transaction_hash: TXN_HASH; class_hash: FELT };
   export type DeployedTransaction = { transaction_hash: TXN_HASH; contract_address: FELT };
@@ -349,25 +338,30 @@ export namespace OPENRPC {
         | Errors.INVALID_BLOCK_ID;
     };
     starknet_blockNumber: {
+      params: {};
       result: BLOCK_NUMBER;
       errors: Errors.NO_BLOCKS;
     };
     starknet_blockHashAndNumber: {
+      params: {};
       result: BLOCK_HASH & BLOCK_NUMBER;
       errors: Errors.NO_BLOCKS;
     };
     starknet_chainId: {
+      params: {};
       result: CHAIN_ID;
     };
     starknet_pendingTransactions: {
+      params: {};
       result: PendingTransactions;
     };
     starknet_syncing: {
+      params: {};
       result: SyncingStatus;
     };
     starknet_getEvents: {
       params: { filter: EVENT_FILTER & RESULT_PAGE_REQUEST };
-      result: { events: EMITTED_EVENT; page_number: number; is_last_page: boolean };
+      result: Events;
       errors: Errors.PAGE_SIZE_TOO_BIG;
     };
     starknet_getNonce: {
@@ -397,7 +391,7 @@ export namespace OPENRPC {
     starknet_addDeployTransaction: {
       params: {
         contract_address_salt: FELT;
-        constructor_calldata: FELT;
+        constructor_calldata: Array<FELT>;
         contract_definition: CONTRACT_CLASS;
       };
       result: DeployedTransaction;

--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -95,9 +95,9 @@ type COMMON_TXN_PROPERTIES = {
   type?: TXN_TYPE;
 };
 type FUNCTION_CALL = {
-  contract_address: ADDRESS;
-  entry_point_selector: FELT;
-  calldata: Array<FELT>;
+  contract_address?: ADDRESS;
+  entry_point_selector?: FELT;
+  calldata?: Array<FELT>;
 };
 type INVOKE_TXN = COMMON_TXN_PROPERTIES & FUNCTION_CALL;
 type DECLARE_TXN = COMMON_TXN_PROPERTIES & {
@@ -364,8 +364,9 @@ export namespace OPENRPC {
       result: Events;
       errors: Errors.PAGE_SIZE_TOO_BIG;
     };
+    // FROM RPC 0.2.0 Pathfinder exception
     starknet_getNonce: {
-      params: { contract_address: ADDRESS };
+      params: { contract_address: ADDRESS; block_id: BLOCK_ID };
       result: FELT;
       errors: Errors.CONTRACT_NOT_FOUND;
     };

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -11,9 +11,11 @@ export namespace RPC {
     };
   };
 
-  export type ChainId = OPENRPC.ChainId;
+  export type ChainId = OPENRPC.CHAIN_ID;
+  export type CallResponse = OPENRPC.CallResponse;
   export type ContractAddress = ADDRESS;
   export type Felt = FELT;
+  export type Nonce = OPENRPC.Nonce;
   export type ContractClass = OPENRPC.ContractClass;
   export type StateUpdate = OPENRPC.StateUpdate;
   export type Transaction = OPENRPC.Transaction;
@@ -40,131 +42,5 @@ export namespace RPC {
   export type DeclaredTransaction = OPENRPC.DeclaredTransaction;
   export type DeployedTransaction = OPENRPC.DeployedTransaction;
 
-  export type Methods = {
-    starknet_pendingTransactions: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: PendingTransactions;
-    };
-    starknet_blockHashAndNumber: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: BlockHashAndNumber;
-    };
-    starknet_getClassHashAt: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: Felt;
-    };
-    starknet_getStateUpdate: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.StateUpdate;
-    };
-    starknet_getClass: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.ContractClass;
-    };
-    starknet_getBlockWithTxHashes: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetBlockWithTxHashesResponse;
-    };
-    starknet_getBlockWithTxs: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetBlockWithTxs;
-    };
-    starknet_getNonce: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.Nonce;
-    };
-    starknet_getStorageAt: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetStorageAtResponse;
-    };
-    starknet_getTransactionByHash: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetTransactionByHashResponse;
-    };
-    starknet_getTransactionByBlockIdAndIndex: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetTransactionByBlockIdAndIndex;
-    };
-    starknet_getTransactionReceipt: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: TransactionReceipt;
-    };
-    starknet_getBlockTransactionCount: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetTransactionCountResponse;
-    };
-    starknet_call: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: string[];
-    };
-    starknet_estimateFee: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.EstimatedFee;
-    };
-    starknet_blockNumber: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetBlockNumberResponse;
-    };
-    starknet_chainId: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.ChainId;
-    };
-    starknet_syncing: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetSyncingStatsResponse;
-    };
-    starknet_getEvents: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: GetEventsResponse;
-    };
-    starknet_addInvokeTransaction: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.InvokedTransaction;
-    };
-    starknet_addDeployTransaction: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.DeployedTransaction;
-    };
-    starknet_addDeclareTransaction: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: OPENRPC.DeclaredTransaction;
-    };
-    starknet_getClassAt: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: any;
-    };
-    starknet_traceTransaction: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: any;
-    };
-    starknet_traceBlockTransactions: {
-      QUERY: never;
-      REQUEST: any[];
-      RESPONSE: any;
-    };
-  };
+  export type Methods = OPENRPC.Methods;
 }

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -9,7 +9,7 @@ export type RawCalldata = BigNumberish[];
 export type DeployContractPayload = {
   contract: CompiledContract | string;
   constructorCalldata?: RawCalldata;
-  addressSalt?: BigNumberish;
+  addressSalt?: string;
 };
 
 export type DeclareContractPayload = {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -4,7 +4,8 @@
  */
 import BN from 'bn.js';
 
-import { Abi, CompressedProgram, EntryPointsByType, RawCalldata, Signature, Status } from './lib';
+import { RPC } from './api/rpc';
+import { Abi, CompressedProgram, RawCalldata, Signature, Status } from './lib';
 
 export interface GetBlockResponse {
   timestamp: number;
@@ -44,7 +45,7 @@ export interface ContractEntryPoint {
 
 export interface ContractClass {
   program: CompressedProgram;
-  entry_points_by_type: EntryPointsByType;
+  entry_points_by_type: RPC.ContractClass['entry_points_by_type'];
   abi?: Abi;
 }
 

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -4,13 +4,10 @@
  */
 import {
   CallContractResponse,
-  DeclareContractResponse,
-  DeployContractResponse,
   EstimateFeeResponse,
   GetBlockResponse,
   GetTransactionReceiptResponse,
   GetTransactionResponse,
-  InvokeFunctionResponse,
 } from '../../types';
 import { RPC } from '../../types/api';
 import { toBN } from '../number';
@@ -28,7 +25,13 @@ type TransactionReceipt = RPC.TransactionReceipt & {
   [key: string]: any;
 };
 
-export class RPCResponseParser extends ResponseParser {
+export class RPCResponseParser
+  implements
+    Omit<
+      ResponseParser,
+      'parseDeclareContractResponse' | 'parseDeployContractResponse' | 'parseInvokeFunctionResponse'
+    >
+{
   public parseGetBlockResponse(res: RpcGetBlockResponse): GetBlockResponse {
     return {
       timestamp: res.timestamp,
@@ -79,26 +82,6 @@ export class RPCResponseParser extends ResponseParser {
   public parseCallContractResponse(res: Array<string>): CallContractResponse {
     return {
       result: res,
-    };
-  }
-
-  public parseInvokeFunctionResponse(res: RPC.InvokedTransaction): InvokeFunctionResponse {
-    return {
-      transaction_hash: res.transaction_hash,
-    };
-  }
-
-  public parseDeployContractResponse(res: RPC.DeployedTransaction): DeployContractResponse {
-    return {
-      transaction_hash: res.transaction_hash,
-      contract_address: res.contract_address,
-    };
-  }
-
-  public parseDeclareContractResponse(res: RPC.DeclaredTransaction): DeclareContractResponse {
-    return {
-      transaction_hash: res.transaction_hash,
-      class_hash: res.class_hash,
     };
   }
 }


### PR DESCRIPTION
## Motivation and Resolution
Continuation on https://github.com/0xs34n/starknet.js/pull/329

### RPC version (if applicable)
0.1.0

## Usage related changes
Enable configure of waitfortrans retries. def 200.
```
new RpcProvider({
  nodeUrl: string;
  retries?: number;
})

```
## Development related changes

- [X] Refactor RPC Methods to OpenRPC method and implementation
- [X]  Refactor RPC fetch and methods to use an object instead of the sorted array with types.
- [X] Merge RPC and OpenRPC but kept the separate file for clarity
- [X] Check valid types on all prev. implemented RPC methods (mostly for 'any')
- [X] Refactor common interface response parser (Omitted unnecessary parsers after rpc.0.1.0 impl.)

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [ ] All tests are passing
