### PR TITLE
[Stage 1] Starknet alpha v0.10.3 - account deployContract, test, refactor

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -24,7 +24,6 @@ describe('deploy and test Wallet', () => {
   beforeAll(async () => {
     expect(account).toBeInstanceOf(Account);
 
-    // New Stuff
     const declareDeploy = await account.declareDeploy({
       contract: compiledErc20,
       classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -180,7 +180,7 @@ describe('deploy and test Wallet', () => {
     });
 
     test('UDC DeployContract', async () => {
-      const deployResponse = await account.deployContract2({
+      const deployResponse = await account.deployContract({
         classHash: erc20ClassHash,
         constructorCalldata: [
           encodeShortString('Token'),

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -3,7 +3,7 @@ import { isBN } from 'bn.js';
 import typedDataExample from '../__mocks__/typedDataExample.json';
 import { Account, Contract, Provider, number, stark } from '../src';
 import { feeTransactionVersion } from '../src/utils/hash';
-import { toBN } from '../src/utils/number';
+import { hexToDecimalString, toBN } from '../src/utils/number';
 import { encodeShortString } from '../src/utils/shortString';
 import { randomAddress } from '../src/utils/stark';
 import {
@@ -24,25 +24,7 @@ describe('deploy and test Wallet', () => {
   beforeAll(async () => {
     expect(account).toBeInstanceOf(Account);
 
-    /*     // Declare
-    const declareTx = await account.declare({
-      contract: compiledErc20,
-      classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
-    });
-    expect(declareTx.transaction_hash).toBeDefined();
-    await provider.waitForTransaction(declareTx.transaction_hash);
-
-    // Deploy Contract
-    const erc20Response = await account.deployContract2({
-      classHash: declareTx.class_hash,
-      constructorCalldata: [
-        encodeShortString('Token'),
-        encodeShortString('ERC20'),
-        account.address,
-      ],
-    });
-    expect(erc20Response.contract_address).toBeDefined(); */
-
+    // New Stuff
     const declareDeploy = await account.declareDeploy({
       contract: compiledErc20,
       classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
@@ -60,12 +42,12 @@ describe('deploy and test Wallet', () => {
 
     expect(number.toBN(x[0].low).toString()).toStrictEqual(number.toBN(1000).toString());
 
-    const dappResponse = await provider.deployContract({
+    const dappResponse = await account.declareDeploy({
       contract: compiledTestDapp,
+      classHash: '0x04367b26fbb92235e8d1137d19c080e6e650a6889ded726d00658411cc1046f5',
     });
-    dapp = new Contract(compiledTestDapp.abi, dappResponse.contract_address!, provider);
 
-    await provider.waitForTransaction(dappResponse.transaction_hash);
+    dapp = new Contract(compiledTestDapp.abi, dappResponse.deploy.contract_address!, provider);
   });
 
   test('estimate fee', async () => {
@@ -195,7 +177,7 @@ describe('deploy and test Wallet', () => {
       await provider.waitForTransaction(declareTx.transaction_hash);
 
       expect(declareTx).toHaveProperty('class_hash');
-      expect(declareTx.class_hash).toEqual(erc20ClassHash);
+      expect(hexToDecimalString(declareTx.class_hash)).toEqual(hexToDecimalString(erc20ClassHash));
     });
 
     test('UDC DeployContract', async () => {

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -10,7 +10,6 @@ import {
   compiledErc20,
   compiledTestDapp,
   erc20ClassHash,
-  getERC20DeployPayload,
   getTestAccount,
   getTestProvider,
 } from './fixtures';
@@ -25,14 +24,37 @@ describe('deploy and test Wallet', () => {
   beforeAll(async () => {
     expect(account).toBeInstanceOf(Account);
 
-    const erc20DeployPayload = getERC20DeployPayload(account.address);
+    /*     // Declare
+    const declareTx = await account.declare({
+      contract: compiledErc20,
+      classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+    });
+    expect(declareTx.transaction_hash).toBeDefined();
+    await provider.waitForTransaction(declareTx.transaction_hash);
 
-    const erc20Response = await provider.deployContract(erc20DeployPayload);
+    // Deploy Contract
+    const erc20Response = await account.deployContract2({
+      classHash: declareTx.class_hash,
+      constructorCalldata: [
+        encodeShortString('Token'),
+        encodeShortString('ERC20'),
+        account.address,
+      ],
+    });
+    expect(erc20Response.contract_address).toBeDefined(); */
 
-    erc20Address = erc20Response.contract_address;
+    const declareDeploy = await account.declareDeploy({
+      contract: compiledErc20,
+      classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+      constructorCalldata: [
+        encodeShortString('Token'),
+        encodeShortString('ERC20'),
+        account.address,
+      ],
+    });
+
+    erc20Address = declareDeploy.deploy.contract_address;
     erc20 = new Contract(compiledErc20.abi, erc20Address, provider);
-
-    await provider.waitForTransaction(erc20Response.transaction_hash);
 
     const x = await erc20.balanceOf(account.address);
 
@@ -174,6 +196,27 @@ describe('deploy and test Wallet', () => {
 
       expect(declareTx).toHaveProperty('class_hash');
       expect(declareTx.class_hash).toEqual(erc20ClassHash);
+    });
+
+    test('UDC DeployContract', async () => {
+      const deployResponse = await account.deployContract2({
+        classHash: erc20ClassHash,
+        constructorCalldata: [
+          encodeShortString('Token'),
+          encodeShortString('ERC20'),
+          account.address,
+        ],
+      });
+
+      expect(deployResponse.contract_address).toBeDefined();
+      expect(deployResponse.transaction_hash).toBeDefined();
+      expect(deployResponse.address).toBeDefined();
+      expect(deployResponse.deployer).toBeDefined();
+      expect(deployResponse.unique).toBeDefined();
+      expect(deployResponse.classHash).toBeDefined();
+      expect(deployResponse.calldata_len).toBeDefined();
+      expect(deployResponse.calldata).toBeDefined();
+      expect(deployResponse.salt).toBeDefined();
     });
 
     test('UDC Deploy', async () => {

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -207,11 +207,10 @@ describe('class ContractFactory {}', () => {
   let erc20Address: string;
   const wallet = stark.randomAddress();
   const account = getTestAccount(provider);
-  let constructorCalldata;
+  const constructorCalldata = [encodeShortString('Token'), encodeShortString('ERC20'), wallet];
+  const classHash = '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a';
 
   beforeAll(async () => {
-    constructorCalldata = [encodeShortString('Token'), encodeShortString('ERC20'), wallet];
-
     await account.declareDeploy({
       contract: compiledErc20,
       classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
@@ -219,17 +218,17 @@ describe('class ContractFactory {}', () => {
     });
   });
   test('deployment of new contract', async () => {
-    const factory = new ContractFactory(compiledErc20, provider);
+    const factory = new ContractFactory(compiledErc20, classHash, account);
     const erc20 = await factory.deploy(constructorCalldata);
     expect(erc20 instanceof Contract);
   });
   test('wait for deployment transaction', async () => {
-    const factory = new ContractFactory(compiledErc20, provider);
+    const factory = new ContractFactory(compiledErc20, classHash, account);
     const contract = await factory.deploy(constructorCalldata);
     expect(contract.deployed()).resolves.not.toThrow();
   });
   test('attach new contract', async () => {
-    const factory = new ContractFactory(compiledErc20, provider);
+    const factory = new ContractFactory(compiledErc20, classHash, account);
     const erc20 = factory.attach(erc20Address);
     expect(erc20 instanceof Contract);
   });

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -87,7 +87,7 @@ describe('class Contract {}', () => {
   });
 
   describe('Type Transformation', () => {
-    let typeTransContract: Contract;
+    let typeTransformedContract: Contract;
 
     beforeAll(async () => {
       const { deploy } = await account.declareDeploy({
@@ -95,7 +95,7 @@ describe('class Contract {}', () => {
         classHash: '0x022a0e662b13d18a2aaa3ee54ae290de6569621b549022c18169c6e7893809ea',
       });
 
-      typeTransContract = new Contract(
+      typeTransformedContract = new Contract(
         compiledTypeTransformation.abi,
         deploy.contract_address!,
         provider
@@ -104,26 +104,30 @@ describe('class Contract {}', () => {
 
     describe('Request Type Transformation', () => {
       test('Parsing the felt in request', async () => {
-        return expect(typeTransContract.request_felt(3)).resolves.not.toThrow();
+        return expect(typeTransformedContract.request_felt(3)).resolves.not.toThrow();
       });
 
       test('Parsing the array of felt in request', async () => {
-        return expect(typeTransContract.request_array_of_felts([1, 2])).resolves.not.toThrow();
+        return expect(
+          typeTransformedContract.request_array_of_felts([1, 2])
+        ).resolves.not.toThrow();
       });
 
       test('Parsing the struct in request', async () => {
-        return expect(typeTransContract.request_struct({ x: 1, y: 2 })).resolves.not.toThrow();
+        return expect(
+          typeTransformedContract.request_struct({ x: 1, y: 2 })
+        ).resolves.not.toThrow();
       });
 
       test('Parsing the array of structs in request', async () => {
         return expect(
-          typeTransContract.request_array_of_structs([{ x: 1, y: 2 }])
+          typeTransformedContract.request_array_of_structs([{ x: 1, y: 2 }])
         ).resolves.not.toThrow();
       });
 
       test('Parsing the nested structs in request', async () => {
         return expect(
-          typeTransContract.request_nested_structs({
+          typeTransformedContract.request_nested_structs({
             p1: { x: 1, y: 2 },
             p2: { x: 3, y: 4 },
             extra: 5,
@@ -132,45 +136,45 @@ describe('class Contract {}', () => {
       });
 
       test('Parsing the tuple in request', async () => {
-        return expect(typeTransContract.request_tuple([1, 2])).resolves.not.toThrow();
+        return expect(typeTransformedContract.request_tuple([1, 2])).resolves.not.toThrow();
       });
 
       test('Parsing the multiple types in request', async () => {
         return expect(
-          typeTransContract.request_mixed_types(2, { x: 1, y: 2 }, [1])
+          typeTransformedContract.request_mixed_types(2, { x: 1, y: 2 }, [1])
         ).resolves.not.toThrow();
       });
     });
 
     describe('Response Type Transformation', () => {
       test('Parsing the felt in response', async () => {
-        const { res } = await typeTransContract.get_felt();
+        const { res } = await typeTransformedContract.get_felt();
         expect(res).toStrictEqual(toBN(4));
       });
 
       test('Parsing the array of felt in response', async () => {
-        const result = await typeTransContract.get_array_of_felts();
+        const result = await typeTransformedContract.get_array_of_felts();
         const [res] = result;
         expect(res).toStrictEqual([toBN(4), toBN(5)]);
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the array of structs in response', async () => {
-        const result = await typeTransContract.get_struct();
+        const result = await typeTransformedContract.get_struct();
         const [res] = result;
         expect(res).toStrictEqual({ x: toBN(1), y: toBN(2) });
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the array of structs in response', async () => {
-        const result = await typeTransContract.get_array_of_structs();
+        const result = await typeTransformedContract.get_array_of_structs();
         const [res] = result;
         expect(res).toStrictEqual([{ x: toBN(1), y: toBN(2) }]);
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the nested structs in response', async () => {
-        const result = await typeTransContract.get_nested_structs();
+        const result = await typeTransformedContract.get_nested_structs();
         const [res] = result;
         expect(res).toStrictEqual({
           p1: { x: toBN(1), y: toBN(2) },
@@ -181,14 +185,14 @@ describe('class Contract {}', () => {
       });
 
       test('Parsing the tuple in response', async () => {
-        const result = await typeTransContract.get_tuple();
+        const result = await typeTransformedContract.get_tuple();
         const [res] = result;
         expect(res).toStrictEqual([toBN(1), toBN(2), toBN(3)]);
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the multiple types in response', async () => {
-        const result = await typeTransContract.get_mixed_types();
+        const result = await typeTransformedContract.get_mixed_types();
         const [tuple, number, array, point] = result;
         expect(tuple).toStrictEqual([toBN(1), toBN(2)]);
         expect(number).toStrictEqual(toBN(3));

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -1,15 +1,15 @@
 import { isBN } from 'bn.js';
 
 import { Contract, ContractFactory, stark } from '../src';
-import { DeployContractPayload } from '../src/types/lib';
 import { getSelectorFromName } from '../src/utils/hash';
 import { BigNumberish, toBN } from '../src/utils/number';
+import { encodeShortString } from '../src/utils/shortString';
 import { compileCalldata } from '../src/utils/stark';
 import {
   compiledErc20,
   compiledMulticall,
   compiledTypeTransformation,
-  getERC20DeployPayload,
+  getTestAccount,
   getTestProvider,
 } from './fixtures';
 
@@ -17,45 +17,46 @@ const provider = getTestProvider();
 
 describe('class Contract {}', () => {
   const wallet = stark.randomAddress();
+  const account = getTestAccount(provider);
 
   describe('Basic Interaction', () => {
-    let erc20: Contract;
-    let contract: Contract;
+    let erc20Contract: Contract;
+    let multicallContract: Contract;
 
     beforeAll(async () => {
-      const erc20DeployPayload = getERC20DeployPayload(wallet);
+      const { deploy } = await account.declareDeploy({
+        contract: compiledErc20,
+        classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+        constructorCalldata: [encodeShortString('Token'), encodeShortString('ERC20'), wallet],
+      });
 
-      const { contract_address, transaction_hash } = await provider.deployContract(
-        erc20DeployPayload
+      erc20Contract = new Contract(compiledErc20.abi, deploy.contract_address!, provider);
+
+      const { deploy: multicallDeploy } = await account.declareDeploy({
+        contract: compiledMulticall,
+        classHash: '0x06f94f3229a8d9c1d51cb84f1f5ec306c8552a805e307540727dda53c4936b43',
+      });
+
+      multicallContract = new Contract(
+        compiledMulticall.abi,
+        multicallDeploy.contract_address!,
+        provider
       );
-
-      erc20 = new Contract(compiledErc20.abi, contract_address!, provider);
-      await provider.waitForTransaction(transaction_hash);
-      // Deploy Multicall
-
-      const { transaction_hash: m_transaction_hash, contract_address: multicallAddress } =
-        await provider.deployContract({
-          contract: compiledMulticall,
-        });
-
-      contract = new Contract(compiledMulticall.abi, multicallAddress!, provider);
-
-      await provider.waitForTransaction(m_transaction_hash);
     });
 
     test('populate transaction for initial balance of that account', async () => {
-      const res = await erc20.populateTransaction.balanceOf(wallet);
+      const res = await erc20Contract.populateTransaction.balanceOf(wallet);
       expect(res).toHaveProperty('contractAddress');
       expect(res).toHaveProperty('entrypoint');
       expect(res).toHaveProperty('calldata');
     });
 
     test('estimate gas fee for `mint` should fail when connected to the provider', async () => {
-      expect(erc20.estimateFee.mint(wallet, ['10', '0'])).rejects.toThrow();
+      expect(erc20Contract.estimateFee.mint(wallet, ['10', '0'])).rejects.toThrow();
     });
 
     test('read initial balance of that account', async () => {
-      const result = await erc20.balanceOf(wallet);
+      const result = await erc20Contract.balanceOf(wallet);
       const [res] = result;
       expect(res.low).toStrictEqual(toBN(1000));
       expect(res).toStrictEqual(result.balance);
@@ -65,17 +66,17 @@ describe('class Contract {}', () => {
       const args1 = { user: wallet };
       const args2 = {};
       const calls = [
-        erc20.address,
+        erc20Contract.address,
         getSelectorFromName('balanceOf'),
         Object.keys(args1).length,
         ...compileCalldata(args1),
 
-        erc20.address,
+        erc20Contract.address,
         getSelectorFromName('decimals'),
         Object.keys(args2).length,
         ...compileCalldata(args2),
       ];
-      const result = await contract.aggregate(calls);
+      const result = await multicallContract.aggregate(calls);
       const [block_number, res] = result;
       expect(isBN(block_number));
       expect(Array.isArray(res));
@@ -86,36 +87,43 @@ describe('class Contract {}', () => {
   });
 
   describe('Type Transformation', () => {
-    let contract: Contract;
+    let typeTransContract: Contract;
 
     beforeAll(async () => {
-      const { transaction_hash, contract_address } = await provider.deployContract({
+      const { deploy } = await account.declareDeploy({
         contract: compiledTypeTransformation,
+        classHash: '0x022a0e662b13d18a2aaa3ee54ae290de6569621b549022c18169c6e7893809ea',
       });
-      contract = new Contract(compiledTypeTransformation.abi, contract_address!, provider);
-      await provider.waitForTransaction(transaction_hash);
+
+      typeTransContract = new Contract(
+        compiledTypeTransformation.abi,
+        deploy.contract_address!,
+        provider
+      );
     });
 
     describe('Request Type Transformation', () => {
       test('Parsing the felt in request', async () => {
-        return expect(contract.request_felt(3)).resolves.not.toThrow();
+        return expect(typeTransContract.request_felt(3)).resolves.not.toThrow();
       });
 
       test('Parsing the array of felt in request', async () => {
-        return expect(contract.request_array_of_felts([1, 2])).resolves.not.toThrow();
+        return expect(typeTransContract.request_array_of_felts([1, 2])).resolves.not.toThrow();
       });
 
       test('Parsing the struct in request', async () => {
-        return expect(contract.request_struct({ x: 1, y: 2 })).resolves.not.toThrow();
+        return expect(typeTransContract.request_struct({ x: 1, y: 2 })).resolves.not.toThrow();
       });
 
       test('Parsing the array of structs in request', async () => {
-        return expect(contract.request_array_of_structs([{ x: 1, y: 2 }])).resolves.not.toThrow();
+        return expect(
+          typeTransContract.request_array_of_structs([{ x: 1, y: 2 }])
+        ).resolves.not.toThrow();
       });
 
       test('Parsing the nested structs in request', async () => {
         return expect(
-          contract.request_nested_structs({
+          typeTransContract.request_nested_structs({
             p1: { x: 1, y: 2 },
             p2: { x: 3, y: 4 },
             extra: 5,
@@ -124,43 +132,45 @@ describe('class Contract {}', () => {
       });
 
       test('Parsing the tuple in request', async () => {
-        return expect(contract.request_tuple([1, 2])).resolves.not.toThrow();
+        return expect(typeTransContract.request_tuple([1, 2])).resolves.not.toThrow();
       });
 
       test('Parsing the multiple types in request', async () => {
-        return expect(contract.request_mixed_types(2, { x: 1, y: 2 }, [1])).resolves.not.toThrow();
+        return expect(
+          typeTransContract.request_mixed_types(2, { x: 1, y: 2 }, [1])
+        ).resolves.not.toThrow();
       });
     });
 
     describe('Response Type Transformation', () => {
       test('Parsing the felt in response', async () => {
-        const { res } = await contract.get_felt();
+        const { res } = await typeTransContract.get_felt();
         expect(res).toStrictEqual(toBN(4));
       });
 
       test('Parsing the array of felt in response', async () => {
-        const result = await contract.get_array_of_felts();
+        const result = await typeTransContract.get_array_of_felts();
         const [res] = result;
         expect(res).toStrictEqual([toBN(4), toBN(5)]);
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the array of structs in response', async () => {
-        const result = await contract.get_struct();
+        const result = await typeTransContract.get_struct();
         const [res] = result;
         expect(res).toStrictEqual({ x: toBN(1), y: toBN(2) });
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the array of structs in response', async () => {
-        const result = await contract.get_array_of_structs();
+        const result = await typeTransContract.get_array_of_structs();
         const [res] = result;
         expect(res).toStrictEqual([{ x: toBN(1), y: toBN(2) }]);
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the nested structs in response', async () => {
-        const result = await contract.get_nested_structs();
+        const result = await typeTransContract.get_nested_structs();
         const [res] = result;
         expect(res).toStrictEqual({
           p1: { x: toBN(1), y: toBN(2) },
@@ -171,14 +181,14 @@ describe('class Contract {}', () => {
       });
 
       test('Parsing the tuple in response', async () => {
-        const result = await contract.get_tuple();
+        const result = await typeTransContract.get_tuple();
         const [res] = result;
         expect(res).toStrictEqual([toBN(1), toBN(2), toBN(3)]);
         expect(res).toStrictEqual(result.res);
       });
 
       test('Parsing the multiple types in response', async () => {
-        const result = await contract.get_mixed_types();
+        const result = await typeTransContract.get_mixed_types();
         const [tuple, number, array, point] = result;
         expect(tuple).toStrictEqual([toBN(1), toBN(2)]);
         expect(number).toStrictEqual(toBN(3));
@@ -196,26 +206,26 @@ describe('class Contract {}', () => {
 describe('class ContractFactory {}', () => {
   let erc20Address: string;
   const wallet = stark.randomAddress();
-  let erc20DeployPayload: DeployContractPayload;
+  const account = getTestAccount(provider);
+  let constructorCalldata;
 
   beforeAll(async () => {
-    erc20DeployPayload = getERC20DeployPayload(wallet);
+    constructorCalldata = [encodeShortString('Token'), encodeShortString('ERC20'), wallet];
 
-    const { contract_address, transaction_hash } = await provider.deployContract(
-      erc20DeployPayload
-    );
-
-    await provider.waitForTransaction(transaction_hash);
-    erc20Address = contract_address;
+    await account.declareDeploy({
+      contract: compiledErc20,
+      classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+      constructorCalldata,
+    });
   });
   test('deployment of new contract', async () => {
     const factory = new ContractFactory(compiledErc20, provider);
-    const erc20 = await factory.deploy(erc20DeployPayload.constructorCalldata);
+    const erc20 = await factory.deploy(constructorCalldata);
     expect(erc20 instanceof Contract);
   });
   test('wait for deployment transaction', async () => {
     const factory = new ContractFactory(compiledErc20, provider);
-    const contract = await factory.deploy(erc20DeployPayload.constructorCalldata);
+    const contract = await factory.deploy(constructorCalldata);
     expect(contract.deployed()).resolves.not.toThrow();
   });
   test('attach new contract', async () => {

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -1,8 +1,7 @@
 import fs from 'fs';
 
 import { Account, ProviderInterface, RpcProvider, SequencerProvider, ec, json } from '../src';
-import { CompiledContract, DeployContractPayload } from '../src/types';
-import { encodeShortString } from '../src/utils/shortString';
+import { CompiledContract } from '../src/types';
 
 const readContract = (name: string): CompiledContract =>
   json.parse(fs.readFileSync(`./__mocks__/${name}.json`).toString('ascii'));
@@ -74,10 +73,3 @@ export const describeIfRpc = describeIf(IS_RPC);
 export const describeIfNotDevnet = describeIf(!IS_DEVNET);
 
 export const erc20ClassHash = '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a';
-
-export const getERC20DeployPayload = (recipient: string): DeployContractPayload => {
-  return {
-    contract: compiledErc20,
-    constructorCalldata: [encodeShortString('Token'), encodeShortString('ERC20'), recipient],
-  };
-};

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -1,10 +1,13 @@
 import fs from 'fs';
+import path from 'path';
 
 import { Account, ProviderInterface, RpcProvider, SequencerProvider, ec, json } from '../src';
 import { CompiledContract } from '../src/types';
 
 const readContract = (name: string): CompiledContract =>
-  json.parse(fs.readFileSync(`./__mocks__/${name}.json`).toString('ascii'));
+  json.parse(
+    fs.readFileSync(path.resolve(__dirname, `../__mocks__/${name}.json`)).toString('ascii')
+  );
 
 export const compiledOpenZeppelinAccount = readContract('Account');
 export const compiledErc20 = readContract('ERC20');

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -13,29 +13,33 @@ export const compiledTypeTransformation = readContract('contract');
 export const compiledMulticall = readContract('multicall');
 export const compiledTestDapp = readContract('TestDapp');
 
-const DEFAULT_TEST_PROVIDER_BASE_URL = 'http://127.0.0.1:5050/';
-const DEFAULT_TEST_ACCOUNT_ADDRESS = // run `starknet-devnet --seed 0` and this will be the first account
+/* Default test config based on run `starknet-devnet --seed 0` */
+const DEFAULT_TEST_PROVIDER_SEQUENCER_URL = 'http://127.0.0.1:5050/';
+const DEFAULT_TEST_ACCOUNT_ADDRESS =
   '0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a';
 const DEFAULT_TEST_ACCOUNT_PRIVATE_KEY = '0xe3e70682c2094cac629f6fbed82c07cd';
 
-const BASE_URL = process.env.TEST_PROVIDER_BASE_URL || DEFAULT_TEST_PROVIDER_BASE_URL;
+/* User defined config or default one */
+const BASE_URL = process.env.TEST_PROVIDER_BASE_URL || DEFAULT_TEST_PROVIDER_SEQUENCER_URL;
 const RPC_URL = process.env.TEST_RPC_URL;
 
-const IS_RPC = !!RPC_URL;
-const IS_RPC_DEVNET = Boolean(
-  RPC_URL && (RPC_URL.includes('localhost') || RPC_URL.includes('127.0.0.1'))
-);
-const IS_SEQUENCER = !IS_RPC;
-const IS_SEQUENCER_DEVNET = !BASE_URL.includes('starknet.io');
-export const IS_SEQUENCER_GOERLI = BASE_URL === 'https://alpha4-2.starknet.io';
-export const IS_DEVNET = IS_SEQUENCER ? IS_SEQUENCER_DEVNET : IS_RPC_DEVNET;
+/* Detect user defined node or sequencer, if none default to sequencer if both default to node */
+const PROVIDER_URL = RPC_URL || BASE_URL;
+
+/* Detect is localhost devnet */
+export const IS_LOCALHOST_DEVNET =
+  PROVIDER_URL.includes('localhost') || PROVIDER_URL.includes('127.0.0.1');
+
+/* Definitions */
+export const IS_RPC = !!RPC_URL;
+export const IS_SEQUENCER = !RPC_URL;
 
 export const getTestProvider = (): ProviderInterface => {
   const provider = RPC_URL
     ? new RpcProvider({ nodeUrl: RPC_URL })
     : new SequencerProvider({ baseUrl: BASE_URL });
 
-  if (IS_DEVNET) {
+  if (IS_LOCALHOST_DEVNET) {
     // accelerate the tests when running locally
     const originalWaitForTransaction = provider.waitForTransaction.bind(provider);
     provider.waitForTransaction = (txHash, retryInterval) => {
@@ -51,11 +55,10 @@ export const getTestAccount = (provider: ProviderInterface) => {
   let testAccountAddress = process.env.TEST_ACCOUNT_ADDRESS;
   let testAccountPrivateKey = process.env.TEST_ACCOUNT_PRIVATE_KEY;
 
-  if (!IS_DEVNET) {
+  if (!IS_LOCALHOST_DEVNET) {
     if (!testAccountPrivateKey) {
       throw new Error('TEST_ACCOUNT_PRIVATE_KEY is not set');
     }
-
     if (!testAccountAddress) {
       throw new Error('TEST_ACCOUNT_ADDRESS is not set');
     }
@@ -68,8 +71,9 @@ export const getTestAccount = (provider: ProviderInterface) => {
 };
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip);
-export const describeIfSequencer = describeIf(IS_DEVNET);
+export const describeIfSequencer = describeIf(IS_SEQUENCER);
 export const describeIfRpc = describeIf(IS_RPC);
-export const describeIfNotDevnet = describeIf(!IS_DEVNET);
+export const describeIfNotDevnet = describeIf(!IS_LOCALHOST_DEVNET);
+export const describeIfDevnet = describeIf(IS_LOCALHOST_DEVNET);
 
 export const erc20ClassHash = '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a';

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -2,6 +2,7 @@ import { Account, GetBlockResponse, RpcProvider, ec } from '../src';
 import { StarknetChainId } from '../src/constants';
 import {
   compiledOpenZeppelinAccount,
+  describeIfNotDevnet,
   describeIfRpc,
   getTestAccount,
   getTestProvider,
@@ -25,12 +26,6 @@ describeIfRpc('RPCProvider', () => {
     );
   });
 
-  xtest('getPendingTransactions', async () => {
-    // devnet not implement
-    const transactions = await rpcProvider.getPendingTransactions();
-    expect(Array.isArray(transactions)).toBe(true);
-  });
-
   test('getTransactionCount', async () => {
     const count = await rpcProvider.getTransactionCount('latest');
     expect(typeof count).toBe('number');
@@ -50,8 +45,15 @@ describeIfRpc('RPCProvider', () => {
     expect(stateUpdate).toHaveProperty('state_diff');
   });
 
-  xtest('getProtocolVersion', async () => {
+  xtest('getProtocolVersion - pathfinder not implement', async () => {
     await rpcProvider.getProtocolVersion();
+  });
+
+  describeIfNotDevnet('devnet not implement', () => {
+    test('getPendingTransactions', async () => {
+      const transactions = await rpcProvider.getPendingTransactions();
+      expect(Array.isArray(transactions)).toBe(true);
+    });
   });
 
   describe('RPC methods', () => {

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -8,15 +8,12 @@ import {
 } from './fixtures';
 
 describeIfRpc('RPCProvider', () => {
-  let rpcProvider: RpcProvider;
+  const rpcProvider = getTestProvider() as RpcProvider;
+  const account = getTestAccount(rpcProvider);
   let accountPublicKey: string;
 
   beforeAll(async () => {
-    rpcProvider = getTestProvider() as RpcProvider;
-    const account = getTestAccount(rpcProvider);
-
     expect(account).toBeInstanceOf(Account);
-
     const accountKeyPair = ec.genKeyPair();
     accountPublicKey = ec.getStarkKey(accountKeyPair);
   });
@@ -28,7 +25,8 @@ describeIfRpc('RPCProvider', () => {
     );
   });
 
-  test('getPendingTransactions', async () => {
+  xtest('getPendingTransactions', async () => {
+    // devnet not implement
     const transactions = await rpcProvider.getPendingTransactions();
     expect(Array.isArray(transactions)).toBe(true);
   });
@@ -90,15 +88,18 @@ describeIfRpc('RPCProvider', () => {
       let transaction_hash;
 
       beforeAll(async () => {
-        ({ contract_address, transaction_hash } = await rpcProvider.deployContract({
+        const { deploy } = await account.declareDeploy({
           contract: compiledOpenZeppelinAccount,
+          classHash: '0x03fcbf77b28c96f4f2fb5bd2d176ab083a12a5e123adeb0de955d7ee228c9854',
           constructorCalldata: [accountPublicKey],
-          addressSalt: accountPublicKey,
-        }));
-        await rpcProvider.waitForTransaction(transaction_hash);
+          salt: accountPublicKey,
+        });
+
+        contract_address = deploy.contract_address;
+        transaction_hash = deploy.transaction_hash;
       });
 
-      test('deployContract result', () => {
+      test('declareDeploy()', () => {
         expect(contract_address).toBeTruthy();
         expect(transaction_hash).toBeTruthy();
       });

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -1,46 +1,35 @@
 import { Contract, Provider, SequencerProvider, stark } from '../src';
 import { toBN } from '../src/utils/number';
+import { encodeShortString } from '../src/utils/shortString';
 import {
-  IS_SEQUENCER_GOERLI,
   compiledErc20,
   compiledL1L2,
+  describeIfDevnet,
   describeIfNotDevnet,
   describeIfSequencer,
-  getERC20DeployPayload,
+  getTestAccount,
   getTestProvider,
 } from './fixtures';
 
-// Run only if Devnet Sequencer
 describeIfSequencer('SequencerProvider', () => {
-  let sequencerProvider: SequencerProvider;
+  const sequencerProvider = getTestProvider() as SequencerProvider;
+  const account = getTestAccount(sequencerProvider);
   let customSequencerProvider: Provider;
   let exampleContractAddress: string;
-
-  beforeAll(async () => {
-    sequencerProvider = getTestProvider() as SequencerProvider;
-    customSequencerProvider = new Provider({
-      sequencer: {
-        baseUrl: 'http://127.0.0.1:5050/',
-        feederGatewayUrl: 'feeder_gateway',
-        gatewayUrl: 'gateway',
-      }, // Similar to arguements used in docs
-    });
-  });
 
   describe('Gateway specific methods', () => {
     let exampleTransactionHash: string;
     const wallet = stark.randomAddress();
 
     beforeAll(async () => {
-      const erc20DeployPayload = getERC20DeployPayload(wallet);
+      const { deploy } = await account.declareDeploy({
+        contract: compiledErc20,
+        classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+        constructorCalldata: [encodeShortString('Token'), encodeShortString('ERC20'), wallet],
+      });
 
-      const { contract_address, transaction_hash } = await sequencerProvider.deployContract(
-        erc20DeployPayload
-      );
-
-      await sequencerProvider.waitForTransaction(transaction_hash);
-      exampleTransactionHash = transaction_hash;
-      exampleContractAddress = contract_address;
+      exampleTransactionHash = deploy.transaction_hash;
+      exampleContractAddress = deploy.contract_address;
     });
 
     test('getTransactionStatus()', async () => {
@@ -69,43 +58,16 @@ describeIfSequencer('SequencerProvider', () => {
     });
   });
 
-  describe('Test calls with Custom Sequencer Provider', () => {
-    let erc20: Contract;
-    const wallet = stark.randomAddress();
-
-    beforeAll(async () => {
-      const erc20DeployPayload = getERC20DeployPayload(wallet);
-
-      const { contract_address, transaction_hash } = await customSequencerProvider.deployContract(
-        erc20DeployPayload
-      );
-
-      await customSequencerProvider.waitForTransaction(transaction_hash);
-      erc20 = new Contract(compiledErc20.abi, contract_address, customSequencerProvider);
-    });
-
-    test('Check ERC20 balance using Custom Sequencer Provider', async () => {
-      const result = await erc20.balanceOf(wallet);
-      const [res] = result;
-      expect(res.low).toStrictEqual(toBN(1000));
-      expect(res).toStrictEqual(result.balance);
-    });
-  });
-
   describe('Test Estimate message fee', () => {
     const L1_ADDRESS = '0x8359E4B0152ed5A731162D3c7B0D8D56edB165A0';
     let l1l2ContractAddress: string;
 
     beforeAll(async () => {
-      if (IS_SEQUENCER_GOERLI) {
-        l1l2ContractAddress = '0x2863141e0d9a74e9b484c1f5b1e3a2f6cbb6b84df8233c7c1cbe31334d9aed8';
-      } else {
-        const { transaction_hash, contract_address } = await sequencerProvider.deployContract({
-          contract: compiledL1L2,
-        });
-        await sequencerProvider.waitForTransaction(transaction_hash);
-        l1l2ContractAddress = contract_address;
-      }
+      const { deploy } = await account.declareDeploy({
+        contract: compiledL1L2,
+        classHash: '0x028d1671fb74ecb54d848d463cefccffaef6df3ae40db52130e19fe8299a7b43',
+      });
+      l1l2ContractAddress = deploy.contract_address;
     });
 
     test('estimate message fee', async () => {
@@ -126,6 +88,36 @@ describeIfSequencer('SequencerProvider', () => {
           unit: 'wei',
         })
       );
+    });
+  });
+
+  describeIfDevnet('Test calls with Custom Devnet Sequencer Provider', () => {
+    let erc20: Contract;
+    const wallet = stark.randomAddress();
+
+    beforeAll(async () => {
+      customSequencerProvider = new Provider({
+        sequencer: {
+          baseUrl: 'http://127.0.0.1:5050/',
+          feederGatewayUrl: 'feeder_gateway',
+          gatewayUrl: 'gateway',
+        },
+      });
+      const accountCustom = getTestAccount(customSequencerProvider);
+      const { deploy } = await accountCustom.declareDeploy({
+        contract: compiledErc20,
+        classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+        constructorCalldata: [encodeShortString('Token'), encodeShortString('ERC20'), wallet],
+      });
+
+      erc20 = new Contract(compiledErc20.abi, deploy.contract_address, customSequencerProvider);
+    });
+
+    test('Check ERC20 balance using Custom Sequencer Provider', async () => {
+      const result = await erc20.balanceOf(wallet);
+      const [res] = result;
+      expect(res.low).toStrictEqual(toBN(1000));
+      expect(res).toStrictEqual(result.balance);
     });
   });
 });

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -27,9 +27,18 @@ describe('compressProgram()', () => {
     expect(compressed).toMatchSnapshot();
   });
 });
+
 describe('hexToDecimalString()', () => {
   test('parse 0xa23', () => {
     expect(number.hexToDecimalString('0xa23')).toBe('2595');
+  });
+});
+
+describe('cleanHex()', () => {
+  test('parse 0xa23', () => {
+    expect(number.cleanHex('0x023Ab')).toBe('0x23ab');
+    expect(number.cleanHex('0x000023Ab')).toBe('0x23ab');
+    expect(number.cleanHex('0x23Ab')).toBe('0x23ab');
   });
 });
 
@@ -42,6 +51,7 @@ describe('makeAddress()', () => {
     expect(starkAddress).toBe('0xdfd0f27fce99b50909de0bdd328aed6eabe76bc5');
   });
 });
+
 describe('getSelectorFromName()', () => {
   test('hash works for value="test"', () => {
     expect(hash.getSelectorFromName('test')).toBe(

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:iife": "tsup --clean false --format iife --platform browser",
     "build:dts": "tsup --clean false --dts-only",
     "pretest": "npm run lint",
-    "test": "jest",
+    "test": "jest -i",
     "posttest": "npm run format",
     "test:watch": "jest --watch",
     "docs": "cd www && npm run start",

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -279,21 +279,11 @@ export class Account extends Provider implements AccountInterface {
       constructorCalldata = [],
       additionalCalls = [],
     }: UniversalDeployerContractPayload,
-    { nonce, version, maxFee }: InvocationsDetails = {}
+    invocationsDetails: InvocationsDetails = {}
   ): Promise<InvokeFunctionResponse> {
     const compiledConstructorCallData = compileCalldata(constructorCalldata);
     const callsArray = Array.isArray(additionalCalls) ? additionalCalls : [additionalCalls];
     const deploySalt = salt ?? randomAddress();
-
-    const deployMaxFee =
-      maxFee ??
-      (await this.getSuggestedMaxFee(
-        {
-          type: 'DEPLOY',
-          payload: { classHash, salt: deploySalt, unique, constructorCalldata, additionalCalls },
-        },
-        {}
-      ));
 
     return this.execute(
       [
@@ -311,11 +301,7 @@ export class Account extends Provider implements AccountInterface {
         ...callsArray,
       ],
       undefined,
-      {
-        nonce,
-        maxFee: deployMaxFee,
-        version,
-      }
+      invocationsDetails
     );
   }
 

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -7,8 +7,8 @@ import {
   Abi,
   Call,
   DeclareContractResponse,
-  DeployContract2Response,
   DeployContractResponse,
+  DeployContractUDCResponse,
   EstimateFeeAction,
   InvocationsDetails,
   InvocationsSignerDetails,
@@ -327,10 +327,10 @@ export class Account extends Provider implements AccountInterface {
    * @param detials InvocationsDetails
    * @returns Promise<AccountDeployContractResponse>
    */
-  public async deployContract2(
+  public async deployContract(
     payload: UniversalDeployerContractPayload,
     details: InvocationsDetails = {}
-  ): Promise<DeployContract2Response> {
+  ): Promise<DeployContractUDCResponse> {
     const deployTx = await this.deploy(payload, details);
     const txReceipt = await this.waitForTransaction(deployTx.transaction_hash);
     return parseUDCEvent(txReceipt);
@@ -342,7 +342,7 @@ export class Account extends Provider implements AccountInterface {
   ) {
     const { transaction_hash } = await this.declare({ contract, classHash }, details);
     const declare = await this.waitForTransaction(transaction_hash);
-    const deploy = await this.deployContract2({ classHash, constructorCalldata }, details);
+    const deploy = await this.deployContract({ classHash, constructorCalldata }, details);
     return { declare: { ...declare, class_hash: classHash }, deploy };
   }
 

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -305,13 +305,6 @@ export class Account extends Provider implements AccountInterface {
     );
   }
 
-  /**
-   * Simplify deploy simulating old DeployContract with same response + UDC specific response
-   *
-   * @param payload UniversalDeployerContractPayload
-   * @param detials InvocationsDetails
-   * @returns Promise<AccountDeployContractResponse>
-   */
   public async deployContract(
     payload: UniversalDeployerContractPayload,
     details: InvocationsDetails = {}

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -170,7 +170,7 @@ export class Account extends Provider implements AccountInterface {
   public async estimateDeployFee(
     {
       classHash,
-      salt = '',
+      salt,
       unique = true,
       constructorCalldata = [],
       additionalCalls = [],
@@ -273,7 +273,7 @@ export class Account extends Provider implements AccountInterface {
   public async deploy(
     {
       classHash,
-      salt = '',
+      salt,
       unique = true,
       constructorCalldata = [],
       additionalCalls = [],
@@ -312,27 +312,11 @@ export class Account extends Provider implements AccountInterface {
    * @returns Promise<AccountDeployContractResponse | Error>
    */
   public async deployContract2(
-    {
-      classHash,
-      salt,
-      unique = true,
-      constructorCalldata = [],
-      additionalCalls = [],
-    }: UniversalDeployerContractPayload,
-    transactionsDetail: InvocationsDetails = {}
+    payload: UniversalDeployerContractPayload,
+    details: InvocationsDetails = {}
   ): Promise<AccountDeployContractResponse | Error> {
-    const deployTx = await this.deploy(
-      {
-        classHash,
-        salt,
-        unique,
-        constructorCalldata,
-        additionalCalls,
-      },
-      transactionsDetail
-    );
+    const deployTx = await this.deploy(payload, details);
     const txReceipt = await this.waitForTransaction(deployTx.transaction_hash);
-
     return this.getUDCResponse(txReceipt);
   }
 

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -5,6 +5,7 @@ import {
   Abi,
   Call,
   DeclareContractResponse,
+  DeclareDeployContractResponse,
   DeployContractResponse,
   EstimateFeeAction,
   EstimateFeeDetails,
@@ -16,6 +17,7 @@ import {
 import {
   AllowArray,
   DeclareContractPayload,
+  DeclareDeployContractPayload,
   DeployAccountContractPayload,
   UniversalDeployerContractPayload,
 } from '../types/lib';
@@ -148,10 +150,10 @@ export abstract class AccountInterface extends ProviderInterface {
    *
    * @param deployContractPayload containing
    * - classHash: computed class hash of compiled contract
-   * - salt: address salt
-   * - unique: bool if true ensure unique salt
-   * - calldata: constructor calldata
-   * - additionalCalls - optional additional calls array to support multicall
+   * - constructorCalldata: constructor calldata
+   * - optional salt: address salt - default random
+   * - optional unique: bool if true ensure unique salt - default true
+   * - optional additionalCalls - optional additional calls array to support multicall
    * @param transactionsDetail Invocation Details containing:
    *  - optional nonce
    *  - optional version
@@ -161,6 +163,26 @@ export abstract class AccountInterface extends ProviderInterface {
     deployContractPayload: UniversalDeployerContractPayload,
     transactionsDetail?: InvocationsDetails
   ): Promise<InvokeFunctionResponse>;
+
+  /**
+   * Declares and Deploy a given compiled contract (json) to starknet using UDC
+   *
+   * @param declareDeployerContractPayload containing
+   * - contract: compiled contract code
+   * - classHash: computed class hash of compiled contract
+   * - optional constructorCalldata: constructor calldata
+   * - optional salt: address salt - default random
+   * - optional unique: bool if true ensure unique salt - default true
+   * - optional additionalCalls: - optional additional calls array to support multicall
+   * @param details
+   * - optional nonce
+   * - optional version
+   * - optional maxFee
+   */
+  public abstract declareDeploy(
+    declareDeployerContractPayload: DeclareDeployContractPayload,
+    details?: InvocationsDetails
+  ): Promise<DeclareDeployContractResponse | Error>;
 
   /**
    * Deploy the account on Starknet

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -152,11 +152,13 @@ export abstract class AccountInterface extends ProviderInterface {
    * - constructorCalldata: constructor calldata
    * - optional salt: address salt - default random
    * - optional unique: bool if true ensure unique salt - default true
-   * - optional additionalCalls - optional additional calls array to support multicall
+   * - optional additionalCalls - optional additional calls array to support multi-call
    * @param transactionsDetail Invocation Details containing:
    *  - optional nonce
    *  - optional version
    *  - optional maxFee
+   * @returns Promise<InvokeFunctionResponse>
+   *  - transaction_hash
    */
   public abstract deploy(
     deployContractPayload: UniversalDeployerContractPayload,
@@ -167,8 +169,25 @@ export abstract class AccountInterface extends ProviderInterface {
    * Simplify deploy simulating old DeployContract with same response + UDC specific response
    *
    * @param payload UniversalDeployerContractPayload
-   * @param detials InvocationsDetails
-   * @returns Promise<AccountDeployContractResponse>
+   *  - classHash: computed class hash of compiled contract
+   *  - constructorCalldata: constructor calldata
+   *  - optional salt: address salt - default random
+   *  - optional unique: bool if true ensure unique salt - default true
+   *  - optional additionalCalls - optional additional calls array to support multi-call
+   * @param details InvocationsDetails
+   *  - optional nonce
+   *  - optional version
+   *  - optional maxFee
+   * @returns Promise<DeployContractUDCResponse>
+   *  - contract_address
+   *  - transaction_hash
+   *  - address
+   *  - deployer
+   *  - unique
+   *  - classHash
+   *  - calldata_len
+   *  - calldata
+   *  - salt
    */
   public abstract deployContract(
     payload: UniversalDeployerContractPayload,
@@ -189,6 +208,19 @@ export abstract class AccountInterface extends ProviderInterface {
    * - optional nonce
    * - optional version
    * - optional maxFee
+   * @returns Promise<DeclareDeployContractResponse>
+   * - declare
+   *    - transaction_hash
+   * - deploy
+   *    - contract_address
+   *    - transaction_hash
+   *    - address
+   *    - deployer
+   *    - unique
+   *    - classHash
+   *    - calldata_len
+   *    - calldata
+   *    - salt
    */
   public abstract declareDeploy(
     declareDeployerContractPayload: DeclareDeployContractPayload,

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -7,6 +7,7 @@ import {
   DeclareContractResponse,
   DeclareDeployContractResponse,
   DeployContractResponse,
+  DeployContractUDCResponse,
   EstimateFeeAction,
   EstimateFeeDetails,
   EstimateFeeResponse,
@@ -163,6 +164,18 @@ export abstract class AccountInterface extends ProviderInterface {
     deployContractPayload: UniversalDeployerContractPayload,
     transactionsDetail?: InvocationsDetails
   ): Promise<InvokeFunctionResponse>;
+
+  /**
+   * Simplify deploy simulating old DeployContract with same response + UDC specific response
+   *
+   * @param payload UniversalDeployerContractPayload
+   * @param detials InvocationsDetails
+   * @returns Promise<AccountDeployContractResponse>
+   */
+  public abstract deployContract(
+    payload: UniversalDeployerContractPayload,
+    details: InvocationsDetails
+  ): Promise<DeployContractUDCResponse>;
 
   /**
    * Declares and Deploy a given compiled contract (json) to starknet using UDC

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -182,7 +182,7 @@ export abstract class AccountInterface extends ProviderInterface {
   public abstract declareDeploy(
     declareDeployerContractPayload: DeclareDeployContractPayload,
     details?: InvocationsDetails
-  ): Promise<DeclareDeployContractResponse | Error>;
+  ): Promise<DeclareDeployContractResponse>;
 
   /**
    * Deploy the account on Starknet

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -131,7 +131,6 @@ export abstract class AccountInterface extends ProviderInterface {
    * @param contractPayload transaction payload to be deployed containing:
   - contract: compiled contract code
   - classHash: computed class hash of compiled contract
-  - signature
    * @param transactionsDetail Invocation Details containing:
   - optional nonce
   - optional version

--- a/src/contract/contractFactory.ts
+++ b/src/contract/contractFactory.ts
@@ -59,10 +59,10 @@ export class ContractFactory {
   /**
    * Attaches to new Provider or Account
    *
-   * @param providerOrAccount - new Provider or Account to attach to
+   * @param account - new Provider or Account to attach to
    */
-  connect(providerOrAccount: AccountInterface): ContractFactory {
-    this.account = providerOrAccount;
+  connect(account: AccountInterface): ContractFactory {
+    this.account = account;
     return this;
   }
 

--- a/src/contract/contractFactory.ts
+++ b/src/contract/contractFactory.ts
@@ -1,8 +1,7 @@
 import assert from 'minimalistic-assert';
 
 import { AccountInterface } from '../account';
-import { ProviderInterface, defaultProvider } from '../provider';
-import { Abi, CompiledContract, RawCalldata } from '../types';
+import { Abi, CompiledContract, RawArgs } from '../types';
 import { Contract } from './default';
 
 export class ContractFactory {
@@ -10,16 +9,20 @@ export class ContractFactory {
 
   compiledContract: CompiledContract;
 
-  providerOrAccount: ProviderInterface | AccountInterface;
+  classHash: string;
+
+  account: AccountInterface;
 
   constructor(
     compiledContract: CompiledContract,
-    providerOrAccount: ProviderInterface | AccountInterface = defaultProvider,
+    classHash: string,
+    account: AccountInterface,
     abi: Abi = compiledContract.abi // abi can be different from the deployed contract ie for proxy contracts
   ) {
     this.abi = abi;
     this.compiledContract = compiledContract;
-    this.providerOrAccount = providerOrAccount;
+    this.account = account;
+    this.classHash = classHash;
   }
 
   /**
@@ -30,20 +33,23 @@ export class ContractFactory {
    * @returns deployed Contract
    */
   public async deploy(
-    constructorCalldata?: RawCalldata,
+    constructorCalldata?: RawArgs,
     addressSalt?: string | undefined
   ): Promise<Contract> {
-    const { contract_address, transaction_hash } = await this.providerOrAccount.deployContract({
+    const {
+      deploy: { contract_address, transaction_hash },
+    } = await this.account.declareDeploy({
       contract: this.compiledContract,
+      classHash: this.classHash,
       constructorCalldata,
-      addressSalt,
+      salt: addressSalt,
     });
     assert(Boolean(contract_address), 'Deployment of the contract failed');
 
     const contractInstance = new Contract(
       this.compiledContract.abi,
       contract_address!,
-      this.providerOrAccount
+      this.account
     );
     contractInstance.deployTransactionHash = transaction_hash;
 
@@ -55,8 +61,8 @@ export class ContractFactory {
    *
    * @param providerOrAccount - new Provider or Account to attach to
    */
-  connect(providerOrAccount: ProviderInterface | AccountInterface): ContractFactory {
-    this.providerOrAccount = providerOrAccount;
+  connect(providerOrAccount: AccountInterface): ContractFactory {
+    this.account = providerOrAccount;
     return this;
   }
 
@@ -67,7 +73,7 @@ export class ContractFactory {
    * @returns Contract
    */
   attach(address: string): Contract {
-    return new Contract(this.abi, address, this.providerOrAccount);
+    return new Contract(this.abi, address, this.account);
   }
 
   // ethers.js' getDeployTransaction cant be supported as it requires the account or signer to return a signed transaction which is not possible with the current implementation

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -147,7 +147,7 @@ export class Provider implements ProviderInterface {
    * @deprecated This method won't be supported, use Account.deploy instead
    */
   public async deployContract(
-    payload: DeployContractPayload,
+    payload: DeployContractPayload | any,
     details: InvocationsDetails
   ): Promise<DeployContractResponse> {
     return this.provider.deployContract(payload, details);

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -35,11 +35,14 @@ export class Provider implements ProviderInterface {
   private provider!: ProviderInterface;
 
   constructor(providerOrOptions?: ProviderOptions | ProviderInterface) {
-    if (
+    if (providerOrOptions instanceof Provider) {
+      // providerOrOptions is Provider
+      this.provider = providerOrOptions.provider;
+    } else if (
       providerOrOptions instanceof RpcProvider ||
       providerOrOptions instanceof SequencerProvider
     ) {
-      // providerOrOptions is provider
+      // providerOrOptions is SequencerProvider or RpcProvider
       this.provider = <ProviderInterface>providerOrOptions;
     } else if (providerOrOptions && 'rpc' in providerOrOptions) {
       // providerOrOptions is rpc option

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -35,13 +35,20 @@ export class Provider implements ProviderInterface {
   private provider!: ProviderInterface;
 
   constructor(providerOrOptions?: ProviderOptions | ProviderInterface) {
-    if (providerOrOptions && 'chainId' in providerOrOptions) {
-      this.provider = providerOrOptions;
-    } else if (providerOrOptions?.rpc) {
-      this.provider = new RpcProvider(providerOrOptions.rpc);
-    } else if (providerOrOptions?.sequencer) {
-      this.provider = new SequencerProvider(providerOrOptions.sequencer);
+    if (
+      providerOrOptions instanceof RpcProvider ||
+      providerOrOptions instanceof SequencerProvider
+    ) {
+      // providerOrOptions is provider
+      this.provider = <ProviderInterface>providerOrOptions;
+    } else if (providerOrOptions && 'rpc' in providerOrOptions) {
+      // providerOrOptions is rpc option
+      this.provider = new RpcProvider(<RpcProviderOptions>providerOrOptions.rpc);
+    } else if (providerOrOptions && 'sequencer' in providerOrOptions) {
+      // providerOrOptions is sequencer option
+      this.provider = new SequencerProvider(<SequencerProviderOptions>providerOrOptions.sequencer);
     } else {
+      // providerOrOptions is none, create SequencerProvider as default
       this.provider = new SequencerProvider();
     }
   }
@@ -180,7 +187,7 @@ export class Provider implements ProviderInterface {
     return this.provider.getCode(contractAddress, blockIdentifier);
   }
 
-  public async waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<void> {
+  public async waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<any> {
     return this.provider.waitForTransaction(txHash, retryInterval);
   }
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -291,5 +291,5 @@ export abstract class ProviderInterface {
    * @param txHash - transaction hash
    * @param retryInterval - retry interval
    */
-  public abstract waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<void>;
+  public abstract waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<any>;
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -288,6 +288,10 @@ export abstract class ProviderInterface {
    * Wait for the transaction to be accepted
    * @param txHash - transaction hash
    * @param retryInterval - retry interval
+   * @return GetTransactionReceiptResponse
    */
-  public abstract waitForTransaction(txHash: BigNumberish, retryInterval?: number): Promise<any>;
+  public abstract waitForTransaction(
+    txHash: BigNumberish,
+    retryInterval?: number
+  ): Promise<GetTransactionReceiptResponse>;
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -149,7 +149,7 @@ export abstract class ProviderInterface {
    * @returns a confirmation of sending a transaction on the starknet contract
    */
   public abstract deployContract(
-    payload: DeployContractPayload,
+    payload: DeployContractPayload | any,
     details?: InvocationsDetails
   ): Promise<DeployContractResponse>;
 

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -405,7 +405,7 @@ export class RpcProvider implements ProviderInterface {
   public async waitForTransaction(txHash: string, retryInterval: number = 8000) {
     let { retries } = this;
     let onchain = false;
-    let txReceipt;
+    let txReceipt: any = {};
 
     while (!onchain) {
       const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -407,7 +407,7 @@ export class RpcProvider implements ProviderInterface {
   public async waitForTransaction(txHash: string, retryInterval: number = 8000) {
     let { retries } = this;
     let onchain = false;
-    let res;
+    let txReceipt;
 
     while (!onchain) {
       const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];
@@ -417,19 +417,19 @@ export class RpcProvider implements ProviderInterface {
       await wait(retryInterval);
       try {
         // eslint-disable-next-line no-await-in-loop
-        res = await this.getTransactionReceipt(txHash);
+        txReceipt = await this.getTransactionReceipt(txHash);
 
-        if (!('status' in res)) {
+        if (!('status' in txReceipt)) {
           const error = new Error('pending transaction');
           throw error;
         }
 
-        if (res.status && successStates.includes(res.status)) {
+        if (txReceipt.status && successStates.includes(txReceipt.status)) {
           onchain = true;
-        } else if (res.status && errorStates.includes(res.status)) {
-          const message = res.status;
+        } else if (txReceipt.status && errorStates.includes(txReceipt.status)) {
+          const message = txReceipt.status;
           const error = new Error(message) as Error & { response: any };
-          error.response = res;
+          error.response = txReceipt;
           throw error;
         }
       } catch (error: unknown) {
@@ -446,7 +446,7 @@ export class RpcProvider implements ProviderInterface {
     }
 
     await wait(retryInterval);
-    return res;
+    return txReceipt;
   }
 
   /**

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -407,6 +407,7 @@ export class RpcProvider implements ProviderInterface {
   public async waitForTransaction(txHash: string, retryInterval: number = 8000) {
     let { retries } = this;
     let onchain = false;
+    let res;
 
     while (!onchain) {
       const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];
@@ -416,7 +417,7 @@ export class RpcProvider implements ProviderInterface {
       await wait(retryInterval);
       try {
         // eslint-disable-next-line no-await-in-loop
-        const res = await this.getTransactionReceipt(txHash);
+        res = await this.getTransactionReceipt(txHash);
 
         if (!('status' in res)) {
           const error = new Error('pending transaction');
@@ -445,6 +446,7 @@ export class RpcProvider implements ProviderInterface {
     }
 
     await wait(retryInterval);
+    return res;
   }
 
   /**

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -450,12 +450,13 @@ export class SequencerProvider implements ProviderInterface {
 
   public async waitForTransaction(txHash: BigNumberish, retryInterval: number = 8000) {
     let onchain = false;
+    let res;
 
     while (!onchain) {
       // eslint-disable-next-line no-await-in-loop
       await wait(retryInterval);
       // eslint-disable-next-line no-await-in-loop
-      const res = await this.getTransactionStatus(txHash);
+      res = await this.getTransactionStatus(txHash);
 
       const successStates = ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2', 'PENDING'];
       const errorStates = ['REJECTED', 'NOT_RECEIVED'];
@@ -471,6 +472,7 @@ export class SequencerProvider implements ProviderInterface {
         throw error;
       }
     }
+    return res;
   }
 
   /**

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -472,7 +472,8 @@ export class SequencerProvider implements ProviderInterface {
         throw error;
       }
     }
-    return res;
+    const txReceipt = await this.getTransactionReceipt(txHash);
+    return txReceipt;
   }
 
   /**

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -2,7 +2,7 @@ import BN from 'bn.js';
 
 import { BlockIdentifier } from '../provider/utils';
 import { BigNumberish } from '../utils/number';
-import { EstimateFeeResponse } from './provider';
+import { DeclareTransactionReceiptResponse, EstimateFeeResponse } from './provider';
 
 export interface EstimateFee extends EstimateFeeResponse {
   suggestedMaxFee: BN;
@@ -12,3 +12,23 @@ export interface EstimateFeeDetails {
   nonce?: BigNumberish;
   blockIdentifier?: BlockIdentifier;
 }
+
+export interface DeployContractResponse {
+  contract_address: string;
+  transaction_hash: string;
+}
+
+export interface DeployContract2Response extends DeployContractResponse {
+  address: string;
+  deployer: string;
+  unique: string;
+  classHash: string;
+  calldata_len: string;
+  calldata: Array<string>;
+  salt: string;
+}
+
+export type DeclareDeployContractResponse = {
+  declare: DeclareTransactionReceiptResponse;
+  deploy: DeployContract2Response;
+};

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -18,7 +18,7 @@ export interface DeployContractResponse {
   transaction_hash: string;
 }
 
-export interface DeployContract2Response extends DeployContractResponse {
+export interface DeployContractUDCResponse extends DeployContractResponse {
   address: string;
   deployer: string;
   unique: string;
@@ -30,5 +30,5 @@ export interface DeployContract2Response extends DeployContractResponse {
 
 export type DeclareDeployContractResponse = {
   declare: DeclareTransactionReceiptResponse;
-  deploy: DeployContract2Response;
+  deploy: DeployContractUDCResponse;
 };

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -27,12 +27,6 @@ export type UniversalDeployerContractPayload = {
   additionalCalls?: AllowArray<Call>; // support multicall
 };
 
-export type DeployContractPayload = {
-  contract: CompiledContract | string;
-  constructorCalldata?: RawCalldata;
-  addressSalt?: string;
-};
-
 export type DeployAccountContractPayload = {
   classHash: BigNumberish;
   constructorCalldata?: RawCalldata;
@@ -51,6 +45,9 @@ export type DeclareContractPayload = {
   contract: CompiledContract | string;
   classHash: BigNumberish; // Once the classHash is included in CompiledContract, this can be removed
 };
+
+export type DeclareDeployContractPayload = DeclareContractPayload &
+  UniversalDeployerContractPayload;
 
 export type DeclareContractTransaction = {
   contractDefinition: ContractClass;

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -21,8 +21,8 @@ export interface ContractClass {
 
 export type UniversalDeployerContractPayload = {
   classHash: BigNumberish;
-  salt: string;
-  unique: boolean;
+  salt?: string;
+  unique?: boolean;
   constructorCalldata?: RawArgs;
   additionalCalls?: AllowArray<Call>; // support multicall
 };

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -27,6 +27,12 @@ export type UniversalDeployerContractPayload = {
   additionalCalls?: AllowArray<Call>; // support multicall
 };
 
+export type DeployContractPayload = {
+  contract: CompiledContract | string;
+  constructorCalldata?: RawCalldata;
+  addressSalt?: string;
+};
+
 export type DeployAccountContractPayload = {
   classHash: BigNumberish;
   constructorCalldata?: RawCalldata;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -106,21 +106,6 @@ export interface InvokeFunctionResponse {
   transaction_hash: string;
 }
 
-export interface DeployContractResponse {
-  contract_address: string;
-  transaction_hash: string;
-}
-
-export interface AccountDeployContractResponse extends DeployContractResponse {
-  address: string;
-  deployer: string;
-  unique: string;
-  classHash: string;
-  calldata_len: string;
-  calldata: Array<string>;
-  salt: string;
-}
-
 export interface DeclareContractResponse {
   transaction_hash: string;
   class_hash: string;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -111,6 +111,16 @@ export interface DeployContractResponse {
   transaction_hash: string;
 }
 
+export interface AccountDeployContractResponse extends DeployContractResponse {
+  address: string;
+  deployer: string;
+  unique: string;
+  classHash: string;
+  calldata_len: string;
+  calldata: Array<string>;
+  salt: string;
+}
+
 export interface DeclareContractResponse {
   transaction_hash: string;
   class_hash: string;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,32 @@
+import { UDC } from '../constants';
+import { InvokeTransactionReceiptResponse } from '../types/provider';
+import { cleanHex } from './number';
+
+/**
+ * Parse Transaction Receipt Event from UDC invoke transaction and
+ * create DeployContractResponse compatibile response with adition of UDC Event data
+ *
+ * @param txReceipt
+ * @returns DeployContractResponse | UDC Event Response data
+ */
+export function parseUDCEvent(txReceipt: InvokeTransactionReceiptResponse) {
+  if (!txReceipt.events) {
+    throw new Error('UDC emited event is empty');
+  }
+  const event = txReceipt.events.find(
+    (it) => cleanHex(it.from_address) === cleanHex(UDC.ADDRESS)
+  ) || {
+    data: [],
+  };
+  return {
+    transaction_hash: txReceipt.transaction_hash,
+    contract_address: event.data[0],
+    address: event.data[0],
+    deployer: event.data[1],
+    unique: event.data[2],
+    classHash: event.data[3],
+    calldata_len: event.data[4],
+    calldata: event.data.slice(5, 5 + parseInt(event.data[4], 16)),
+    salt: event.data[event.data.length - 1],
+  };
+}

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -34,6 +34,12 @@ export function toFelt(num: BigNumberish): string {
   return toBN(num).toString();
 }
 
+/**
+ * Remove hex string leading zero and lower case '0x01A'.. -> '0x1a..'
+ * @param hex string
+ */
+export const cleanHex = (hex: string) => hex.toLowerCase().replace(/^(0x)0+/, '$1');
+
 /*
  Asserts input is equal to or greater then lowerBound and lower then upperBound.
  Assert message specifies inputName.

--- a/www/docs/API/account.md
+++ b/www/docs/API/account.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 An Account extends <ins>[`Provider`](/docs/API/provider)</ins> and inherits all of its methods.
 
-It also introduces new methods that allow Accounts to create and verify signatures with a custom <ins>[`Signer`](/docs/API/signer)</ins>.
+It also introduces new methods that allow Accounts to create and verify signatures with a custom <ins>[`Signer`](/docs/API/signer)</ins>, declare and deploy Contract and deploy new Account
 
 This API is the primary way to interact with an account contract on StarkNet.
 
@@ -89,7 +89,7 @@ The _estimateFeeDetails_ object may include any of:
 
 account.**estimateAccountDeployFee**(contractPayload [ , estimateFeeDetails ]) => _Promise < EstimateFeeResponse >_
 
-Estimate Fee for executing a DEPLOY_ACCOUNT transaction on starknet
+Estimate Fee for executing a DEPLOY_ACCOUNT transaction on StarkNet
 
 The _contractPayload_ object structure:
 
@@ -142,6 +142,8 @@ The _transactionsDetail_ object may include any of:
 
 <hr />
 
+### Declare
+
 account.**declare**(contractPayload [ , transactionsDetail ]) => _Promise < DeclareContractResponse >_
 
 Declares a given compiled contract (json) to starknet.
@@ -179,6 +181,158 @@ const declareTx = await account.declare({
 ```
 
 <hr />
+
+### Deploy
+
+Deploys a given compiled contract (json) to starknet, wrapper around _execute_ invoke function
+
+**deploy**(deployContractPayload [ , transactionsDetail ]) => _Promise < InvokeFunctionResponse >_
+
+@param object **_deployContractPayload_**
+
+- **classHash**: computed class hash of compiled contract
+- **constructorCalldata**: constructor calldata
+- optional salt: address salt - default random
+- optional unique: bool if true ensure unique salt - default true
+- optional additionalCalls - optional additional calls array to support multi-call
+
+@param object **transactionsDetail** Invocation Details
+
+- optional nonce
+- optional version
+- optional maxFee
+
+@returns **transaction_hash**
+
+Example:
+
+```typescript
+  const deployment = await account.deploy({
+    classHash: erc20ClassHash,
+    constructorCalldata: [
+      encodeShortString('Token'),
+      encodeShortString('ERC20'),
+      account.address,
+    ],
+    salt: randomAddress(),
+    unique: true, // Using true here so as not to clash with normal erc20 deploy in account and provider test
+  });
+
+  await provider.waitForTransaction(deployment.transaction_hash);
+```
+
+Example multi-call:
+
+```typescript
+TODO Example with multi-call
+```
+
+<hr />
+
+### DeployContract
+
+✅ NEW
+High level wrapper for deploy. Doesn't require waitForTransaction. Response similar to deprecated provider deployContract.
+
+**deployContract**(payload [ , details ]) => _Promise < DeployContractUDCResponse >_
+
+@param object **_payload_** UniversalDeployerContractPayload
+
+- **classHash**: computed class hash of compiled contract
+- **constructorCalldata**: constructor calldata
+- optional salt: address salt - default random
+- optional unique: bool if true ensure unique salt - default true
+- optional additionalCalls - optional additional calls array to support multi-call
+
+@param object **details** InvocationsDetails
+
+- optional nonce
+- optional version
+- optional maxFee
+
+@returns Promise DeployContractUDCResponse
+
+- contract_address
+- transaction_hash
+- address
+- deployer
+- unique
+- classHash
+- calldata_len
+- calldata
+- salt
+
+Example:
+
+```typescript
+  const deployResponse = await account.deployContract({
+    classHash: erc20ClassHash,
+    constructorCalldata: [
+      encodeShortString('Token'),
+      encodeShortString('ERC20'),
+      account.address,
+    ],
+  });
+```
+
+<hr />
+
+### DeclareDeploy
+
+✅ NEW
+High level wrapper for declare & deploy. Doesn't require waitForTransaction. Functionality similar to deprecated provider deployContract. Declare and Deploy contract using single function.
+
+**declareDeploy**(payload [ , details ]) => _Promise < DeclareDeployContractResponse >_
+
+@param object **_payload_** DeclareDeployContractPayload
+
+- **contract**: compiled contract code
+- **classHash**: computed class hash of compiled contract
+- optional constructorCalldata: constructor calldata
+- optional salt: address salt - default random
+- optional unique: bool if true ensure unique salt - default true
+- optional additionalCalls - optional additional calls array to support multi-call
+
+@param object **details** InvocationsDetails
+
+- optional nonce
+- optional version
+- optional maxFee
+
+@returns Promise object DeclareDeployContractResponse
+
+- declare: CommonTransactionReceiptResponse
+  - transaction_hash
+- deploy: DeployContractUDCResponse;
+  - contract_address
+  - transaction_hash
+  - address
+  - deployer
+  - unique
+  - classHash
+  - calldata_len
+  - calldata
+  - salt
+  <hr />
+
+Example:
+
+```typescript
+  const declareDeploy = await account.declareDeploy({
+    contract: compiledErc20,
+    classHash: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+    constructorCalldata: [
+      encodeShortString('Token'),
+      encodeShortString('ERC20'),
+      account.address,
+    ],
+  });
+
+  const declareTransactionHash = declareDeploy.declare.transaction_hash
+  const erc20Address = declareDeploy.deploy.contract_address;
+```
+
+### deployAccount
 
 account.**deployAccount**(contractPayload [ , transactionsDetail ]) => _Promise < DeployContractResponse >_
 

--- a/www/docs/API/contractFactory.md
+++ b/www/docs/API/contractFactory.md
@@ -8,33 +8,29 @@ Contract Factory allow you to deploy contracts to StarkNet. To deploy a Contract
 
 ## Creating an instance
 
-`new starknet.ContractFactory( compiledContract , providerOrAccount, [ , abi ] )`
+`new starknet.ContractFactory( compiledContract, classHash, account, [ , abi ] )`
 
 Creates a new instance of a ContractFactory for the contract described by the _compiledContract_.
 
-`contractFactory.connect(providerOrAccount)` _for changing the provider or account_
+`contractFactory.connect(account)` _for changing the provider or account_
 
 `contractFactory.attach(address)` _for changing the address of the connected contract factory_
 
 ## Properties
 
-contractFactory.**abi** => _Abi_
+contractFactory.**compiledContract** => _CompiledContract_ (the compiled contract the contractFactory was constructed with)
 
-The ABI the contractFactory was constructed with.
+contractFactory.**classHash** => _string_ (contract classHash can be obtained using tool for compiling contract)
 
-contractFactory.**compiledContract** => _CompiledContract_
+contractFactory.**account** => _AccountInterface_ (account that are used to interact with the network)
 
-The compiled contract the contractFactory was constructed with.
-
-contractFactory.**providerOrAccount** => _ProviderInterface | AccountInterface_
-
-Provider or account that are used to interact with the network.
+contractFactory.**abi** => _Abi_ (the ABI the contractFactory was constructed with)
 
 ## Methods
 
 contractFactory.**attach**( address ) ⇒ _Contract_
 
-Return an instance of a _Contract_ attached to address. This is the same as using the _Contract_ constructor with address and this _compiledContract_ and _providerOrAccount_ passed in when creating the ContractFactory.
+Return an instance of a _Contract_ attached to address. This is the same as using the _Contract_ constructor with address and this _compiledContract_ and _account_ passed in when creating the ContractFactory.
 
 <hr />
 

--- a/www/docs/API/provider.md
+++ b/www/docs/API/provider.md
@@ -242,7 +242,9 @@ Estimate fee for declare transaction.
 
 <hr/>
 
-provider.**waitForTransaction**(txHash [ , retryInterval]) => _Promise < void >_
+### waitForTransaction
+
+provider.**waitForTransaction**(txHash [ , retryInterval]) => _Promise < GetTransactionReceiptResponse >_
 
 Wait for the transaction to be accepted on L2 or L1.
 

--- a/www/docs/API/utils.md
+++ b/www/docs/API/utils.md
@@ -136,6 +136,14 @@ Converts BN to hex.
 
 Returns a string.
 
+### cleanHex
+
+`cleanHex(hex: string): string`
+
+Remove leading zeroes and lowercase hex string after '0x'
+
+`0x01AFF` -> `0x1aff`
+
 ### hexToDecimalString
 
 `hexToDecimalString(hex: string): string`

--- a/www/guides/account.md
+++ b/www/guides/account.md
@@ -35,6 +35,8 @@ const starkKeyPub = ec.getStarkKey(starkKeyPair);
 
 ## Deploy Account Contract
 
+🐛 Deprecated: TODO: Refactor with account deployContract
+
 Deploy the Account contract and wait for it to be verified on StarkNet.
 
 ```javascript

--- a/www/guides/erc20.md
+++ b/www/guides/erc20.md
@@ -4,6 +4,8 @@ sidebar_position: 3
 
 # Deploy an ERC20 Contract
 
+🐛 Outdated TODO Fix - defaultProvider.deployContract is not supported anymore
+
 Deploy the contract and wait for deployment transaction to be accepted on StarkNet
 
 ```javascript


### PR DESCRIPTION
## Motivation and Resolution
**Starknet alpha v0.10.3**
Provider.deployContract removal, deploy need to be done true Account

**Account.deploy** -> low level deploy contract, return transaction_hash

NEW **Account.deployContract**  -> high-level deploy (doesn't require waitForTransaction)
- required params: `classHash`
- return: `same data as provider.deployContract + UDC specific data`

NEW **Account.declareDeploy** -> high-level  declare & deploy (doesn't require waitForTransaction)
- required params: `same as provider.deployContract + classHash`
- return: 
```js
{
    declare: TransactionReceiptResponse,
    deploy: "same data as provider.deployContract + UDC specific data"
 }
 ```

- [x] Fixed Provider Constructor + added Provider.provider case when pass instance of Provider (from Account). 
- [x] Added default random Salt on account.deploy when not provided (prevent error for same addresses). 
- [x] Added response from waitForTransactions returning transaction Receipt (seq == rpc). 
- [x] Fix Fixtures bug on local devnet Sequencer test. 
- [x] Cleanup Fixtures. 
- [x] Remove Provider.deployContract and used Account.declareDeploy in all tests. 
- [x] Cleanup Tests. 
- [x] Added numbers.cleanHex -> lowercase and remove trailing hex zeroes (devnet - testnet response diff 0x01 -> 0x1). 
- [x] Refactor contract factory with account.deployContract
- [x] Remove Provider.deployContract in separate PR. 

Open Questions:
Should Account.deployContract & Account.declareDeploy be part of Account or contractFactory?

### RPC version (if applicable)
0.2.1

## Usage-related changes
- [x] waitForTransaction return TransactionReceipt on completion

## Development-related changes
Switch to Account.deploy or  Account.deployContract or Account.declareDeploy from provider.deployContract

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
