### PR TITLE
fix: properly parse blockIdentifier in buildCall function

### DIFF
--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -9,6 +9,7 @@ import {
   AbiEntry,
   Args,
   AsyncContractFunction,
+  BlockTag,
   Call,
   Calldata,
   ContractFunction,
@@ -36,7 +37,15 @@ function parseFelt(candidate: string): BN {
  */
 function buildCall(contract: Contract, functionAbi: FunctionAbi): AsyncContractFunction {
   return async function (...args: Array<any>): Promise<any> {
-    return contract.call(functionAbi.name, args);
+    let blockIdentifier: BlockTag | null = null;
+
+    args.forEach((arg) => {
+      if (arg.blockIdentifier) {
+        blockIdentifier = arg.blockIdentifier;
+      }
+    });
+
+    return contract.call(functionAbi.name, args, { blockIdentifier });
   };
 }
 


### PR DESCRIPTION
## Motivation and Resolution

When I try to pass BlockIdentifier 'latest' to contract call, Starknet.js still uses 'pending'

### RPC version (if applicable)

n/a

## Usage related changes

- When users want to fetch data from 'latest' block, Starknet.js will properly use 'latest' BlockIdentifier.

## Development related changes

n/a

## Issue

https://github.com/0xs34n/starknet.js/issues/419

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
