### PR TITLE
Feat/sequencer network chainid

### DIFF
--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -46,7 +46,7 @@ import { Block, BlockIdentifier } from './utils';
 type NetworkName = 'mainnet-alpha' | 'goerli-alpha' | 'goerli-alpha-2';
 
 export type SequencerProviderOptions =
-  | { network: NetworkName }
+  | { network: NetworkName | StarknetChainId }
   | {
       baseUrl: string;
       feederGatewayUrl?: string;
@@ -104,13 +104,13 @@ export class SequencerProvider implements ProviderInterface {
     }
   }
 
-  protected static getNetworkFromName(name: NetworkName) {
+  protected static getNetworkFromName(name: NetworkName | StarknetChainId) {
     switch (name) {
-      case 'mainnet-alpha':
+      case 'mainnet-alpha' || StarknetChainId.MAINNET:
         return 'https://alpha-mainnet.starknet.io';
-      case 'goerli-alpha':
+      case 'goerli-alpha' || StarknetChainId.TESTNET:
         return 'https://alpha4.starknet.io';
-      case 'goerli-alpha-2':
+      case 'goerli-alpha-2' || StarknetChainId.TESTNET2:
         return 'https://alpha4-2.starknet.io';
       default:
         return 'https://alpha4.starknet.io';

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -45,15 +45,6 @@ import { Block, BlockIdentifier } from './utils';
 
 type NetworkName = 'mainnet-alpha' | 'goerli-alpha' | 'goerli-alpha-2';
 
-function isEmptyQueryObject(obj?: Record<any, any>): obj is undefined {
-  return (
-    obj === undefined ||
-    Object.keys(obj).length === 0 ||
-    (Object.keys(obj).length === 1 &&
-      Object.entries(obj).every(([k, v]) => k === 'blockIdentifier' && v === null))
-  );
-}
-
 export type SequencerProviderOptions =
   | { network: NetworkName }
   | {
@@ -63,6 +54,19 @@ export type SequencerProviderOptions =
       chainId?: StarknetChainId;
       headers?: object;
     };
+
+function isEmptyQueryObject(obj?: Record<any, any>): obj is undefined {
+  return (
+    obj === undefined ||
+    Object.keys(obj).length === 0 ||
+    (Object.keys(obj).length === 1 &&
+      Object.entries(obj).every(([k, v]) => k === 'blockIdentifier' && v === null))
+  );
+}
+
+const defaultOptions: SequencerProviderOptions = {
+  network: 'goerli-alpha-2',
+};
 
 export class SequencerProvider implements ProviderInterface {
   public baseUrl: string;
@@ -77,7 +81,7 @@ export class SequencerProvider implements ProviderInterface {
 
   private responseParser = new SequencerAPIResponseParser();
 
-  constructor(optionsOrProvider: SequencerProviderOptions = { network: 'goerli-alpha-2' }) {
+  constructor(optionsOrProvider: SequencerProviderOptions = defaultOptions) {
     if ('network' in optionsOrProvider) {
       this.baseUrl = SequencerProvider.getNetworkFromName(optionsOrProvider.network);
       this.chainId = SequencerProvider.getChainIdFromBaseUrl(this.baseUrl);
@@ -118,6 +122,9 @@ export class SequencerProvider implements ProviderInterface {
       const url = new URL(baseUrl);
       if (url.host.includes('mainnet.starknet.io')) {
         return StarknetChainId.MAINNET;
+      }
+      if (url.host.includes('alpha4-2.starknet.io')) {
+        return StarknetChainId.TESTNET2;
       }
     } catch {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Motivation and Resolution
Fix https://github.com/0xs34n/starknet.js/issues/401
No breaking changes just extends existing functionality

## Usage related changes
Enable usage of ChainId in network parameter when creating a new Sequencer provider.

## Development related changes
`new Provider({ sequencer: { network: "mainnet-alpha" | "goerli-alpha" | "goerli-alpha-2" } })`
Now you can do also
`new Provider({ sequencer: { network: "0x534e5f4d41494e" | "0x534e5f474f45524c49" | "0x534e5f474f45524c4932" } })`
Or
`new Provider({ sequencer: { network: StarknetChainId.MAINNET | StarknetChainId.TESTNET | StarknetChainId.TESTNET2 } })`

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->


## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [ ] All tests are passing
