### PR TITLE
fix: change txn version for estimate fee apis to be feeTransactionVersion

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -2,6 +2,7 @@ import { isBN } from 'bn.js';
 
 import typedDataExample from '../__mocks__/typedDataExample.json';
 import { Account, Contract, Provider, number, stark } from '../src';
+import { feeTransactionVersion } from '../src/utils/hash';
 import { toBN } from '../src/utils/number';
 import {
   compiledErc20,
@@ -43,12 +44,15 @@ describe('deploy and test Wallet', () => {
   });
 
   test('estimate fee', async () => {
+    const innerInvokeEstFeeSpy = jest.spyOn(account.signer, 'signTransaction');
     const { overall_fee } = await account.estimateInvokeFee({
       contractAddress: erc20Address,
       entrypoint: 'transfer',
       calldata: [erc20.address, '10', '0'],
     });
     expect(isBN(overall_fee)).toBe(true);
+    expect(innerInvokeEstFeeSpy.mock.calls[0][1].version).toBe(feeTransactionVersion);
+    innerInvokeEstFeeSpy.mockClear();
   });
 
   test('read balance of wallet', async () => {

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -22,7 +22,11 @@ import {
   DeployAccountContractPayload,
   UniversalDeployerContractPayload,
 } from '../types/lib';
-import { calculateContractAddressFromHash, transactionVersion } from '../utils/hash';
+import {
+  calculateContractAddressFromHash,
+  feeTransactionVersion,
+  transactionVersion,
+} from '../utils/hash';
 import { BigNumberish, toBN, toCairoBool } from '../utils/number';
 import { parseContract } from '../utils/provider';
 import { compileCalldata, estimatedFeeToMaxFee } from '../utils/stark';
@@ -63,7 +67,7 @@ export class Account extends Provider implements AccountInterface {
   ): Promise<EstimateFee> {
     const transactions = Array.isArray(calls) ? calls : [calls];
     const nonce = toBN(providedNonce ?? (await this.getNonce()));
-    const version = toBN(transactionVersion);
+    const version = toBN(feeTransactionVersion);
     const chainId = await this.getChainId();
 
     const signerDetails: InvocationsSignerDetails = {
@@ -96,7 +100,7 @@ export class Account extends Provider implements AccountInterface {
     { blockIdentifier, nonce: providedNonce }: EstimateFeeDetails = {}
   ): Promise<EstimateFee> {
     const nonce = toBN(providedNonce ?? (await this.getNonce()));
-    const version = toBN(transactionVersion);
+    const version = toBN(feeTransactionVersion);
     const chainId = await this.getChainId();
     const contractDefinition = parseContract(contract);
 
@@ -132,7 +136,7 @@ export class Account extends Provider implements AccountInterface {
     { blockIdentifier, nonce: providedNonce }: EstimateFeeDetails = {}
   ): Promise<EstimateFee> {
     const nonce = toBN(providedNonce ?? (await this.getNonce()));
-    const version = toBN(transactionVersion);
+    const version = toBN(feeTransactionVersion);
     const chainId = await this.getChainId();
     const contractAddress =
       providedContractAddress ??


### PR DESCRIPTION
Solves #391 

## Motivation and Resolution
Estimate fee calls should use `feeTransactionVersion`

## Checklist:

- [ X] Performed a self-review of the code
- [ X] Rebased to the last commit of the target branch (or merged it into my branch)
- [ X] Linked the issues which this PR resolves
- [ X] Updated the tests
- [ X] All tests are passing
