### PR TITLE
fix(ci): use correct devnet image for release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
     services:
       devnet:
-        image: janek2601/starknet-devnet-patched
+        image: shardlabs/starknet-devnet:0.3.1-seed0
         ports:
           - 5050:5050
     env:


### PR DESCRIPTION
## Motivation and Resolution
Fixes the release pipeline needed with starknet 0.10 update. Uses new devnet image.
