### PR TITLE
Sequencer estimate message fee

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:0.3.1-seed0
+        image: shardlabs/starknet-devnet:fa88493228fdf5016d686a8a1b99ec573e045f43-seed0
         ports:
           - 5050:5050
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
     services:
       devnet:
-        image: shardlabs/starknet-devnet:0.3.1-seed0
+        image: shardlabs/starknet-devnet:fa88493228fdf5016d686a8a1b99ec573e045f43-seed0
         ports:
           - 5050:5050
     env:

--- a/__mocks__/l1l2_compiled.json
+++ b/__mocks__/l1l2_compiled.json
@@ -1,0 +1,10107 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "name": "user",
+          "type": "felt"
+        }
+      ],
+      "name": "get_balance",
+      "outputs": [
+        {
+          "name": "balance",
+          "type": "felt"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "user",
+          "type": "felt"
+        },
+        {
+          "name": "amount",
+          "type": "felt"
+        }
+      ],
+      "name": "increase_balance",
+      "outputs": [],
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "user",
+          "type": "felt"
+        },
+        {
+          "name": "amount",
+          "type": "felt"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "from_address",
+          "type": "felt"
+        },
+        {
+          "name": "user",
+          "type": "felt"
+        },
+        {
+          "name": "amount",
+          "type": "felt"
+        }
+      ],
+      "name": "deposit",
+      "outputs": [],
+      "type": "l1_handler"
+    }
+  ],
+  "entry_points_by_type": {
+    "CONSTRUCTOR": [],
+    "EXTERNAL": [
+      {
+        "offset": "0xef",
+        "selector": "0x15511cc3694f64379908437d6d64458dc76d02482052bfb8a5b33a72c054c77"
+      },
+      {
+        "offset": "0xb4",
+        "selector": "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
+      },
+      {
+        "offset": "0x94",
+        "selector": "0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695"
+      }
+    ],
+    "L1_HANDLER": [
+      {
+        "offset": "0x113",
+        "selector": "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01"
+      }
+    ]
+  },
+  "program": {
+    "attributes": [],
+    "builtins": ["pedersen", "range_check"],
+    "compiler_version": "0.10.0",
+    "data": [
+      "0x40780017fff7fff",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x400380007ffb7ffc",
+      "0x400380017ffb7ffd",
+      "0x482680017ffb8000",
+      "0x3",
+      "0x480280027ffb8000",
+      "0x208b7fff7fff7ffe",
+      "0x400380007ffc7ffd",
+      "0x482680017ffc8000",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x3ffffffffffffffffffffffffffffff",
+      "0x480280017ffc8000",
+      "0x48307fff80007ffe",
+      "0x400280027ffc7fff",
+      "0x480280017ffc8000",
+      "0x484480017fff8000",
+      "0x100000000000000000000000000000000",
+      "0x480280007ffc8000",
+      "0x40317fff7ffe7ffd",
+      "0x482680017ffc8000",
+      "0x3",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x20680017fff7fff",
+      "0x10",
+      "0x480a7ffc7fff8000",
+      "0x482680017ffd8000",
+      "0x11000000000000000000000000000000000000000000000101",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+      "0x480680017fff8000",
+      "0x800000000000011000000000000000000000000000000000000000000000000",
+      "0x48127ffe7fff8000",
+      "0x48287ffd80007ffe",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe7",
+      "0x482680017ffd8000",
+      "0x11000000000000000000000000000000000000000000000101",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x20680017fff7fff",
+      "0xc",
+      "0x40780017fff7fff",
+      "0xa",
+      "0x480680017fff8000",
+      "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeff",
+      "0x480a7ffc7fff8000",
+      "0x48287ffd80007ffe",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd8",
+      "0x10780017fff7fff",
+      "0x8",
+      "0x40780017fff7fff",
+      "0xb",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd0",
+      "0x480a7ffd7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53746f7261676552656164",
+      "0x400280007ffc7fff",
+      "0x400380017ffc7ffd",
+      "0x482680017ffc8000",
+      "0x3",
+      "0x480280027ffc8000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53746f726167655772697465",
+      "0x400280007ffb7fff",
+      "0x400380017ffb7ffc",
+      "0x400380027ffb7ffd",
+      "0x482680017ffb8000",
+      "0x3",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53656e644d657373616765546f4c31",
+      "0x400280007ffa7fff",
+      "0x400380017ffa7ffb",
+      "0x400380027ffa7ffc",
+      "0x400380037ffa7ffd",
+      "0x482680017ffa8000",
+      "0x4",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480680017fff8000",
+      "0x206f38f7e4f15e87567361213c28f235cccdaa1d7fd34c9db1dfe9489c6a091",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffa5",
+      "0x480a7ffc7fff8000",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb8",
+      "0x48127fe17fff8000",
+      "0x48127ffd7fff8000",
+      "0x48127ffd7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff0",
+      "0x480a7ffa7fff8000",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd3",
+      "0x48127ffe7fff8000",
+      "0x48127ff57fff8000",
+      "0x48127ff57fff8000",
+      "0x48127ffc7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe2",
+      "0x480a7ff97fff8000",
+      "0x48127ffe7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcc",
+      "0x48127ff67fff8000",
+      "0x48127ff67fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe2",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x4003800080007ffc",
+      "0x4826800180008000",
+      "0x1",
+      "0x480a7ffd7fff8000",
+      "0x4828800080007ffe",
+      "0x480a80007fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffea",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+      "0x48127ff47fff8000",
+      "0x48127ff47fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc0",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x48287ffd7ffb8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc7",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffeb",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff41",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x48127ffd7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff9b",
+      "0x48287ffd80007fff",
+      "0x48127ffd7fff8000",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff36",
+      "0x48127ff67fff8000",
+      "0x48127ff67fff8000",
+      "0x48127ffd7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x48127ff67fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff9d",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff24",
+      "0x480680017fff8000",
+      "0x0",
+      "0x400080007ffe7fff",
+      "0x400180017ffe7ffc",
+      "0x400180027ffe7ffd",
+      "0x48127ff97fff8000",
+      "0x480680017fff8000",
+      "0x8359e4b0152ed5a731162d3c7b0d8d56edb165a0",
+      "0x480680017fff8000",
+      "0x3",
+      "0x48127ffb7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff69",
+      "0x48127ff27fff8000",
+      "0x48127ff27fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd1",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x400780017fff7ffb",
+      "0x8359e4b0152ed5a731162d3c7b0d8d56edb165a0",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff62",
+      "0x48287ffd7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x48127ffb7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff68",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x3",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x480280027ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe7",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+      "file_contents": {
+        "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo": "assert [cast(fp + (-4), felt*)] = __calldata_actual_size;\n",
+        "autogen/starknet/arg_processor/0ae74b618268537af5fcaa41212b7ca3dfd2d216fa900cc3732f21ca90f31672.cairo": "let __calldata_arg_user = [__calldata_ptr];\nlet __calldata_ptr = __calldata_ptr + 1;\n",
+        "autogen/starknet/arg_processor/4b7b48b3c9d8e672ec28525f85db2fe9046605ea49959542755a87de7866e20e.cairo": "let __calldata_arg_from_address = [__calldata_ptr];\nlet __calldata_ptr = __calldata_ptr + 1;\n",
+        "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo": "let __calldata_arg_amount = [__calldata_ptr];\nlet __calldata_ptr = __calldata_ptr + 1;\n",
+        "autogen/starknet/arg_processor/9f3c4eff40ffb80d3eca5f2c2ee6a7e00929907666d5c2b11c75c57406fca77e.cairo": "assert [__return_value_ptr] = ret_value.balance;\nlet __return_value_ptr = __return_value_ptr + 1;\n",
+        "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo": "let __calldata_actual_size =  __calldata_ptr - cast([cast(fp + (-3), felt**)], felt*);\n",
+        "autogen/starknet/external/deposit/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+        "autogen/starknet/external/deposit/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+        "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(from_address=__calldata_arg_from_address, user=__calldata_arg_user, amount=__calldata_arg_amount,);\n%{ memory[ap] = segments.add() %}        // Allocate memory for return value.\ntempvar retdata: felt*;\nlet retdata_size = 0;\n",
+        "autogen/starknet/external/deposit/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+        "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+        "autogen/starknet/external/get_balance/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+        "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(user=__calldata_arg_user,);\nlet (range_check_ptr, retdata_size, retdata) = get_balance_encode_return(ret_value, range_check_ptr);\n",
+        "autogen/starknet/external/get_balance/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+        "autogen/starknet/external/get_balance/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+        "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+        "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(user=__calldata_arg_user, amount=__calldata_arg_amount,);\n%{ memory[ap] = segments.add() %}        // Allocate memory for return value.\ntempvar retdata: felt*;\nlet retdata_size = 0;\n",
+        "autogen/starknet/external/increase_balance/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+        "autogen/starknet/external/increase_balance/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+        "autogen/starknet/external/increase_balance/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+        "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+        "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo": "func get_balance_encode_return(ret_value: (balance: felt), range_check_ptr) -> (\n        range_check_ptr: felt, data_len: felt, data: felt*) {\n    %{ memory[ap] = segments.add() %}\n    alloc_locals;\n    local __return_value_ptr_start: felt*;\n    let __return_value_ptr = __return_value_ptr_start;\n    with range_check_ptr {\n    }\n    return (\n        range_check_ptr=range_check_ptr,\n        data_len=__return_value_ptr - __return_value_ptr_start,\n        data=__return_value_ptr_start);\n}\n",
+        "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo": "let ret_value = __wrapped_func{syscall_ptr=syscall_ptr, pedersen_ptr=pedersen_ptr, range_check_ptr=range_check_ptr}(user=__calldata_arg_user, amount=__calldata_arg_amount,);\n%{ memory[ap] = segments.add() %}        // Allocate memory for return value.\ntempvar retdata: felt*;\nlet retdata_size = 0;\n",
+        "autogen/starknet/external/withdraw/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo": "let range_check_ptr = [cast([cast(fp + (-5), felt**)] + 2, felt*)];\n",
+        "autogen/starknet/external/withdraw/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo": "let pedersen_ptr = [cast([cast(fp + (-5), felt**)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)];\n",
+        "autogen/starknet/external/withdraw/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo": "let syscall_ptr = [cast([cast(fp + (-5), felt**)] + 0, felt**)];\n",
+        "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo": "return (syscall_ptr,pedersen_ptr,range_check_ptr,retdata_size,retdata);\n",
+        "autogen/starknet/storage_var/balance/decl.cairo": "namespace balance {\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr: HashBuiltin*, range_check_ptr}(user: felt) -> (res: felt) {\n        let res = 0;\n        call hash2;\n        call normalize_address;\n    }\n\n    func read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(user: felt) -> (\n        res: felt\n    ) {\n        let storage_addr = 0;\n        call addr;\n        call storage_read;\n    }\n\n    func write{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(\n        user: felt, value: felt\n    ) {\n        let storage_addr = 0;\n        call addr;\n        call storage_write;\n    }\n}",
+        "autogen/starknet/storage_var/balance/impl.cairo": "namespace balance {\n    from starkware.starknet.common.storage import normalize_address\n    from starkware.starknet.common.syscalls import storage_read, storage_write\n    from starkware.cairo.common.cairo_builtins import HashBuiltin\n    from starkware.cairo.common.hash import hash2\n\n    func addr{pedersen_ptr: HashBuiltin*, range_check_ptr}(user: felt) -> (res: felt) {\n        let res = 916907772491729262376534102982219947830828984996257231353398618781993312401;\n        let (res) = hash2{hash_ptr=pedersen_ptr}(res, cast(&user, felt*)[0]);\n        let (res) = normalize_address(addr=res);\n        return (res=res);\n    }\n\n    func read{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(user: felt) -> (\n        res: felt\n    ) {\n        let (storage_addr) = addr(user);\n        let (__storage_var_temp0) = storage_read(address=storage_addr + 0);\n\n        tempvar syscall_ptr = syscall_ptr;\n        tempvar pedersen_ptr = pedersen_ptr;\n        tempvar range_check_ptr = range_check_ptr;\n        tempvar __storage_var_temp0: felt = __storage_var_temp0;\n        return ([cast(&__storage_var_temp0, felt*)],);\n    }\n\n    func write{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(\n        user: felt, value: felt\n    ) {\n        let (storage_addr) = addr(user);\n        storage_write(address=storage_addr + 0, value=[cast(&value, felt) + 0]);\n        return ();\n    }\n}"
+      },
+      "instruction_locations": {
+        "0": {
+          "accessible_scopes": [
+            "starkware.cairo.common.alloc",
+            "starkware.cairo.common.alloc.alloc"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 38,
+                "end_line": 3,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                },
+                "start_col": 5,
+                "start_line": 3
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 12,
+            "end_line": 4,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+            },
+            "start_col": 5,
+            "start_line": 4
+          }
+        },
+        "2": {
+          "accessible_scopes": [
+            "starkware.cairo.common.alloc",
+            "starkware.cairo.common.alloc.alloc"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 5,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+            },
+            "start_col": 5,
+            "start_line": 5
+          }
+        },
+        "3": {
+          "accessible_scopes": ["starkware.cairo.common.hash", "starkware.cairo.common.hash.hash2"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 19,
+            "end_line": 14,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+            },
+            "start_col": 5,
+            "start_line": 14
+          }
+        },
+        "4": {
+          "accessible_scopes": ["starkware.cairo.common.hash", "starkware.cairo.common.hash.hash2"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 19,
+            "end_line": 15,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+            },
+            "start_col": 5,
+            "start_line": 15
+          }
+        },
+        "5": {
+          "accessible_scopes": ["starkware.cairo.common.hash", "starkware.cairo.common.hash.hash2"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 47,
+            "end_line": 17,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 34,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 28,
+                    "end_line": 18,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 18
+                  },
+                  "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                ],
+                "start_col": 12,
+                "start_line": 13
+              },
+              "While expanding the reference 'hash_ptr' in:"
+            ],
+            "start_col": 20,
+            "start_line": 17
+          }
+        },
+        "7": {
+          "accessible_scopes": ["starkware.cairo.common.hash", "starkware.cairo.common.hash.hash2"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 16,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 26,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                },
+                "start_col": 20,
+                "start_line": 18
+              },
+              "While expanding the reference 'result' in:"
+            ],
+            "start_col": 18,
+            "start_line": 16
+          }
+        },
+        "8": {
+          "accessible_scopes": ["starkware.cairo.common.hash", "starkware.cairo.common.hash.hash2"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 28,
+            "end_line": 18,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+            },
+            "start_col": 5,
+            "start_line": 18
+          }
+        },
+        "9": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_nn"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 7,
+                "end_line": 46,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "start_col": 5,
+                "start_line": 42
+              },
+              "n_prefix_newlines": 1
+            }
+          ],
+          "inst": {
+            "end_col": 26,
+            "end_line": 47,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 5,
+            "start_line": 47
+          }
+        },
+        "10": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_nn"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 46,
+            "end_line": 48,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 31,
+                "end_line": 41,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 15,
+                    "end_line": 49,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 49
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 16,
+                "start_line": 41
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 27,
+            "start_line": 48
+          }
+        },
+        "12": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_nn"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 49,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 5,
+            "start_line": 49
+          }
+        },
+        "13": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 7,
+                "end_line": 106,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "start_col": 5,
+                "start_line": 97
+              },
+              "n_prefix_newlines": 1
+            }
+          ],
+          "inst": {
+            "end_col": 50,
+            "end_line": 108,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 36,
+            "start_line": 108
+          }
+        },
+        "15": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 37,
+            "end_line": 95,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 57,
+                "end_line": 108,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "start_col": 53,
+                "start_line": 108
+              },
+              "While expanding the reference 'high' in:"
+            ],
+            "start_col": 16,
+            "start_line": 95
+          }
+        },
+        "16": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 57,
+            "end_line": 108,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 36,
+            "start_line": 108
+          }
+        },
+        "17": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 108,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 5,
+            "start_line": 108
+          }
+        },
+        "18": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 37,
+            "end_line": 95,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 24,
+                "end_line": 113,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "start_col": 20,
+                "start_line": 113
+              },
+              "While expanding the reference 'high' in:"
+            ],
+            "start_col": 16,
+            "start_line": 95
+          }
+        },
+        "19": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 32,
+            "end_line": 113,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 20,
+            "start_line": 113
+          }
+        },
+        "21": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 32,
+            "end_line": 94,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 38,
+                "end_line": 113,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "start_col": 35,
+                "start_line": 113
+              },
+              "While expanding the reference 'low' in:"
+            ],
+            "start_col": 15,
+            "start_line": 94
+          }
+        },
+        "22": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 113,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 5,
+            "start_line": 113
+          }
+        },
+        "23": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 46,
+            "end_line": 115,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 89,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 15,
+                    "end_line": 116,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 116
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 21,
+                "start_line": 89
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 27,
+            "start_line": 115
+          }
+        },
+        "25": {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 116,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "start_col": 5,
+            "start_line": 116
+          }
+        },
+        "26": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 22,
+            "end_line": 13,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 5,
+            "start_line": 13
+          }
+        },
+        "28": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 7,
+                "end_line": 21,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 5,
+                "start_line": 14
+              },
+              "n_prefix_newlines": 1
+            }
+          ],
+          "inst": {
+            "end_col": 7,
+            "end_line": 22,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 5,
+            "start_line": 22
+          }
+        },
+        "30": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 89,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 26,
+                    "end_line": 50,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 50
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 21,
+                "start_line": 89
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 24,
+            "start_line": 12
+          }
+        },
+        "31": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 34,
+            "end_line": 48,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 25,
+                "end_line": 50,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 24,
+                "start_line": 50
+              },
+              "While expanding the reference 'x' in:"
+            ],
+            "start_col": 17,
+            "start_line": 48
+          }
+        },
+        "33": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 26,
+            "end_line": 50,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 50
+          }
+        },
+        "35": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 20,
+            "end_line": 49,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 25,
+                "end_line": 51,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 24,
+                "start_line": 51
+              },
+              "While expanding the reference 'y' in:"
+            ],
+            "start_col": 18,
+            "start_line": 49
+          }
+        },
+        "37": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 36,
+            "end_line": 89,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 26,
+                "end_line": 50,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 36,
+                    "end_line": 89,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 26,
+                        "end_line": 51,
+                        "input_file": {
+                          "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 51
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 21,
+                    "start_line": 89
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 9,
+                "start_line": 50
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 21,
+            "start_line": 89
+          }
+        },
+        "38": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 28,
+            "end_line": 49,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 25,
+                "end_line": 51,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 24,
+                "start_line": 51
+              },
+              "While expanding the reference 'y' in:"
+            ],
+            "start_col": 17,
+            "start_line": 49
+          }
+        },
+        "39": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 26,
+            "end_line": 51,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 51
+          }
+        },
+        "41": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 38,
+            "end_line": 52,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 21,
+            "start_line": 52
+          }
+        },
+        "43": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 52,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 52
+          }
+        },
+        "44": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 24,
+            "end_line": 23,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 23
+          }
+        },
+        "46": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 57,
+                "end_line": 24,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 9,
+                "start_line": 24
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 11,
+            "end_line": 25,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 25
+          }
+        },
+        "48": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 21,
+            "end_line": 30,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 13,
+            "start_line": 30
+          }
+        },
+        "50": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 42,
+            "end_line": 32,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 28,
+            "start_line": 32
+          }
+        },
+        "52": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 89,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 50,
+                    "end_line": 32,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                    },
+                    "start_col": 13,
+                    "start_line": 32
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 21,
+                "start_line": 89
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 24,
+            "start_line": 12
+          }
+        },
+        "53": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 49,
+            "end_line": 32,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 28,
+            "start_line": 32
+          }
+        },
+        "54": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 50,
+            "end_line": 32,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 13,
+            "start_line": 32
+          }
+        },
+        "56": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 11,
+            "end_line": 25,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 25
+          }
+        },
+        "58": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 21,
+            "end_line": 26,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 13,
+            "start_line": 26
+          }
+        },
+        "60": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 89,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 33,
+                    "end_line": 28,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                    },
+                    "start_col": 13,
+                    "start_line": 28
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 21,
+                "start_line": 89
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 24,
+            "start_line": 12
+          }
+        },
+        "61": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 51,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 32,
+                "end_line": 28,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 28,
+                "start_line": 28
+              },
+              "While expanding the reference 'addr' in:"
+            ],
+            "start_col": 41,
+            "start_line": 12
+          }
+        },
+        "62": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 28,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 13,
+            "start_line": 28
+          }
+        },
+        "64": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 51,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 25,
+                "end_line": 34,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "start_col": 21,
+                "start_line": 34
+              },
+              "While expanding the reference 'addr' in:"
+            ],
+            "start_col": 41,
+            "start_line": 12
+          }
+        },
+        "65": {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 27,
+            "end_line": 34,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "start_col": 9,
+            "start_line": 34
+          }
+        },
+        "66": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 79,
+            "end_line": 350,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 58,
+            "start_line": 350
+          }
+        },
+        "68": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 98,
+            "end_line": 350,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 350
+          }
+        },
+        "69": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 98,
+            "end_line": 350,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 350
+          }
+        },
+        "70": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 87,
+                "end_line": 351,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                },
+                "start_col": 5,
+                "start_line": 351
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 53,
+            "end_line": 353,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 37,
+                "end_line": 348,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 35,
+                    "end_line": 354,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 354
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 19,
+                "start_line": 348
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 23,
+            "start_line": 353
+          }
+        },
+        "72": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 354,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 19,
+            "start_line": 354
+          }
+        },
+        "73": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 35,
+            "end_line": 354,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 354
+          }
+        },
+        "74": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 368,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 18,
+            "start_line": 368
+          }
+        },
+        "76": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 368,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 367
+          }
+        },
+        "77": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 368,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 367
+          }
+        },
+        "78": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 368,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 367
+          }
+        },
+        "79": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 88,
+                "end_line": 369,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                },
+                "start_col": 5,
+                "start_line": 369
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 54,
+            "end_line": 370,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 38,
+                "end_line": 366,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 15,
+                    "end_line": 371,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 371
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 20,
+                "start_line": 366
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 23,
+            "start_line": 370
+          }
+        },
+        "81": {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 371,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "start_col": 5,
+            "start_line": 371
+          }
+        },
+        "82": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 45,
+            "end_line": 6,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "start_col": 18,
+            "start_line": 6
+          }
+        },
+        "84": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 30,
+            "end_line": 9,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "start_col": 5,
+            "start_line": 5
+          }
+        },
+        "85": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 30,
+            "end_line": 9,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "start_col": 5,
+            "start_line": 5
+          }
+        },
+        "86": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 30,
+            "end_line": 9,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "start_col": 5,
+            "start_line": 5
+          }
+        },
+        "87": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 30,
+            "end_line": 9,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "start_col": 5,
+            "start_line": 5
+          }
+        },
+        "88": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 93,
+                "end_line": 10,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+                },
+                "start_col": 5,
+                "start_line": 10
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 64,
+            "end_line": 11,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 43,
+                "end_line": 4,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 15,
+                    "end_line": 12,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 12
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 25,
+                "start_line": 4
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 23,
+            "start_line": 11
+          }
+        },
+        "90": {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+            },
+            "start_col": 5,
+            "start_line": 12
+          }
+        },
+        "91": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 41,
+            "end_line": 7,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 48,
+                "end_line": 9,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 36,
+                "start_line": 9
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 7
+          }
+        },
+        "92": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 94,
+            "end_line": 8,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 53,
+                "end_line": 9,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 50,
+                "start_line": 9
+              },
+              "While expanding the reference 'res' in:"
+            ],
+            "start_col": 19,
+            "start_line": 8
+          }
+        },
+        "94": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 76,
+            "end_line": 9,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 55,
+            "start_line": 9
+          }
+        },
+        "95": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 77,
+            "end_line": 9,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 21,
+            "start_line": 9
+          }
+        },
+        "97": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 7,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 12,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 48,
+                    "end_line": 10,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 10
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 24,
+                "start_line": 12
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 43,
+            "start_line": 7
+          }
+        },
+        "98": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 17,
+            "end_line": 9,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 47,
+                "end_line": 10,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 44,
+                "start_line": 10
+              },
+              "While expanding the reference 'res' in:"
+            ],
+            "start_col": 14,
+            "start_line": 9
+          }
+        },
+        "99": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 48,
+            "end_line": 10,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 21,
+            "start_line": 10
+          }
+        },
+        "101": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 48,
+            "end_line": 9,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 41,
+                "end_line": 7,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 26,
+                    "end_line": 11,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 11
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 7
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 36,
+            "start_line": 9
+          }
+        },
+        "102": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 12,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/storage.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 48,
+                "end_line": 10,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 58,
+                    "end_line": 7,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 26,
+                        "end_line": 11,
+                        "input_file": {
+                          "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 11
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 7
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 21,
+                "start_line": 10
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 24,
+            "start_line": 12
+          }
+        },
+        "103": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 17,
+            "end_line": 10,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 24,
+                "end_line": 11,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 21,
+                "start_line": 11
+              },
+              "While expanding the reference 'res' in:"
+            ],
+            "start_col": 14,
+            "start_line": 10
+          }
+        },
+        "104": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.addr"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 26,
+            "end_line": 11,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 9,
+            "start_line": 11
+          }
+        },
+        "105": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 61,
+            "end_line": 14,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 41,
+                "end_line": 7,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 17,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 30,
+                    "start_line": 17
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 7
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 35,
+            "start_line": 14
+          }
+        },
+        "106": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 78,
+            "end_line": 14,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 58,
+                "end_line": 7,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 17,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 30,
+                    "start_line": 17
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 43,
+                "start_line": 7
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 63,
+            "start_line": 14
+          }
+        },
+        "107": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 90,
+            "end_line": 14,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 17,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 35,
+                "start_line": 17
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 80,
+            "start_line": 14
+          }
+        },
+        "108": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 17,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 30,
+            "start_line": 17
+          }
+        },
+        "110": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 14,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 37,
+                "end_line": 348,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 75,
+                    "end_line": 18,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 37,
+                    "start_line": 18
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 19,
+                "start_line": 348
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 14
+          }
+        },
+        "111": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 26,
+            "end_line": 17,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 70,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 58,
+                "start_line": 18
+              },
+              "While expanding the reference 'storage_addr' in:"
+            ],
+            "start_col": 14,
+            "start_line": 17
+          }
+        },
+        "112": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 75,
+            "end_line": 18,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 37,
+            "start_line": 18
+          }
+        },
+        "114": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 37,
+            "end_line": 348,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 75,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 42,
+                    "end_line": 20,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 20
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 37,
+                "start_line": 18
+              },
+              "While trying to update the implicit return value 'syscall_ptr' in:"
+            ],
+            "start_col": 19,
+            "start_line": 348
+          }
+        },
+        "115": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 41,
+            "end_line": 7,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 17,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 44,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 32,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 30,
+                "start_line": 17
+              },
+              "While trying to update the implicit return value 'pedersen_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 7
+          }
+        },
+        "116": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 7,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 17,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 50,
+                    "end_line": 22,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 35,
+                    "start_line": 22
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 30,
+                "start_line": 17
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 43,
+            "start_line": 7
+          }
+        },
+        "117": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 18,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 64,
+                "end_line": 23,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 45,
+                "start_line": 23
+              },
+              "While expanding the reference '__storage_var_temp0' in:"
+            ],
+            "start_col": 14,
+            "start_line": 18
+          }
+        },
+        "118": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.read"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 55,
+            "end_line": 24,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 9,
+            "start_line": 24
+          }
+        },
+        "119": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 62,
+            "end_line": 27,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 41,
+                "end_line": 7,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 30,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 30,
+                    "start_line": 30
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 7
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 36,
+            "start_line": 27
+          }
+        },
+        "120": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 79,
+            "end_line": 27,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 58,
+                "end_line": 7,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 30,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 30,
+                    "start_line": 30
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 43,
+                "start_line": 7
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 64,
+            "start_line": 27
+          }
+        },
+        "121": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 19,
+            "end_line": 28,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 30,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 35,
+                "start_line": 30
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 9,
+            "start_line": 28
+          }
+        },
+        "122": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 30,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 30,
+            "start_line": 30
+          }
+        },
+        "124": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 34,
+            "end_line": 27,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 38,
+                "end_line": 366,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 80,
+                    "end_line": 31,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 31
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 20,
+                "start_line": 366
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 16,
+            "start_line": 27
+          }
+        },
+        "125": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 26,
+            "end_line": 30,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 43,
+                "end_line": 31,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "start_col": 31,
+                "start_line": 31
+              },
+              "While expanding the reference 'storage_addr' in:"
+            ],
+            "start_col": 14,
+            "start_line": 30
+          }
+        },
+        "126": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 79,
+            "end_line": 31,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 55,
+            "start_line": 31
+          }
+        },
+        "127": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 80,
+            "end_line": 31,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 9,
+            "start_line": 31
+          }
+        },
+        "129": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 41,
+            "end_line": 7,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 30,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 19,
+                        "end_line": 32,
+                        "input_file": {
+                          "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 32
+                      },
+                      "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 36,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 30,
+                "start_line": 30
+              },
+              "While trying to update the implicit return value 'pedersen_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 7
+          }
+        },
+        "130": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 7,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 30,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 79,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 19,
+                        "end_line": 32,
+                        "input_file": {
+                          "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+                        },
+                        "start_col": 9,
+                        "start_line": 32
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 64,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 30,
+                "start_line": 30
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 43,
+            "start_line": 7
+          }
+        },
+        "131": {
+          "accessible_scopes": ["__main__", "__main__.balance", "__main__.balance.write"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 19,
+            "end_line": 32,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/impl.cairo"
+            },
+            "start_col": 9,
+            "start_line": 32
+          }
+        },
+        "132": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 36,
+            "end_line": 18,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 33,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 21
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 13
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 18,
+            "start_line": 18
+          }
+        },
+        "133": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 64,
+            "end_line": 18,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 61,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 21
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 35,
+                "start_line": 13
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 38,
+            "start_line": 18
+          }
+        },
+        "134": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 81,
+            "end_line": 18,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 78,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 21
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 63,
+                "start_line": 13
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 66,
+            "start_line": 18
+          }
+        },
+        "135": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 93,
+            "end_line": 18,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 21,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 35,
+                "start_line": 21
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 83,
+            "start_line": 18
+          }
+        },
+        "136": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 21,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 17,
+            "start_line": 21
+          }
+        },
+        "138": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 26,
+            "end_line": 22,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 22
+          }
+        },
+        "139": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 38,
+                "end_line": 3,
+                "input_file": {
+                  "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 17,
+                    "end_line": 18,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 6,
+                    "start_line": 18
+                  },
+                  "While handling return value of"
+                ],
+                "start_col": 5,
+                "start_line": 3
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 18,
+            "end_line": 4,
+            "input_file": {
+              "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While handling return value of"
+            ],
+            "start_col": 5,
+            "start_line": 4
+          }
+        },
+        "141": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 49,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/9f3c4eff40ffb80d3eca5f2c2ee6a7e00929907666d5c2b11c75c57406fca77e.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 18,
+                "end_line": 19,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 5,
+                "start_line": 19
+              },
+              "While handling return value 'balance'"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "142": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 48,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/9f3c4eff40ffb80d3eca5f2c2ee6a7e00929907666d5c2b11c75c57406fca77e.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 18,
+                "end_line": 19,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 36,
+                    "end_line": 11,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While handling return value of"
+                    ],
+                    "start_col": 18,
+                    "start_line": 11
+                  },
+                  "While expanding the reference '__return_value_ptr' in:"
+                ],
+                "start_col": 5,
+                "start_line": 19
+              },
+              "While handling return value 'balance'"
+            ],
+            "start_col": 26,
+            "start_line": 2
+          }
+        },
+        "144": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 75,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 10,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While handling return value of"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While handling return value of"
+            ],
+            "start_col": 60,
+            "start_line": 1
+          }
+        },
+        "145": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 63,
+            "end_line": 11,
+            "input_file": {
+              "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While handling return value of"
+            ],
+            "start_col": 18,
+            "start_line": 11
+          }
+        },
+        "146": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 35,
+            "end_line": 5,
+            "input_file": {
+              "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 38,
+                    "end_line": 12,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While handling return value of"
+                    ],
+                    "start_col": 14,
+                    "start_line": 12
+                  },
+                  "While expanding the reference '__return_value_ptr_start' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While handling return value of"
+            ],
+            "start_col": 11,
+            "start_line": 5
+          }
+        },
+        "147": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 12,
+            "input_file": {
+              "filename": "autogen/starknet/external/return/get_balance/e2c905266ed24cd90f54da7d6caa2cf64575631c8b58e11a7de7ee8e93b858b6.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While handling return value of"
+            ],
+            "start_col": 5,
+            "start_line": 9
+          }
+        },
+        "148": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/0ae74b618268537af5fcaa41212b7ca3dfd2d216fa900cc3732f21ca90f31672.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 93,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 45,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "parent_location": [
+                          {
+                            "end_col": 57,
+                            "end_line": 1,
+                            "input_file": {
+                              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+                            },
+                            "parent_location": [
+                              {
+                                "end_col": 17,
+                                "end_line": 18,
+                                "input_file": {
+                                  "filename": "l1l2.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 18
+                              },
+                              "While handling calldata of"
+                            ],
+                            "start_col": 35,
+                            "start_line": 1
+                          },
+                          "While expanding the reference '__calldata_actual_size' in:"
+                        ],
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While handling calldata of"
+                    ],
+                    "start_col": 31,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_ptr' in:"
+                ],
+                "start_col": 83,
+                "start_line": 18
+              },
+              "While handling calldata argument 'user'"
+            ],
+            "start_col": 22,
+            "start_line": 2
+          }
+        },
+        "150": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While handling calldata of"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "151": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 64,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 55,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 44,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 18,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 19,
+            "start_line": 1
+          }
+        },
+        "152": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 110,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 64,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 82,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 70,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 38,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 1
+          }
+        },
+        "153": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 67,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 81,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 115,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 100,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 66,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 23,
+            "start_line": 1
+          }
+        },
+        "154": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 43,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/0ae74b618268537af5fcaa41212b7ca3dfd2d216fa900cc3732f21ca90f31672.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 93,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 141,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 122,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_user' in:"
+                ],
+                "start_col": 83,
+                "start_line": 18
+              },
+              "While handling calldata argument 'user'"
+            ],
+            "start_col": 27,
+            "start_line": 1
+          }
+        },
+        "155": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 17,
+            "end_line": 18,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 6,
+            "start_line": 18
+          }
+        },
+        "157": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 115,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 100,
+                    "end_line": 2,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 85,
+                    "start_line": 2
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 100,
+            "start_line": 1
+          }
+        },
+        "158": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 101,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 48,
+            "start_line": 2
+          }
+        },
+        "160": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 55,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 20,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 9,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 44,
+            "start_line": 1
+          }
+        },
+        "161": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 82,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 33,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 21,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 70,
+            "start_line": 1
+          }
+        },
+        "162": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 21,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 49,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 34,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 6,
+            "start_line": 2
+          }
+        },
+        "163": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 35,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 50,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata_size' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 23,
+            "start_line": 2
+          }
+        },
+        "164": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 44,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/888d9e3ba73d8b147fcd71c777af4367c30047c7d163e51d7c1d7cc7594fc79f.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 70,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 17,
+                        "end_line": 18,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 18
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 63,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata' in:"
+                ],
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 37,
+            "start_line": 2
+          }
+        },
+        "165": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.get_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/get_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 17,
+                "end_line": 18,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 18
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "166": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 41,
+            "end_line": 26,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 33,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 29,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 29
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 13
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 23,
+            "start_line": 26
+          }
+        },
+        "167": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 69,
+            "end_line": 26,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 61,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 29,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 29
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 35,
+                "start_line": 13
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 43,
+            "start_line": 26
+          }
+        },
+        "168": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 86,
+            "end_line": 26,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 78,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 29,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 29
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 63,
+                "start_line": 13
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 71,
+            "start_line": 26
+          }
+        },
+        "169": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 27,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 29,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 35,
+                "start_line": 29
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 5,
+            "start_line": 27
+          }
+        },
+        "170": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 29,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 17,
+            "start_line": 29
+          }
+        },
+        "172": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 29,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 34,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 38,
+                        "end_line": 30,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 30
+                      },
+                      "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                    ],
+                    "start_col": 16,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 29
+              },
+              "While trying to update the implicit return value 'syscall_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 13
+          }
+        },
+        "173": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 61,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 29,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 38,
+                        "end_line": 30,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 30
+                      },
+                      "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 36,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 29
+              },
+              "While trying to update the implicit return value 'pedersen_ptr' in:"
+            ],
+            "start_col": 35,
+            "start_line": 13
+          }
+        },
+        "174": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 78,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 29,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 79,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 38,
+                        "end_line": 30,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 30
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 64,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 29
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 63,
+            "start_line": 13
+          }
+        },
+        "175": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 27,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 23,
+                "end_line": 30,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 19,
+                "start_line": 30
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 5,
+            "start_line": 27
+          }
+        },
+        "176": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 37,
+            "end_line": 30,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 25,
+            "start_line": 30
+          }
+        },
+        "177": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 38,
+            "end_line": 30,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 30
+          }
+        },
+        "179": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.increase_balance"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 31,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 31
+          }
+        },
+        "180": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 29,
+                "end_line": 27,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 45,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "parent_location": [
+                          {
+                            "end_col": 57,
+                            "end_line": 1,
+                            "input_file": {
+                              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+                            },
+                            "parent_location": [
+                              {
+                                "end_col": 22,
+                                "end_line": 26,
+                                "input_file": {
+                                  "filename": "l1l2.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 26
+                              },
+                              "While handling calldata of"
+                            ],
+                            "start_col": 35,
+                            "start_line": 1
+                          },
+                          "While expanding the reference '__calldata_actual_size' in:"
+                        ],
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While handling calldata of"
+                    ],
+                    "start_col": 31,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 27
+              },
+              "While handling calldata argument 'amount'"
+            ],
+            "start_col": 22,
+            "start_line": 2
+          }
+        },
+        "182": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While handling calldata of"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "183": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 64,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 41,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 55,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 44,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 23,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 19,
+            "start_line": 1
+          }
+        },
+        "184": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 110,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 69,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 82,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 70,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 43,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 1
+          }
+        },
+        "185": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 67,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 86,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 115,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 100,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 71,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 23,
+            "start_line": 1
+          }
+        },
+        "186": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 43,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/0ae74b618268537af5fcaa41212b7ca3dfd2d216fa900cc3732f21ca90f31672.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 15,
+                "end_line": 27,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 141,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 122,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_user' in:"
+                ],
+                "start_col": 5,
+                "start_line": 27
+              },
+              "While handling calldata argument 'user'"
+            ],
+            "start_col": 27,
+            "start_line": 1
+          }
+        },
+        "187": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 45,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 29,
+                "end_line": 27,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 171,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 150,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_amount' in:"
+                ],
+                "start_col": 17,
+                "start_line": 27
+              },
+              "While handling calldata argument 'amount'"
+            ],
+            "start_col": 29,
+            "start_line": 1
+          }
+        },
+        "188": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 22,
+            "end_line": 26,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 6,
+            "start_line": 26
+          }
+        },
+        "190": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 34,
+                "end_line": 2,
+                "input_file": {
+                  "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 22,
+                    "end_line": 26,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 6,
+                    "start_line": 26
+                  },
+                  "While constructing the external wrapper for:"
+                ],
+                "start_col": 1,
+                "start_line": 2
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 24,
+            "end_line": 3,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 3
+          }
+        },
+        "192": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 55,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 20,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 9,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 44,
+            "start_line": 1
+          }
+        },
+        "193": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 82,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 33,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 21,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 70,
+            "start_line": 1
+          }
+        },
+        "194": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 115,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 49,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 34,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 100,
+            "start_line": 1
+          }
+        },
+        "195": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 21,
+            "end_line": 4,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 50,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata_size' in:"
+                ],
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 4
+          }
+        },
+        "197": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 16,
+            "end_line": 3,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 70,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 22,
+                        "end_line": 26,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 26
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 63,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata' in:"
+                ],
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 9,
+            "start_line": 3
+          }
+        },
+        "198": {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/increase_balance/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 26,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 26
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "199": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 78,
+            "end_line": 35,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 31,
+                "end_line": 41,
+                "input_file": {
+                  "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 22,
+                    "end_line": 39,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 39
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 16,
+                "start_line": 41
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 63,
+            "start_line": 35
+          }
+        },
+        "200": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 29,
+            "end_line": 36,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 21,
+                "end_line": 39,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 15,
+                "start_line": 39
+              },
+              "While expanding the reference 'amount' in:"
+            ],
+            "start_col": 17,
+            "start_line": 36
+          }
+        },
+        "201": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 22,
+            "end_line": 39,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 39
+          }
+        },
+        "203": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 35,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 33,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 41,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 41
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 13
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 35
+          }
+        },
+        "204": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 61,
+            "end_line": 35,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 61,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 41,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 41
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 35,
+                "start_line": 13
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 35,
+            "start_line": 35
+          }
+        },
+        "205": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 31,
+            "end_line": 41,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 22,
+                "end_line": 39,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 78,
+                    "end_line": 13,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 40,
+                        "end_line": 41,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 17,
+                        "start_line": 41
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 63,
+                    "start_line": 13
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 5,
+                "start_line": 39
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 16,
+            "start_line": 41
+          }
+        },
+        "206": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 36,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 41,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 35,
+                "start_line": 41
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 5,
+            "start_line": 36
+          }
+        },
+        "207": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 41,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 17,
+            "start_line": 41
+          }
+        },
+        "209": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 42,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 27,
+            "start_line": 42
+          }
+        },
+        "210": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 78,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 41,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 31,
+                    "end_line": 41,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 27,
+                        "end_line": 45,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 45
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 16,
+                    "start_line": 41
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 41
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 63,
+            "start_line": 13
+          }
+        },
+        "211": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 24,
+            "end_line": 42,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 26,
+                "end_line": 45,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 15,
+                "start_line": 45
+              },
+              "While expanding the reference 'new_balance' in:"
+            ],
+            "start_col": 13,
+            "start_line": 42
+          }
+        },
+        "212": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 27,
+            "end_line": 45,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 45
+          }
+        },
+        "214": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 41,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 34,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 37,
+                        "end_line": 48,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 48
+                      },
+                      "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                    ],
+                    "start_col": 16,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 41
+              },
+              "While trying to update the implicit return value 'syscall_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 13
+          }
+        },
+        "215": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 61,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 41,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 37,
+                        "end_line": 48,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 48
+                      },
+                      "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 36,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 41
+              },
+              "While trying to update the implicit return value 'pedersen_ptr' in:"
+            ],
+            "start_col": 35,
+            "start_line": 13
+          }
+        },
+        "216": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 31,
+            "end_line": 41,
+            "input_file": {
+              "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 27,
+                "end_line": 45,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 79,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 37,
+                        "end_line": 48,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 48
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 64,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 5,
+                "start_line": 45
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 16,
+            "start_line": 41
+          }
+        },
+        "217": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 36,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 23,
+                "end_line": 48,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 19,
+                "start_line": 48
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 5,
+            "start_line": 36
+          }
+        },
+        "218": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 24,
+            "end_line": 42,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 48,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 25,
+                "start_line": 48
+              },
+              "While expanding the reference 'new_balance' in:"
+            ],
+            "start_col": 13,
+            "start_line": 42
+          }
+        },
+        "219": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 37,
+            "end_line": 48,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 48
+          }
+        },
+        "221": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 43,
+            "end_line": 51,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 36,
+            "start_line": 51
+          }
+        },
+        "223": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 49,
+            "end_line": 52,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 33,
+            "start_line": 52
+          }
+        },
+        "225": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 50,
+            "end_line": 52,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 52
+          }
+        },
+        "226": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 38,
+            "end_line": 53,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 53
+          }
+        },
+        "227": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 54,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 54
+          }
+        },
+        "228": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 34,
+            "end_line": 21,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 37,
+                "end_line": 48,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 43,
+                    "end_line": 4,
+                    "input_file": {
+                      "filename": "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/starkware/starknet/common/messages.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 96,
+                        "end_line": 55,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 55
+                      },
+                      "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 4
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 5,
+                "start_line": 48
+              },
+              "While trying to update the implicit return value 'syscall_ptr' in:"
+            ],
+            "start_col": 16,
+            "start_line": 21
+          }
+        },
+        "229": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 54,
+            "end_line": 55,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 35,
+            "start_line": 55
+          }
+        },
+        "231": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 70,
+            "end_line": 55,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 69,
+            "start_line": 55
+          }
+        },
+        "233": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 32,
+            "end_line": 51,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 95,
+                "end_line": 55,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 80,
+                "start_line": 55
+              },
+              "While expanding the reference 'message_payload' in:"
+            ],
+            "start_col": 10,
+            "start_line": 51
+          }
+        },
+        "234": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 96,
+            "end_line": 55,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 55
+          }
+        },
+        "236": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 62,
+            "end_line": 21,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 37,
+                "end_line": 48,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 61,
+                    "end_line": 35,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 15,
+                        "end_line": 57,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 57
+                      },
+                      "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 35,
+                    "start_line": 35
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 5,
+                "start_line": 48
+              },
+              "While trying to update the implicit return value 'pedersen_ptr' in:"
+            ],
+            "start_col": 36,
+            "start_line": 21
+          }
+        },
+        "237": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 79,
+            "end_line": 21,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 37,
+                "end_line": 48,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 78,
+                    "end_line": 35,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 15,
+                        "end_line": 57,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 57
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 63,
+                    "start_line": 35
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 5,
+                "start_line": 48
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 64,
+            "start_line": 21
+          }
+        },
+        "238": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 57,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 57
+          }
+        },
+        "239": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 29,
+                "end_line": 36,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 45,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "parent_location": [
+                          {
+                            "end_col": 57,
+                            "end_line": 1,
+                            "input_file": {
+                              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+                            },
+                            "parent_location": [
+                              {
+                                "end_col": 14,
+                                "end_line": 35,
+                                "input_file": {
+                                  "filename": "l1l2.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 35
+                              },
+                              "While handling calldata of"
+                            ],
+                            "start_col": 35,
+                            "start_line": 1
+                          },
+                          "While expanding the reference '__calldata_actual_size' in:"
+                        ],
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While handling calldata of"
+                    ],
+                    "start_col": 31,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 36
+              },
+              "While handling calldata argument 'amount'"
+            ],
+            "start_col": 22,
+            "start_line": 2
+          }
+        },
+        "241": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While handling calldata of"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "242": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 64,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 33,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 55,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 44,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 19,
+            "start_line": 1
+          }
+        },
+        "243": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 110,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 61,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 82,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 70,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 35,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 1
+          }
+        },
+        "244": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 67,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 78,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 115,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 100,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 63,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 23,
+            "start_line": 1
+          }
+        },
+        "245": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 43,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/0ae74b618268537af5fcaa41212b7ca3dfd2d216fa900cc3732f21ca90f31672.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 15,
+                "end_line": 36,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 141,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 122,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_user' in:"
+                ],
+                "start_col": 5,
+                "start_line": 36
+              },
+              "While handling calldata argument 'user'"
+            ],
+            "start_col": 27,
+            "start_line": 1
+          }
+        },
+        "246": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 45,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 29,
+                "end_line": 36,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 171,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 150,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_amount' in:"
+                ],
+                "start_col": 17,
+                "start_line": 36
+              },
+              "While handling calldata argument 'amount'"
+            ],
+            "start_col": 29,
+            "start_line": 1
+          }
+        },
+        "247": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 14,
+            "end_line": 35,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 6,
+            "start_line": 35
+          }
+        },
+        "249": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 34,
+                "end_line": 2,
+                "input_file": {
+                  "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 14,
+                    "end_line": 35,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 6,
+                    "start_line": 35
+                  },
+                  "While constructing the external wrapper for:"
+                ],
+                "start_col": 1,
+                "start_line": 2
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 24,
+            "end_line": 3,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 3
+          }
+        },
+        "251": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 55,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 20,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 9,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 44,
+            "start_line": 1
+          }
+        },
+        "252": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 82,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 33,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 21,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 70,
+            "start_line": 1
+          }
+        },
+        "253": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 115,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 49,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 34,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 100,
+            "start_line": 1
+          }
+        },
+        "254": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 21,
+            "end_line": 4,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 50,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata_size' in:"
+                ],
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 4
+          }
+        },
+        "256": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 16,
+            "end_line": 3,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/5b002840e70a1e3a92212e3537e71d7c7246cb81eb2c86bd0cd7c3e9dd379071.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 70,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 14,
+                        "end_line": 35,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 35
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 63,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata' in:"
+                ],
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 9,
+            "start_line": 3
+          }
+        },
+        "257": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/withdraw/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 14,
+                "end_line": 35,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 35
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "258": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 47,
+            "end_line": 65,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 65
+          }
+        },
+        "260": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 32,
+            "end_line": 61,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 33,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 68,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 68
+                  },
+                  "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                ],
+                "start_col": 15,
+                "start_line": 13
+              },
+              "While expanding the reference 'syscall_ptr' in:"
+            ],
+            "start_col": 14,
+            "start_line": 61
+          }
+        },
+        "261": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 60,
+            "end_line": 61,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 61,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 68,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 68
+                  },
+                  "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                ],
+                "start_col": 35,
+                "start_line": 13
+              },
+              "While expanding the reference 'pedersen_ptr' in:"
+            ],
+            "start_col": 34,
+            "start_line": 61
+          }
+        },
+        "262": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 77,
+            "end_line": 61,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 78,
+                "end_line": 13,
+                "input_file": {
+                  "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 40,
+                    "end_line": 68,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 68
+                  },
+                  "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                ],
+                "start_col": 63,
+                "start_line": 13
+              },
+              "While expanding the reference 'range_check_ptr' in:"
+            ],
+            "start_col": 62,
+            "start_line": 61
+          }
+        },
+        "263": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 35,
+            "end_line": 62,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 39,
+                "end_line": 68,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 35,
+                "start_line": 68
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 25,
+            "start_line": 62
+          }
+        },
+        "264": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 68,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 17,
+            "start_line": 68
+          }
+        },
+        "266": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 39,
+            "end_line": 71,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 27,
+            "start_line": 71
+          }
+        },
+        "267": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 33,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 68,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 34,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 37,
+                        "end_line": 72,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 72
+                      },
+                      "While trying to retrieve the implicit argument 'syscall_ptr' in:"
+                    ],
+                    "start_col": 16,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 68
+              },
+              "While trying to update the implicit return value 'syscall_ptr' in:"
+            ],
+            "start_col": 15,
+            "start_line": 13
+          }
+        },
+        "268": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 61,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 68,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 37,
+                        "end_line": 72,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 72
+                      },
+                      "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 36,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 68
+              },
+              "While trying to update the implicit return value 'pedersen_ptr' in:"
+            ],
+            "start_col": 35,
+            "start_line": 13
+          }
+        },
+        "269": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 78,
+            "end_line": 13,
+            "input_file": {
+              "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 40,
+                "end_line": 68,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 79,
+                    "end_line": 21,
+                    "input_file": {
+                      "filename": "autogen/starknet/storage_var/balance/decl.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 37,
+                        "end_line": 72,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 5,
+                        "start_line": 72
+                      },
+                      "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                    ],
+                    "start_col": 64,
+                    "start_line": 21
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 17,
+                "start_line": 68
+              },
+              "While trying to update the implicit return value 'range_check_ptr' in:"
+            ],
+            "start_col": 63,
+            "start_line": 13
+          }
+        },
+        "270": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 35,
+            "end_line": 62,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 23,
+                "end_line": 72,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 19,
+                "start_line": 72
+              },
+              "While expanding the reference 'user' in:"
+            ],
+            "start_col": 25,
+            "start_line": 62
+          }
+        },
+        "271": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 24,
+            "end_line": 71,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 36,
+                "end_line": 72,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 25,
+                "start_line": 72
+              },
+              "While expanding the reference 'new_balance' in:"
+            ],
+            "start_col": 13,
+            "start_line": 71
+          }
+        },
+        "272": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 37,
+            "end_line": 72,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 72
+          }
+        },
+        "274": {
+          "accessible_scopes": ["__main__", "__main__", "__main__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 15,
+            "end_line": 74,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 5,
+            "start_line": 74
+          }
+        },
+        "275": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 40,
+            "end_line": 2,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 49,
+                "end_line": 62,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 45,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/arg_processor/c31620b02d4d706f0542c989b2aadc01b0981d1f6a5933a8fe4937ace3d70d92.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "parent_location": [
+                          {
+                            "end_col": 57,
+                            "end_line": 1,
+                            "input_file": {
+                              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+                            },
+                            "parent_location": [
+                              {
+                                "end_col": 13,
+                                "end_line": 61,
+                                "input_file": {
+                                  "filename": "l1l2.cairo"
+                                },
+                                "start_col": 6,
+                                "start_line": 61
+                              },
+                              "While handling calldata of"
+                            ],
+                            "start_col": 35,
+                            "start_line": 1
+                          },
+                          "While expanding the reference '__calldata_actual_size' in:"
+                        ],
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While handling calldata of"
+                    ],
+                    "start_col": 31,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_ptr' in:"
+                ],
+                "start_col": 37,
+                "start_line": 62
+              },
+              "While handling calldata argument 'amount'"
+            ],
+            "start_col": 22,
+            "start_line": 2
+          }
+        },
+        "277": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 58,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/01cba52f8515996bb9d7070bde81ff39281d096d7024a558efcba6e1fd2402cf.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While handling calldata of"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        },
+        "278": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 64,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/b2c52ca2d2a8fc8791a983086d8716c5eacd0c3d62934914d2286f84b98ff4cb.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 32,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 55,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 44,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 14,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 19,
+            "start_line": 1
+          }
+        },
+        "279": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 110,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/9684a85e93c782014ca14293edea4eb2502039a5a7b6538ecd39c56faaf12529.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 60,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 82,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 70,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 34,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 1
+          }
+        },
+        "280": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 67,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/741ea357d6336b0bed7bf0472425acd0311d543883b803388880e60a232040c7.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 77,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 115,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 100,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 62,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 23,
+            "start_line": 1
+          }
+        },
+        "281": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 51,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/4b7b48b3c9d8e672ec28525f85db2fe9046605ea49959542755a87de7866e20e.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 23,
+                "end_line": 62,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 157,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 130,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_from_address' in:"
+                ],
+                "start_col": 5,
+                "start_line": 62
+              },
+              "While handling calldata argument 'from_address'"
+            ],
+            "start_col": 35,
+            "start_line": 1
+          }
+        },
+        "282": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 43,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/0ae74b618268537af5fcaa41212b7ca3dfd2d216fa900cc3732f21ca90f31672.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 35,
+                "end_line": 62,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 183,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 164,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_user' in:"
+                ],
+                "start_col": 25,
+                "start_line": 62
+              },
+              "While handling calldata argument 'user'"
+            ],
+            "start_col": 27,
+            "start_line": 1
+          }
+        },
+        "283": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 45,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/arg_processor/73e68c490b7650388f650e9e1ff9b2b3ced88dabf86213d6a0831077eb1a0800.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 49,
+                "end_line": 62,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 213,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 192,
+                    "start_line": 1
+                  },
+                  "While expanding the reference '__calldata_arg_amount' in:"
+                ],
+                "start_col": 37,
+                "start_line": 62
+              },
+              "While handling calldata argument 'amount'"
+            ],
+            "start_col": 29,
+            "start_line": 1
+          }
+        },
+        "284": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 13,
+            "end_line": 61,
+            "input_file": {
+              "filename": "l1l2.cairo"
+            },
+            "start_col": 6,
+            "start_line": 61
+          }
+        },
+        "286": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [
+            {
+              "location": {
+                "end_col": 34,
+                "end_line": 2,
+                "input_file": {
+                  "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 13,
+                    "end_line": 61,
+                    "input_file": {
+                      "filename": "l1l2.cairo"
+                    },
+                    "start_col": 6,
+                    "start_line": 61
+                  },
+                  "While constructing the external wrapper for:"
+                ],
+                "start_col": 1,
+                "start_line": 2
+              },
+              "n_prefix_newlines": 0
+            }
+          ],
+          "inst": {
+            "end_col": 24,
+            "end_line": 3,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 3
+          }
+        },
+        "288": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 55,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 20,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 9,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'syscall_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 44,
+            "start_line": 1
+          }
+        },
+        "289": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 82,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 33,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 21,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'pedersen_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 70,
+            "start_line": 1
+          }
+        },
+        "290": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 115,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 49,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 34,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'range_check_ptr' in:"
+                ],
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 100,
+            "start_line": 1
+          }
+        },
+        "291": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 21,
+            "end_line": 4,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 62,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 50,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata_size' in:"
+                ],
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 20,
+            "start_line": 4
+          }
+        },
+        "293": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 16,
+            "end_line": 3,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/ac3a4225bd13670de1caa7fd52c9d6d1cd23372164e12937d014775feac0fbb8.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "parent_location": [
+                  {
+                    "end_col": 70,
+                    "end_line": 1,
+                    "input_file": {
+                      "filename": "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+                    },
+                    "parent_location": [
+                      {
+                        "end_col": 13,
+                        "end_line": 61,
+                        "input_file": {
+                          "filename": "l1l2.cairo"
+                        },
+                        "start_col": 6,
+                        "start_line": 61
+                      },
+                      "While constructing the external wrapper for:"
+                    ],
+                    "start_col": 63,
+                    "start_line": 1
+                  },
+                  "While expanding the reference 'retdata' in:"
+                ],
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 9,
+            "start_line": 3
+          }
+        },
+        "294": {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "flow_tracking_data": null,
+          "hints": [],
+          "inst": {
+            "end_col": 72,
+            "end_line": 1,
+            "input_file": {
+              "filename": "autogen/starknet/external/deposit/da17921a4e81c09e730800bbf23bfdbe5e9e6bfaedc59d80fbf62087fa43c27d.cairo"
+            },
+            "parent_location": [
+              {
+                "end_col": 13,
+                "end_line": 61,
+                "input_file": {
+                  "filename": "l1l2.cairo"
+                },
+                "start_col": 6,
+                "start_line": 61
+              },
+              "While constructing the external wrapper for:"
+            ],
+            "start_col": 1,
+            "start_line": 1
+          }
+        }
+      }
+    },
+    "hints": {
+      "0": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.alloc",
+            "starkware.cairo.common.alloc.alloc"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 0,
+              "offset": 0
+            },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "9": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_nn"
+          ],
+          "code": "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 2,
+              "offset": 0
+            },
+            "reference_ids": {
+              "starkware.cairo.common.math.assert_nn.a": 0
+            }
+          }
+        }
+      ],
+      "13": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_250_bit"
+          ],
+          "code": "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 3,
+              "offset": 0
+            },
+            "reference_ids": {
+              "starkware.cairo.common.math.assert_250_bit.high": 3,
+              "starkware.cairo.common.math.assert_250_bit.low": 2,
+              "starkware.cairo.common.math.assert_250_bit.value": 1
+            }
+          }
+        }
+      ],
+      "28": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "code": "# Verify the assumptions on the relationship between 2**250, ADDR_BOUND and PRIME.\nADDR_BOUND = ids.ADDR_BOUND % PRIME\nassert (2**250 < ADDR_BOUND <= 2**251) and (2 * 2**250 < PRIME) and (\n        ADDR_BOUND * 2 > PRIME), \\\n    'normalize_address() cannot be used with the current constants.'\nids.is_small = 1 if ids.addr < ADDR_BOUND else 0",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 4,
+              "offset": 1
+            },
+            "reference_ids": {
+              "starkware.starknet.common.storage.normalize_address.addr": 4,
+              "starkware.starknet.common.storage.normalize_address.is_small": 5
+            }
+          }
+        }
+      ],
+      "46": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.storage",
+            "starkware.starknet.common.storage.normalize_address"
+          ],
+          "code": "ids.is_250 = 1 if ids.addr < 2**250 else 0",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 4,
+              "offset": 2
+            },
+            "reference_ids": {
+              "starkware.starknet.common.storage.normalize_address.addr": 4,
+              "starkware.starknet.common.storage.normalize_address.is_250": 6
+            }
+          }
+        }
+      ],
+      "70": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "code": "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 5,
+              "offset": 1
+            },
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.storage_read.syscall_ptr": 7
+            }
+          }
+        }
+      ],
+      "79": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "code": "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 6,
+              "offset": 1
+            },
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.storage_write.syscall_ptr": 8
+            }
+          }
+        }
+      ],
+      "88": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.messages",
+            "starkware.starknet.common.messages.send_message_to_l1"
+          ],
+          "code": "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 7,
+              "offset": 1
+            },
+            "reference_ids": {
+              "starkware.starknet.common.messages.send_message_to_l1.syscall_ptr": 9
+            }
+          }
+        }
+      ],
+      "139": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.get_balance_encode_return"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 12,
+              "offset": 0
+            },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "190": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.increase_balance"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 15,
+              "offset": 129
+            },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "249": [
+        {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.withdraw"],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 17,
+              "offset": 154
+            },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "286": [
+        {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.deposit"],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": {
+              "group": 19,
+              "offset": 131
+            },
+            "reference_ids": {}
+          }
+        }
+      ]
+    },
+    "identifiers": {
+      "__main__.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "__main__.L1_CONTRACT_ADDRESS": {
+        "type": "const",
+        "value": 749882478819638189522059655282096373471980381600
+      },
+      "__main__.MESSAGE_WITHDRAW": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "__main__.assert_nn": {
+        "destination": "starkware.cairo.common.math.assert_nn",
+        "type": "alias"
+      },
+      "__main__.balance": {
+        "type": "namespace"
+      },
+      "__main__.balance.Args": {
+        "full_name": "__main__.balance.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__main__.balance.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "__main__.balance.ImplicitArgs": {
+        "full_name": "__main__.balance.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__main__.balance.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.balance.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.balance.addr": {
+        "decorators": [],
+        "pc": 91,
+        "type": "function"
+      },
+      "__main__.balance.addr.Args": {
+        "full_name": "__main__.balance.addr.Args",
+        "members": {
+          "user": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.balance.addr.ImplicitArgs": {
+        "full_name": "__main__.balance.addr.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 0
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__main__.balance.addr.Return": {
+        "cairo_type": "(res: felt)",
+        "type": "type_definition"
+      },
+      "__main__.balance.addr.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.balance.hash2": {
+        "destination": "starkware.cairo.common.hash.hash2",
+        "type": "alias"
+      },
+      "__main__.balance.normalize_address": {
+        "destination": "starkware.starknet.common.storage.normalize_address",
+        "type": "alias"
+      },
+      "__main__.balance.read": {
+        "decorators": [],
+        "pc": 105,
+        "type": "function"
+      },
+      "__main__.balance.read.Args": {
+        "full_name": "__main__.balance.read.Args",
+        "members": {
+          "user": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.balance.read.ImplicitArgs": {
+        "full_name": "__main__.balance.read.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.balance.read.Return": {
+        "cairo_type": "(res: felt)",
+        "type": "type_definition"
+      },
+      "__main__.balance.read.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.balance.storage_read": {
+        "destination": "starkware.starknet.common.syscalls.storage_read",
+        "type": "alias"
+      },
+      "__main__.balance.storage_write": {
+        "destination": "starkware.starknet.common.syscalls.storage_write",
+        "type": "alias"
+      },
+      "__main__.balance.write": {
+        "decorators": [],
+        "pc": 119,
+        "type": "function"
+      },
+      "__main__.balance.write.Args": {
+        "full_name": "__main__.balance.write.Args",
+        "members": {
+          "user": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "value": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__main__.balance.write.ImplicitArgs": {
+        "full_name": "__main__.balance.write.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.balance.write.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.balance.write.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.deposit": {
+        "decorators": ["l1_handler"],
+        "pc": 258,
+        "type": "function"
+      },
+      "__main__.deposit.Args": {
+        "full_name": "__main__.deposit.Args",
+        "members": {
+          "amount": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "from_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "user": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.deposit.ImplicitArgs": {
+        "full_name": "__main__.deposit.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.deposit.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.deposit.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.get_balance": {
+        "decorators": ["view"],
+        "pc": 132,
+        "type": "function"
+      },
+      "__main__.get_balance.Args": {
+        "full_name": "__main__.get_balance.Args",
+        "members": {
+          "user": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.get_balance.ImplicitArgs": {
+        "full_name": "__main__.get_balance.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.get_balance.Return": {
+        "cairo_type": "(balance: felt)",
+        "type": "type_definition"
+      },
+      "__main__.get_balance.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.increase_balance": {
+        "decorators": ["external"],
+        "pc": 166,
+        "type": "function"
+      },
+      "__main__.increase_balance.Args": {
+        "full_name": "__main__.increase_balance.Args",
+        "members": {
+          "amount": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "user": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__main__.increase_balance.ImplicitArgs": {
+        "full_name": "__main__.increase_balance.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.increase_balance.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.increase_balance.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__main__.send_message_to_l1": {
+        "destination": "starkware.starknet.common.messages.send_message_to_l1",
+        "type": "alias"
+      },
+      "__main__.withdraw": {
+        "decorators": ["external"],
+        "pc": 199,
+        "type": "function"
+      },
+      "__main__.withdraw.Args": {
+        "full_name": "__main__.withdraw.Args",
+        "members": {
+          "amount": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "user": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__main__.withdraw.ImplicitArgs": {
+        "full_name": "__main__.withdraw.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.withdraw.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "__main__.withdraw.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__wrappers__.deposit": {
+        "decorators": ["l1_handler"],
+        "pc": 275,
+        "type": "function"
+      },
+      "__wrappers__.deposit.Args": {
+        "full_name": "__wrappers__.deposit.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.deposit.ImplicitArgs": {
+        "full_name": "__wrappers__.deposit.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.deposit.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.deposit.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__wrappers__.deposit.__wrapped_func": {
+        "destination": "__main__.deposit",
+        "type": "alias"
+      },
+      "__wrappers__.deposit_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.get_balance": {
+        "decorators": ["view"],
+        "pc": 148,
+        "type": "function"
+      },
+      "__wrappers__.get_balance.Args": {
+        "full_name": "__wrappers__.get_balance.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.get_balance.ImplicitArgs": {
+        "full_name": "__wrappers__.get_balance.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.get_balance.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.get_balance.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__wrappers__.get_balance.__wrapped_func": {
+        "destination": "__main__.get_balance",
+        "type": "alias"
+      },
+      "__wrappers__.get_balance_encode_return": {
+        "decorators": [],
+        "pc": 139,
+        "type": "function"
+      },
+      "__wrappers__.get_balance_encode_return.Args": {
+        "full_name": "__wrappers__.get_balance_encode_return.Args",
+        "members": {
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "ret_value": {
+            "cairo_type": "(balance: felt)",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__wrappers__.get_balance_encode_return.ImplicitArgs": {
+        "full_name": "__wrappers__.get_balance_encode_return.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.get_balance_encode_return.Return": {
+        "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.get_balance_encode_return.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 1
+      },
+      "__wrappers__.get_balance_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.increase_balance": {
+        "decorators": ["external"],
+        "pc": 180,
+        "type": "function"
+      },
+      "__wrappers__.increase_balance.Args": {
+        "full_name": "__wrappers__.increase_balance.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.increase_balance.ImplicitArgs": {
+        "full_name": "__wrappers__.increase_balance.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.increase_balance.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.increase_balance.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__wrappers__.increase_balance.__wrapped_func": {
+        "destination": "__main__.increase_balance",
+        "type": "alias"
+      },
+      "__wrappers__.increase_balance_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.withdraw": {
+        "decorators": ["external"],
+        "pc": 239,
+        "type": "function"
+      },
+      "__wrappers__.withdraw.Args": {
+        "full_name": "__wrappers__.withdraw.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.withdraw.ImplicitArgs": {
+        "full_name": "__wrappers__.withdraw.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.withdraw.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.withdraw.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "__wrappers__.withdraw.__wrapped_func": {
+        "destination": "__main__.withdraw",
+        "type": "alias"
+      },
+      "__wrappers__.withdraw_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "starkware.cairo.common.alloc.alloc": {
+        "decorators": [],
+        "pc": 0,
+        "type": "function"
+      },
+      "starkware.cairo.common.alloc.alloc.Args": {
+        "full_name": "starkware.cairo.common.alloc.alloc.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.alloc.alloc.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.alloc.alloc.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.alloc.alloc.Return": {
+        "cairo_type": "(ptr: felt*)",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.alloc.alloc.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.cairo.common.bool.FALSE": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.cairo.common.bool.TRUE": {
+        "type": "const",
+        "value": 1
+      },
+      "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "members": {
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "x_and_y": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "x_or_y": {
+            "cairo_type": "felt",
+            "offset": 4
+          },
+          "x_xor_y": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+        "members": {
+          "m": {
+            "cairo_type": "felt",
+            "offset": 4
+          },
+          "p": {
+            "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+            "offset": 0
+          },
+          "q": {
+            "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+            "offset": 2
+          },
+          "r": {
+            "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.EcPoint": {
+        "destination": "starkware.cairo.common.ec_point.EcPoint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "members": {
+          "result": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+        "members": {
+          "input": {
+            "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "offset": 0
+          },
+          "output": {
+            "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "offset": 8
+          }
+        },
+        "size": 16,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+        "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+        "members": {
+          "message": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "pub_key": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.dict_access.DictAccess": {
+        "full_name": "starkware.cairo.common.dict_access.DictAccess",
+        "members": {
+          "key": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "new_value": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "prev_value": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.ec_point.EcPoint": {
+        "full_name": "starkware.cairo.common.ec_point.EcPoint",
+        "members": {
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.hash.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.hash.hash2": {
+        "decorators": [],
+        "pc": 3,
+        "type": "function"
+      },
+      "starkware.cairo.common.hash.hash2.Args": {
+        "full_name": "starkware.cairo.common.hash.hash2.Args",
+        "members": {
+          "x": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "y": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.hash.hash2.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.hash.hash2.ImplicitArgs",
+        "members": {
+          "hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.hash.hash2.Return": {
+        "cairo_type": "(result: felt)",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.hash.hash2.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+        "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+        "members": {
+          "s0": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "s1": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "s2": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "s3": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "s4": {
+            "cairo_type": "felt",
+            "offset": 4
+          },
+          "s5": {
+            "cairo_type": "felt",
+            "offset": 5
+          },
+          "s6": {
+            "cairo_type": "felt",
+            "offset": 6
+          },
+          "s7": {
+            "cairo_type": "felt",
+            "offset": 7
+          }
+        },
+        "size": 8,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.FALSE": {
+        "destination": "starkware.cairo.common.bool.FALSE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math.TRUE": {
+        "destination": "starkware.cairo.common.bool.TRUE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math.assert_250_bit": {
+        "decorators": ["known_ap_change"],
+        "pc": 13,
+        "type": "function"
+      },
+      "starkware.cairo.common.math.assert_250_bit.Args": {
+        "full_name": "starkware.cairo.common.math.assert_250_bit.Args",
+        "members": {
+          "value": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_250_bit.HIGH_BOUND": {
+        "type": "const",
+        "value": 5316911983139663491615228241121378304
+      },
+      "starkware.cairo.common.math.assert_250_bit.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.math.assert_250_bit.ImplicitArgs",
+        "members": {
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_250_bit.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.math.assert_250_bit.SHIFT": {
+        "type": "const",
+        "value": 340282366920938463463374607431768211456
+      },
+      "starkware.cairo.common.math.assert_250_bit.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.cairo.common.math.assert_250_bit.UPPER_BOUND": {
+        "type": "const",
+        "value": 1809251394333065553493296640760748560207343510400633813116524750123642650624
+      },
+      "starkware.cairo.common.math.assert_250_bit.high": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_250_bit.high",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 3,
+              "offset": 0
+            },
+            "pc": 13,
+            "value": "[cast([fp + (-4)] + 1, felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_250_bit.low": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_250_bit.low",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 3,
+              "offset": 0
+            },
+            "pc": 13,
+            "value": "[cast([fp + (-4)], felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_250_bit.value": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_250_bit.value",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 3,
+              "offset": 0
+            },
+            "pc": 13,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_nn": {
+        "decorators": [],
+        "pc": 9,
+        "type": "function"
+      },
+      "starkware.cairo.common.math.assert_nn.Args": {
+        "full_name": "starkware.cairo.common.math.assert_nn.Args",
+        "members": {
+          "a": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_nn.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.math.assert_nn.ImplicitArgs",
+        "members": {
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_nn.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.math.assert_nn.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.cairo.common.math.assert_nn.a": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_nn.a",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 2,
+              "offset": 0
+            },
+            "pc": 9,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.messages.SEND_MESSAGE_TO_L1_SELECTOR": {
+        "destination": "starkware.starknet.common.syscalls.SEND_MESSAGE_TO_L1_SELECTOR",
+        "type": "alias"
+      },
+      "starkware.starknet.common.messages.SendMessageToL1SysCall": {
+        "destination": "starkware.starknet.common.syscalls.SendMessageToL1SysCall",
+        "type": "alias"
+      },
+      "starkware.starknet.common.messages.send_message_to_l1": {
+        "decorators": [],
+        "pc": 82,
+        "type": "function"
+      },
+      "starkware.starknet.common.messages.send_message_to_l1.Args": {
+        "full_name": "starkware.starknet.common.messages.send_message_to_l1.Args",
+        "members": {
+          "payload": {
+            "cairo_type": "felt*",
+            "offset": 2
+          },
+          "payload_size": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "to_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.messages.send_message_to_l1.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.messages.send_message_to_l1.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.messages.send_message_to_l1.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.messages.send_message_to_l1.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.messages.send_message_to_l1.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.messages.send_message_to_l1.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 7,
+              "offset": 0
+            },
+            "pc": 82,
+            "value": "[cast(fp + (-6), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "group": 7,
+              "offset": 1
+            },
+            "pc": 88,
+            "value": "cast([fp + (-6)] + 4, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.storage.ADDR_BOUND": {
+        "type": "const",
+        "value": -106710729501573572985208420194530329073740042555888586719489
+      },
+      "starkware.starknet.common.storage.MAX_STORAGE_ITEM_SIZE": {
+        "type": "const",
+        "value": 256
+      },
+      "starkware.starknet.common.storage.assert_250_bit": {
+        "destination": "starkware.cairo.common.math.assert_250_bit",
+        "type": "alias"
+      },
+      "starkware.starknet.common.storage.normalize_address": {
+        "decorators": ["known_ap_change"],
+        "pc": 26,
+        "type": "function"
+      },
+      "starkware.starknet.common.storage.normalize_address.Args": {
+        "full_name": "starkware.starknet.common.storage.normalize_address.Args",
+        "members": {
+          "addr": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.storage.normalize_address.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.storage.normalize_address.ImplicitArgs",
+        "members": {
+          "range_check_ptr": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.storage.normalize_address.Return": {
+        "cairo_type": "(res: felt)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.storage.normalize_address.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.storage.normalize_address.addr": {
+        "cairo_type": "felt",
+        "full_name": "starkware.starknet.common.storage.normalize_address.addr",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 4,
+              "offset": 0
+            },
+            "pc": 26,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.storage.normalize_address.is_250": {
+        "cairo_type": "felt",
+        "full_name": "starkware.starknet.common.storage.normalize_address.is_250",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 4,
+              "offset": 2
+            },
+            "pc": 46,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.storage.normalize_address.is_small": {
+        "cairo_type": "felt",
+        "full_name": "starkware.starknet.common.storage.normalize_address.is_small",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 4,
+              "offset": 1
+            },
+            "pc": 28,
+            "value": "[cast(ap + (-1), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.CALL_CONTRACT_SELECTOR": {
+        "type": "const",
+        "value": 20853273475220472486191784820
+      },
+      "starkware.starknet.common.syscalls.CallContract": {
+        "full_name": "starkware.starknet.common.syscalls.CallContract",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.CallContractRequest": {
+        "full_name": "starkware.starknet.common.syscalls.CallContractRequest",
+        "members": {
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "contract_address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "function_selector": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.CallContractResponse": {
+        "full_name": "starkware.starknet.common.syscalls.CallContractResponse",
+        "members": {
+          "retdata": {
+            "cairo_type": "felt*",
+            "offset": 1
+          },
+          "retdata_size": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DELEGATE_CALL_SELECTOR": {
+        "type": "const",
+        "value": 21167594061783206823196716140
+      },
+      "starkware.starknet.common.syscalls.DELEGATE_L1_HANDLER_SELECTOR": {
+        "type": "const",
+        "value": 23274015802972845247556842986379118667122
+      },
+      "starkware.starknet.common.syscalls.DEPLOY_SELECTOR": {
+        "type": "const",
+        "value": 75202468540281
+      },
+      "starkware.starknet.common.syscalls.Deploy": {
+        "full_name": "starkware.starknet.common.syscalls.Deploy",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.DeployRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.DeployResponse",
+            "offset": 6
+          }
+        },
+        "size": 9,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DeployRequest": {
+        "full_name": "starkware.starknet.common.syscalls.DeployRequest",
+        "members": {
+          "class_hash": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "constructor_calldata": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "constructor_calldata_size": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "contract_address_salt": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "deploy_from_zero": {
+            "cairo_type": "felt",
+            "offset": 5
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 6,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DeployResponse": {
+        "full_name": "starkware.starknet.common.syscalls.DeployResponse",
+        "members": {
+          "constructor_retdata": {
+            "cairo_type": "felt*",
+            "offset": 2
+          },
+          "constructor_retdata_size": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "contract_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DictAccess": {
+        "destination": "starkware.cairo.common.dict_access.DictAccess",
+        "type": "alias"
+      },
+      "starkware.starknet.common.syscalls.EMIT_EVENT_SELECTOR": {
+        "type": "const",
+        "value": 1280709301550335749748
+      },
+      "starkware.starknet.common.syscalls.EmitEvent": {
+        "full_name": "starkware.starknet.common.syscalls.EmitEvent",
+        "members": {
+          "data": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "data_len": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "keys": {
+            "cairo_type": "felt*",
+            "offset": 2
+          },
+          "keys_len": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GET_BLOCK_NUMBER_SELECTOR": {
+        "type": "const",
+        "value": 1448089106835523001438702345020786
+      },
+      "starkware.starknet.common.syscalls.GET_BLOCK_TIMESTAMP_SELECTOR": {
+        "type": "const",
+        "value": 24294903732626645868215235778792757751152
+      },
+      "starkware.starknet.common.syscalls.GET_CALLER_ADDRESS_SELECTOR": {
+        "type": "const",
+        "value": 94901967781393078444254803017658102643
+      },
+      "starkware.starknet.common.syscalls.GET_CONTRACT_ADDRESS_SELECTOR": {
+        "type": "const",
+        "value": 6219495360805491471215297013070624192820083
+      },
+      "starkware.starknet.common.syscalls.GET_SEQUENCER_ADDRESS_SELECTOR": {
+        "type": "const",
+        "value": 1592190833581991703053805829594610833820054387
+      },
+      "starkware.starknet.common.syscalls.GET_TX_INFO_SELECTOR": {
+        "type": "const",
+        "value": 1317029390204112103023
+      },
+      "starkware.starknet.common.syscalls.GET_TX_SIGNATURE_SELECTOR": {
+        "type": "const",
+        "value": 1448089128652340074717162277007973
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumber": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumber",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumberRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumberResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+        "members": {
+          "block_number": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestamp": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestamp",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestampRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestampResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+        "members": {
+          "block_timestamp": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+        "members": {
+          "caller_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+        "members": {
+          "contract_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+        "members": {
+          "sequencer_address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfo": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfo",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfoRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfoResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+        "members": {
+          "tx_info": {
+            "cairo_type": "starkware.starknet.common.syscalls.TxInfo*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignature": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignature",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+            "offset": 1
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignatureRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+        "members": {
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignatureResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+        "members": {
+          "signature": {
+            "cairo_type": "felt*",
+            "offset": 1
+          },
+          "signature_len": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.LIBRARY_CALL_L1_HANDLER_SELECTOR": {
+        "type": "const",
+        "value": 436233452754198157705746250789557519228244616562
+      },
+      "starkware.starknet.common.syscalls.LIBRARY_CALL_SELECTOR": {
+        "type": "const",
+        "value": 92376026794327011772951660
+      },
+      "starkware.starknet.common.syscalls.LibraryCall": {
+        "full_name": "starkware.starknet.common.syscalls.LibraryCall",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.LibraryCallRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.LibraryCallRequest": {
+        "full_name": "starkware.starknet.common.syscalls.LibraryCallRequest",
+        "members": {
+          "calldata": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "calldata_size": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "class_hash": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "function_selector": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.SEND_MESSAGE_TO_L1_SELECTOR": {
+        "type": "const",
+        "value": 433017908768303439907196859243777073
+      },
+      "starkware.starknet.common.syscalls.STORAGE_READ_SELECTOR": {
+        "type": "const",
+        "value": 100890693370601760042082660
+      },
+      "starkware.starknet.common.syscalls.STORAGE_WRITE_SELECTOR": {
+        "type": "const",
+        "value": 25828017502874050592466629733
+      },
+      "starkware.starknet.common.syscalls.SendMessageToL1SysCall": {
+        "full_name": "starkware.starknet.common.syscalls.SendMessageToL1SysCall",
+        "members": {
+          "payload_ptr": {
+            "cairo_type": "felt*",
+            "offset": 3
+          },
+          "payload_size": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "to_address": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageRead": {
+        "full_name": "starkware.starknet.common.syscalls.StorageRead",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.StorageReadRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageReadRequest": {
+        "full_name": "starkware.starknet.common.syscalls.StorageReadRequest",
+        "members": {
+          "address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageReadResponse": {
+        "full_name": "starkware.starknet.common.syscalls.StorageReadResponse",
+        "members": {
+          "value": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageWrite": {
+        "full_name": "starkware.starknet.common.syscalls.StorageWrite",
+        "members": {
+          "address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "selector": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "value": {
+            "cairo_type": "felt",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.TxInfo": {
+        "full_name": "starkware.starknet.common.syscalls.TxInfo",
+        "members": {
+          "account_contract_address": {
+            "cairo_type": "felt",
+            "offset": 1
+          },
+          "chain_id": {
+            "cairo_type": "felt",
+            "offset": 6
+          },
+          "max_fee": {
+            "cairo_type": "felt",
+            "offset": 2
+          },
+          "nonce": {
+            "cairo_type": "felt",
+            "offset": 7
+          },
+          "signature": {
+            "cairo_type": "felt*",
+            "offset": 4
+          },
+          "signature_len": {
+            "cairo_type": "felt",
+            "offset": 3
+          },
+          "transaction_hash": {
+            "cairo_type": "felt",
+            "offset": 5
+          },
+          "version": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 8,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read": {
+        "decorators": [],
+        "pc": 66,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.storage_read.Args": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.Args",
+        "members": {
+          "address": {
+            "cairo_type": "felt",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read.Return": {
+        "cairo_type": "(value: felt)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.storage_read.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.storage_read.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.storage_read.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 5,
+              "offset": 0
+            },
+            "pc": 66,
+            "value": "[cast(fp + (-4), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "group": 5,
+              "offset": 1
+            },
+            "pc": 70,
+            "value": "cast([fp + (-4)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_write": {
+        "decorators": [],
+        "pc": 74,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.storage_write.Args": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.Args",
+        "members": {
+          "address": {
+            "cairo_type": "felt",
+            "offset": 0
+          },
+          "value": {
+            "cairo_type": "felt",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_write.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.ImplicitArgs",
+        "members": {
+          "syscall_ptr": {
+            "cairo_type": "felt*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_write.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.storage_write.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.storage_write.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.storage_write.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": {
+              "group": 6,
+              "offset": 0
+            },
+            "pc": 74,
+            "value": "[cast(fp + (-5), felt**)]"
+          },
+          {
+            "ap_tracking_data": {
+              "group": 6,
+              "offset": 1
+            },
+            "pc": 79,
+            "value": "cast([fp + (-5)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 0
+          },
+          "pc": 9,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 3,
+            "offset": 0
+          },
+          "pc": 13,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 3,
+            "offset": 0
+          },
+          "pc": 13,
+          "value": "[cast([fp + (-4)], felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 3,
+            "offset": 0
+          },
+          "pc": 13,
+          "value": "[cast([fp + (-4)] + 1, felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 0
+          },
+          "pc": 26,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 1
+          },
+          "pc": 28,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 4,
+            "offset": 2
+          },
+          "pc": 46,
+          "value": "[cast(ap + (-1), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 5,
+            "offset": 0
+          },
+          "pc": 66,
+          "value": "[cast(fp + (-4), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 6,
+            "offset": 0
+          },
+          "pc": 74,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 7,
+            "offset": 0
+          },
+          "pc": 82,
+          "value": "[cast(fp + (-6), felt**)]"
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -27,7 +27,7 @@ const IS_RPC_DEVNET = Boolean(
 );
 const IS_SEQUENCER = !IS_RPC;
 const IS_SEQUENCER_DEVNET = !BASE_URL.includes('starknet.io');
-export const IS_SEQUENCER_GOERLY = BASE_URL === 'https://alpha4.starknet.io';
+export const IS_SEQUENCER_GOERLI = BASE_URL === 'https://alpha4.starknet.io';
 export const IS_DEVNET = IS_SEQUENCER ? IS_SEQUENCER_DEVNET : IS_RPC_DEVNET;
 
 export const getTestProvider = () => {

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -8,6 +8,7 @@ const readContract = (name: string): CompiledContract =>
 
 export const compiledOpenZeppelinAccount = readContract('Account');
 export const compiledErc20 = readContract('ERC20');
+export const compiledL1L2 = readContract('l1l2_compiled');
 export const compiledTypeTransformation = readContract('contract');
 export const compiledMulticall = readContract('multicall');
 export const compiledTestDapp = readContract('TestDapp');
@@ -26,6 +27,7 @@ const IS_RPC_DEVNET = Boolean(
 );
 const IS_SEQUENCER = !IS_RPC;
 const IS_SEQUENCER_DEVNET = !BASE_URL.includes('starknet.io');
+export const IS_SEQUENCER_GOERLY = BASE_URL === 'https://alpha4.starknet.io';
 export const IS_DEVNET = IS_SEQUENCER ? IS_SEQUENCER_DEVNET : IS_RPC_DEVNET;
 
 export const getTestProvider = () => {

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -1,14 +1,15 @@
 import { Contract, Provider, SequencerProvider, stark } from '../src';
 import { toBN } from '../src/utils/number';
 import {
+  IS_SEQUENCER_GOERLY,
   compiledErc20,
+  compiledL1L2,
   describeIfNotDevnet,
-  describeIfSequencer,
   getTestProvider,
 } from './fixtures';
 
 // Run only if Devnet Sequencer
-describeIfSequencer('SequencerProvider', () => {
+describe('SequencerProvider', () => {
   let sequencerProvider: SequencerProvider;
   let customSequencerProvider: Provider;
   let exampleContractAddress: string;
@@ -80,6 +81,43 @@ describeIfSequencer('SequencerProvider', () => {
       const [res] = result;
       expect(res).toStrictEqual(toBN(0));
       expect(res).toStrictEqual(result.res);
+    });
+  });
+
+  describe('Test Estimate message fee', () => {
+    const L1_ADDRESS = '0x8359E4B0152ed5A731162D3c7B0D8D56edB165A0';
+    let l1l2ContractAddress: string;
+
+    beforeAll(async () => {
+      if (IS_SEQUENCER_GOERLY) {
+        l1l2ContractAddress = '0x2863141e0d9a74e9b484c1f5b1e3a2f6cbb6b84df8233c7c1cbe31334d9aed8';
+      } else {
+        const { transaction_hash, contract_address } = await sequencerProvider.deployContract({
+          contract: compiledL1L2,
+        });
+        await sequencerProvider.waitForTransaction(transaction_hash);
+        l1l2ContractAddress = contract_address;
+      }
+    });
+
+    test('estimate message fee', async () => {
+      const estimation = await sequencerProvider.estimateMessageFee(
+        {
+          from_address: L1_ADDRESS,
+          to_address: l1l2ContractAddress,
+          entry_point_selector: 'deposit',
+          payload: ['556', '123'],
+        },
+        'latest'
+      );
+      expect(estimation).toEqual(
+        expect.objectContaining({
+          overall_fee: expect.any(Number),
+          gas_price: expect.any(Number),
+          gas_usage: expect.any(Number),
+          unit: 'wei',
+        })
+      );
     });
   });
 });

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -1,7 +1,7 @@
 import { Contract, Provider, SequencerProvider, stark } from '../src';
 import { toBN } from '../src/utils/number';
 import {
-  IS_SEQUENCER_GOERLY,
+  IS_SEQUENCER_GOERLI,
   compiledErc20,
   compiledL1L2,
   describeIfNotDevnet,
@@ -90,7 +90,7 @@ describeIfSequencer('SequencerProvider', () => {
     let l1l2ContractAddress: string;
 
     beforeAll(async () => {
-      if (IS_SEQUENCER_GOERLY) {
+      if (IS_SEQUENCER_GOERLI) {
         l1l2ContractAddress = '0x2863141e0d9a74e9b484c1f5b1e3a2f6cbb6b84df8233c7c1cbe31334d9aed8';
       } else {
         const { transaction_hash, contract_address } = await sequencerProvider.deployContract({

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -5,11 +5,12 @@ import {
   compiledErc20,
   compiledL1L2,
   describeIfNotDevnet,
+  describeIfSequencer,
   getTestProvider,
 } from './fixtures';
 
 // Run only if Devnet Sequencer
-describe('SequencerProvider', () => {
+describeIfSequencer('SequencerProvider', () => {
   let sequencerProvider: SequencerProvider;
   let customSequencerProvider: Provider;
   let exampleContractAddress: string;
@@ -112,9 +113,9 @@ describe('SequencerProvider', () => {
       );
       expect(estimation).toEqual(
         expect.objectContaining({
-          overall_fee: expect.any(Number),
-          gas_price: expect.any(Number),
-          gas_usage: expect.any(Number),
+          overall_fee: expect.anything(),
+          gas_price: expect.anything(),
+          gas_usage: expect.anything(),
           unit: 'wei',
         })
       );

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -425,7 +425,6 @@ export class SequencerProvider implements ProviderInterface {
     { from_address, to_address, entry_point_selector, payload }: CallL1Handler,
     blockIdentifier: BlockIdentifier = 'pending'
   ): Promise<Sequencer.EstimateFeeResponse> {
-    // ensure from_address is decimalString, can be sent hexString, decimalString
     const validCallL1Handler = {
       from_address: getDecimalString(from_address),
       to_address: getHexString(to_address),

--- a/src/types/api/sequencer.ts
+++ b/src/types/api/sequencer.ts
@@ -73,6 +73,13 @@ export type RawArgs = {
   [inputName: string]: string | string[] | { type: 'struct'; [k: string]: BigNumberish };
 };
 
+export type CallL1Handler = {
+  from_address: string;
+  to_address: string;
+  entry_point_selector: string;
+  payload: Array<string>;
+};
+
 export namespace Sequencer {
   export type DeclareTransaction = {
     type: 'DECLARE';
@@ -339,6 +346,11 @@ export namespace Sequencer {
       };
       REQUEST: never;
       RESPONSE: any;
+    };
+    estimate_message_fee: {
+      QUERY: any;
+      REQUEST: any;
+      RESPONSE: EstimateFeeResponse;
     };
   };
 }

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -15,7 +15,15 @@ import {
 import { RawCalldata } from '../types/lib';
 import { ec } from './ellipticCurve';
 import { addHexPrefix, buf2hex, removeHexPrefix, utf8ToArray } from './encode';
-import { BigNumberish, toBN, toFelt, toHex } from './number';
+import {
+  BigNumberish,
+  isHex,
+  isStringWholeNumber,
+  toBN,
+  toFelt,
+  toHex,
+  toHexString,
+} from './number';
 
 export const transactionVersion = 1;
 export const feeTransactionVersion = toBN(2).pow(toBN(128)).add(toBN(transactionVersion));
@@ -51,6 +59,21 @@ export function starknetKeccak(value: string): BN {
 export function getSelectorFromName(funcName: string) {
   // sometimes BigInteger pads the hex string with zeros, which isnt allowed in the starknet api
   return toHex(starknetKeccak(funcName));
+}
+
+/**
+ * Function to get hex selector from function name, decimal string or hex string
+ * @param value hex string | decimal string | string
+ * @returns Hex selector
+ */
+export function getSelector(value: string) {
+  if (isHex(value)) {
+    return value;
+  }
+  if (isStringWholeNumber(value)) {
+    return toHexString(value);
+  }
+  return getSelectorFromName(value);
 }
 
 const constantPoints = CONSTANT_POINTS.map((coords: string[]) =>

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -61,3 +61,30 @@ export function bigNumberishArrayToDecimalStringArray(rawCalldata: BigNumberish[
 export function bigNumberishArrayToHexadecimalStringArray(rawCalldata: BigNumberish[]): string[] {
   return rawCalldata.map((x) => toHex(toBN(x)));
 }
+
+export const isStringWholeNumber = (value: string) => /^\d+$/.test(value);
+export const toHexString = (value: string) => toHex(toBN(value));
+
+export function getDecimalString(value: string) {
+  if (isHex(value)) {
+    return hexToDecimalString(value);
+  }
+  if (isStringWholeNumber(value)) {
+    return value;
+  }
+  throw new Error(`${value} need to be hex-string or whole-number-string`);
+}
+
+export function getHexString(value: string) {
+  if (isHex(value)) {
+    return value;
+  }
+  if (isStringWholeNumber(value)) {
+    return toHexString(value);
+  }
+  throw new Error(`${value} need to be hex-string or whole-number-string`);
+}
+
+export function getHexStringArray(value: Array<string>) {
+  return value.map((el) => getHexString(el));
+}


### PR DESCRIPTION
## Motivation and Resolution
Fix https://github.com/0xs34n/starknet.js/issues/339
Provide a new function for estimating L1 -> L2 message fee
New workflow devnet with implementation - tag release

## Usage related changes

```ts
type CallL1Handler = {
  from_address: string; // L1 Address
  to_address: string; // L2 Address
  entry_point_selector: string; // L2 Cairo function with @l1_handler
  payload: Array<string>; // L2 Cairo function params
};
```
```js
sequencerProvider.estimateMessageFee(CallL1Handler [, blockIdentifier])
```
Despite data type inconsistency between estimate fee and estimate message fee,
estimateMessageFee is implemented so that users can pass a decimal string or Hex String and for entry_point_selector decimal string, hex String, or function name and it will be formatted as endpoint required.

## Development related changes
**Extended Utils and Numbers** with detect-conversion-functions
**Extend Fixtures** with IS_SEQUENCER_GOERLY constant so that we can skip deployment of contract and use predeployed one.
Used for test **expect.objectContaining** that provide almost like schema validation.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [ ] Updated the docs (www)
- [x] Updated the tests
- [ ] All tests are passing
