### PR TITLE
fix issue with fix-size merkle tree

### DIFF
--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -119,7 +119,7 @@ describe('typedData', () => {
     );
     expect(merkleTreeHash).toBe(tree.root);
     expect(merkleTreeHash).toMatchInlineSnapshot(
-      `"0xe5d3a1485ef98aab230e888bfcf3a6793a8b1330c0702dae504f2c502c9aa8"`
+      `"0x12354b159e3799dc0ebe86d62dde4ce7b300538d471e5a7fef23dcbac076011"`
     );
   });
 
@@ -217,7 +217,7 @@ describe('typedData', () => {
       '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'
     );
     expect(hash).toMatchInlineSnapshot(
-      `"0x43c6768a7402cd86d7c8684e8ea51956cab49ddb65b4f613d3e1c07d5464785"`
+      `"0x751fb7d98545f7649d0d0eadc80d770fcd88d8cfaa55590b284f4e1b701ef0a"`
     );
   });
 });

--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -72,7 +72,7 @@ describe('typedData', () => {
     const [, merkleTreeHash] = encodeValue({}, 'merkletree', tree.leaves);
     expect(merkleTreeHash).toBe(tree.root);
     expect(merkleTreeHash).toMatchInlineSnapshot(
-      `"0x551b4adb6c35d49c686a00b9192da9332b18c9b262507cad0ece37f3b6918d2"`
+      `"0x15ac9e457789ef0c56e5d559809e7336a909c14ee2511503fa7af69be1ba639"`
     );
   });
 
@@ -119,7 +119,7 @@ describe('typedData', () => {
     );
     expect(merkleTreeHash).toBe(tree.root);
     expect(merkleTreeHash).toMatchInlineSnapshot(
-      `"0x75c4f467f4527a5348f3e302007228a6b0057fc4c015f981ffb5b3ace475727"`
+      `"0xe5d3a1485ef98aab230e888bfcf3a6793a8b1330c0702dae504f2c502c9aa8"`
     );
   });
 
@@ -217,7 +217,7 @@ describe('typedData', () => {
       '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'
     );
     expect(hash).toMatchInlineSnapshot(
-      `"0x1ad0330a62a4a94eae5ea1a7ad96388179d2e4d33e6f909d17421d315110653"`
+      `"0x43c6768a7402cd86d7c8684e8ea51956cab49ddb65b4f613d3e1c07d5464785"`
     );
   });
 });

--- a/src/utils/merkle.ts
+++ b/src/utils/merkle.ts
@@ -23,7 +23,7 @@ export class MerkleTree {
     const newLeaves = [];
     for (let i = 0; i < leaves.length; i += 2) {
       if (i + 1 === leaves.length) {
-        newLeaves.push(leaves[i]);
+        newLeaves.push(MerkleTree.hash(leaves[i], '0x0'));
       } else {
         newLeaves.push(MerkleTree.hash(leaves[i], leaves[i + 1]));
       }
@@ -53,9 +53,7 @@ export class MerkleTree {
         : this.branches.findIndex((b) => b.length === branch.length);
     const nextBranch = this.branches[currentBranchLevelIndex + 1] ?? [this.root];
     return this.getProof(
-      neededBranch === '0x0'
-        ? leaf
-        : MerkleTree.hash(isLeft ? leaf : neededBranch, isLeft ? neededBranch : leaf),
+      MerkleTree.hash(isLeft ? leaf : neededBranch, isLeft ? neededBranch : leaf),
       nextBranch,
       newHashPath
     );


### PR DESCRIPTION
## Motivation and Resolution
This issue was not properly corrected in previous attempt (see https://github.com/0xs34n/starknet.js/pull/331 now closed). The goal of this new PR is to have a merkle proof that is fixed in size and matches the depth of the tree. It would also have to be correct!

1. SessionKey.cairo in the contract project, shows 3 things:
- the proof verification does not treat 0x0 in any specific ways. It would simply be applied
- it does not rebuild the root but just compare it with the proof
- the length of the proof has to be the same for all the calls in the multicall

2. The first step of this PR consists in producing some failing tests, A good one is actually the one with 7 values where we pick 0x5 to start. It shows that:

```
      Array [
        "0x6",
    -   "0x6453d426673d0a0a477bd603579a6aa41c8dc1d862b2138c074be609afeb08e",
    +   "0x7",
        "0x38118a340bbba28e678413cd3b07a9436a5e60fd6a7cbda7db958a6d501e274",
      ]
```

This test it is false because:
- if you choose 0x7, you would have to pad it with 0x0 to have 3 in length
- As a result, if you choose 0x5 or 0x6, **you would also have to hash2 0x7 with 0x0** otherwise, you would not match the previous proof.

The problem with the current algorithm is that the key at the right does not get hashed with 0x0 when it is located on an even index, yet it should. This PR just fix that issue!

3. The fix consists in padding the last key on the leaves with "0x0" if it is on an even index. It actually simplifies the cases as you can see from the code. In addition, all the tests pass including the new ones.

### RPC version (if applicable)
N/A. Only the merkle.ts script from the utils directory has been modified

## Usage related changes
- None

## Development related changes
N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes
- [ ] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
