### PR TITLE
feat: return precalculated address from deploy, reimplement multi-deploy

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -322,7 +322,6 @@ describe('deploy and test Wallet', () => {
     });
 
     test('UDC multi Deploy', async () => {
-      // TODO: add test with multiple deploys
       const deployments = await account.deploy([
         {
           classHash: '0x04367b26fbb92235e8d1137d19c080e6e650a6889ded726d00658411cc1046f5',

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -4,7 +4,7 @@ import typedDataExample from '../__mocks__/typedDataExample.json';
 import { Account, Contract, Provider, number, stark } from '../src';
 import { parseUDCEvent } from '../src/utils/events';
 import { feeTransactionVersion } from '../src/utils/hash';
-import { hexToDecimalString, toBN } from '../src/utils/number';
+import { cleanHex, hexToDecimalString, toBN } from '../src/utils/number';
 import { encodeShortString } from '../src/utils/shortString';
 import { randomAddress } from '../src/utils/stark';
 import {
@@ -284,7 +284,7 @@ describe('deploy and test Wallet', () => {
       // check pre-calculated address
       const txReceipt = await provider.waitForTransaction(deployment.transaction_hash);
       const udcEvent = parseUDCEvent(txReceipt);
-      expect(deployment.contract_address).toBe(udcEvent.contract_address);
+      expect(cleanHex(deployment.contract_address[0])).toBe(cleanHex(udcEvent.contract_address));
     });
 
     test('UDC Deploy non-unique', async () => {
@@ -305,7 +305,27 @@ describe('deploy and test Wallet', () => {
       // check pre-calculated address
       const txReceipt = await provider.waitForTransaction(deployment.transaction_hash);
       const udcEvent = parseUDCEvent(txReceipt);
-      expect(deployment.contract_address).toBe(udcEvent.contract_address);
+      expect(cleanHex(deployment.contract_address[0])).toBe(cleanHex(udcEvent.contract_address));
+    });
+
+    test('UDC multi Deploy', async () => {
+      // TODO: add test with multiple deploys
+      const deployments = await account.deploy([
+        {
+          classHash: '0x04367b26fbb92235e8d1137d19c080e6e650a6889ded726d00658411cc1046f5',
+        },
+        {
+          classHash: erc20ClassHash,
+          constructorCalldata: [
+            encodeShortString('Token'),
+            encodeShortString('ERC20'),
+            account.address,
+          ],
+        },
+      ]);
+      expect(deployments).toHaveProperty('transaction_hash');
+      expect(deployments.contract_address[0]).toBeDefined();
+      expect(deployments.contract_address[1]).toBeDefined();
     });
   });
 });

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -12,6 +12,7 @@ import {
   DeclareContractPayload,
   DeclareContractResponse,
   DeclareDeployContractPayload,
+  DeclareDeployUDCResponse,
   DeployAccountContractPayload,
   DeployContractResponse,
   DeployContractUDCResponse,
@@ -321,7 +322,7 @@ export class Account extends Provider implements AccountInterface {
 
   public async deploy(
     payload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
-    details: InvocationsDetails = {}
+    details?: InvocationsDetails | undefined
   ): Promise<MultiDeployContractResponse> {
     const params = [].concat(payload as []).map((it) => {
       const {
@@ -366,8 +367,8 @@ export class Account extends Provider implements AccountInterface {
   }
 
   public async deployContract(
-    payload: UniversalDeployerContractPayload,
-    details: InvocationsDetails = {}
+    payload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
+    details?: InvocationsDetails | undefined
   ): Promise<DeployContractUDCResponse> {
     const deployTx = await this.deploy(payload, details);
     const txReceipt = await this.waitForTransaction(deployTx.transaction_hash, undefined, [
@@ -377,9 +378,10 @@ export class Account extends Provider implements AccountInterface {
   }
 
   public async declareDeploy(
-    { classHash, contract, constructorCalldata, salt, unique }: DeclareDeployContractPayload,
-    details?: InvocationsDetails
-  ) {
+    payload: DeclareDeployContractPayload,
+    details?: InvocationsDetails | undefined
+  ): Promise<DeclareDeployUDCResponse> {
+    const { classHash, contract, constructorCalldata, salt, unique } = payload;
     const { transaction_hash } = await this.declare({ contract, classHash }, details);
     const declare = await this.waitForTransaction(transaction_hash, undefined, ['ACCEPTED_ON_L2']);
     const deploy = await this.deployContract(

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -8,7 +8,7 @@ import {
   DeclareContractPayload,
   DeclareContractResponse,
   DeclareDeployContractPayload,
-  DeclareDeployContractResponse,
+  DeclareDeployUDCResponse,
   DeployAccountContractPayload,
   DeployContractResponse,
   DeployContractUDCResponse,
@@ -144,40 +144,41 @@ export abstract class AccountInterface extends ProviderInterface {
   ): Promise<DeclareContractResponse>;
 
   /**
-   * Deploys a given compiled contract (json) to starknet using Universal Deployer Contract (UDC)
-   * This is different from the normal DEPLOY transaction as it goes through the Universal Deployer Contract (UDC)
+   * Deploys a declared contract to starknet - using Universal Deployer Contract (UDC)
+   * support multicall
    *
-   * @param deployContractPayload array or object containing
+   * @param payload -
    * - classHash: computed class hash of compiled contract
-   * - constructorCalldata: constructor calldata
-   * - optional salt: address salt - default random
-   * - optional unique: bool if true ensure unique salt - default true
-   * @param transactionsDetail Invocation Details containing:
-   *  - optional nonce
-   *  - optional version
-   *  - optional maxFee
-   * @returns Promise<MultiDeployContractResponse>
-   *  - transaction_hash
+   * - [constructorCalldata] contract constructor calldata
+   * - [salt=pseudorandom] deploy address salt
+   * - [unique=true] ensure unique salt
+   * @param details -
+   * - [nonce=getNonce]
+   * - [version=transactionVersion]
+   * - [maxFee=getSuggestedMaxFee]
+   * @returns
+   * - contract_address[]
+   * - transaction_hash
    */
   public abstract deploy(
-    deployContractPayload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
-    transactionsDetail?: InvocationsDetails
+    payload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
+    details?: InvocationsDetails | undefined
   ): Promise<MultiDeployContractResponse>;
 
   /**
    * Simplify deploy simulating old DeployContract with same response + UDC specific response
+   * Internal wait for L2 transaction, support multicall
    *
-   * @param payload UniversalDeployerContractPayload
-   *  - classHash: computed class hash of compiled contract
-   *  - constructorCalldata: constructor calldata
-   *  - optional salt: address salt - default random
-   *  - optional unique: bool if true ensure unique salt - default true
-   *  - optional additionalCalls - optional additional calls array to support multi-call
-   * @param details InvocationsDetails
-   *  - optional nonce
-   *  - optional version
-   *  - optional maxFee
-   * @returns Promise<DeployContractUDCResponse>
+   * @param payload -
+   * - classHash: computed class hash of compiled contract
+   * - [constructorCalldata] contract constructor calldata
+   * - [salt=pseudorandom] deploy address salt
+   * - [unique=true] ensure unique salt
+   * @param details -
+   * - [nonce=getNonce]
+   * - [version=transactionVersion]
+   * - [maxFee=getSuggestedMaxFee]
+   * @returns
    *  - contract_address
    *  - transaction_hash
    *  - address
@@ -189,25 +190,25 @@ export abstract class AccountInterface extends ProviderInterface {
    *  - salt
    */
   public abstract deployContract(
-    payload: UniversalDeployerContractPayload,
-    details: InvocationsDetails
+    payload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
+    details?: InvocationsDetails | undefined
   ): Promise<DeployContractUDCResponse>;
 
   /**
    * Declares and Deploy a given compiled contract (json) to starknet using UDC
+   * Internal wait for L2 transaction, do not support multicall
    *
-   * @param declareDeployerContractPayload containing
+   * @param  containing
    * - contract: compiled contract code
    * - classHash: computed class hash of compiled contract
-   * - optional constructorCalldata: constructor calldata
-   * - optional salt: address salt - default random
-   * - optional unique: bool if true ensure unique salt - default true
-   * - optional additionalCalls: - optional additional calls array to support multicall
+   * - [constructorCalldata] contract constructor calldata
+   * - [salt=pseudorandom] deploy address salt
+   * - [unique=true] ensure unique salt
    * @param details
-   * - optional nonce
-   * - optional version
-   * - optional maxFee
-   * @returns Promise<DeclareDeployContractResponse>
+   * - [nonce=getNonce]
+   * - [version=transactionVersion]
+   * - [maxFee=getSuggestedMaxFee]
+   * @returns
    * - declare
    *    - transaction_hash
    * - deploy
@@ -222,9 +223,9 @@ export abstract class AccountInterface extends ProviderInterface {
    *    - salt
    */
   public abstract declareDeploy(
-    declareDeployerContractPayload: DeclareDeployContractPayload,
-    details?: InvocationsDetails
-  ): Promise<DeclareDeployContractResponse>;
+    payload: DeclareDeployContractPayload,
+    details?: InvocationsDetails | undefined
+  ): Promise<DeclareDeployUDCResponse>;
 
   /**
    * Deploy the account on Starknet

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -96,7 +96,6 @@ export abstract class AccountInterface extends ProviderInterface {
    * - salt: address salt
    * - unique: bool if true ensure unique salt
    * - calldata: constructor calldata
-   * - additionalCalls - optional additional calls array to support multicall
    * 
    * @param transactionsDetail Invocation Details containing:
    *  - optional nonce
@@ -104,7 +103,7 @@ export abstract class AccountInterface extends ProviderInterface {
    *  - optional maxFee
    */
   public abstract estimateDeployFee(
-    deployContractPayload: UniversalDeployerContractPayload,
+    deployContractPayload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
     transactionsDetail?: InvocationsDetails
   ): Promise<EstimateFeeResponse>;
 
@@ -147,12 +146,11 @@ export abstract class AccountInterface extends ProviderInterface {
    * Deploys a given compiled contract (json) to starknet using Universal Deployer Contract (UDC)
    * This is different from the normal DEPLOY transaction as it goes through the Universal Deployer Contract (UDC)
    *
-   * @param deployContractPayload containing
+   * @param deployContractPayload array or object containing
    * - classHash: computed class hash of compiled contract
    * - constructorCalldata: constructor calldata
    * - optional salt: address salt - default random
    * - optional unique: bool if true ensure unique salt - default true
-   * - optional additionalCalls - optional additional calls array to support multi-call
    * @param transactionsDetail Invocation Details containing:
    *  - optional nonce
    *  - optional version
@@ -161,7 +159,7 @@ export abstract class AccountInterface extends ProviderInterface {
    *  - transaction_hash
    */
   public abstract deploy(
-    deployContractPayload: UniversalDeployerContractPayload,
+    deployContractPayload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
     transactionsDetail?: InvocationsDetails
   ): Promise<InvokeFunctionResponse>;
 

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -17,6 +17,7 @@ import {
   EstimateFeeResponse,
   InvocationsDetails,
   InvokeFunctionResponse,
+  MultiDeployContractResponse,
   Signature,
   UniversalDeployerContractPayload,
 } from '../types';
@@ -155,13 +156,13 @@ export abstract class AccountInterface extends ProviderInterface {
    *  - optional nonce
    *  - optional version
    *  - optional maxFee
-   * @returns Promise<InvokeFunctionResponse>
+   * @returns Promise<MultiDeployContractResponse>
    *  - transaction_hash
    */
   public abstract deploy(
     deployContractPayload: UniversalDeployerContractPayload | UniversalDeployerContractPayload[],
     transactionsDetail?: InvocationsDetails
-  ): Promise<InvokeFunctionResponse>;
+  ): Promise<MultiDeployContractResponse>;
 
   /**
    * Simplify deploy simulating old DeployContract with same response + UDC specific response

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -18,6 +18,11 @@ export interface DeployContractResponse {
   transaction_hash: string;
 }
 
+export interface MultiDeployContractResponse {
+  contract_address: Array<string>;
+  transaction_hash: string;
+}
+
 export interface DeployContractUDCResponse extends DeployContractResponse {
   address: string;
   deployer: string;

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -18,12 +18,14 @@ export interface DeployContractResponse {
   transaction_hash: string;
 }
 
-export interface MultiDeployContractResponse {
+export type MultiDeployContractResponse = {
   contract_address: Array<string>;
   transaction_hash: string;
-}
+};
 
-export interface DeployContractUDCResponse extends DeployContractResponse {
+export type DeployContractUDCResponse = {
+  contract_address: string;
+  transaction_hash: string;
   address: string;
   deployer: string;
   unique: string;
@@ -31,9 +33,11 @@ export interface DeployContractUDCResponse extends DeployContractResponse {
   calldata_len: string;
   calldata: Array<string>;
   salt: string;
-}
+};
 
-export type DeclareDeployContractResponse = {
-  declare: DeclareTransactionReceiptResponse;
+export type DeclareDeployUDCResponse = {
+  declare: {
+    class_hash: BigNumberish;
+  } & DeclareTransactionReceiptResponse;
   deploy: DeployContractUDCResponse;
 };

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -24,7 +24,6 @@ export type UniversalDeployerContractPayload = {
   salt?: string;
   unique?: boolean;
   constructorCalldata?: RawArgs;
-  additionalCalls?: AllowArray<Call>; // support multicall
 };
 
 export type DeployContractPayload = {

--- a/www/docs/API/account.md
+++ b/www/docs/API/account.md
@@ -191,10 +191,9 @@ Deploys a given compiled contract (json) to starknet, wrapper around _execute_ i
 @param object **_deployContractPayload_**
 
 - **classHash**: computed class hash of compiled contract
-- **constructorCalldata**: constructor calldata
+- optional constructorCalldata: constructor calldata
 - optional salt: address salt - default random
 - optional unique: bool if true ensure unique salt - default true
-- optional additionalCalls - optional additional calls array to support multi-call
 
 @param object **transactionsDetail** Invocation Details
 
@@ -242,7 +241,6 @@ High level wrapper for deploy. Doesn't require waitForTransaction. Response simi
 - **constructorCalldata**: constructor calldata
 - optional salt: address salt - default random
 - optional unique: bool if true ensure unique salt - default true
-- optional additionalCalls - optional additional calls array to support multi-call
 
 @param object **details** InvocationsDetails
 
@@ -282,7 +280,7 @@ Example:
 ✅ NEW
 High level wrapper for declare & deploy. Doesn't require waitForTransaction. Functionality similar to deprecated provider deployContract. Declare and Deploy contract using single function.
 
-**declareDeploy**(payload [ , details ]) => _Promise < DeclareDeployContractResponse >_
+**declareDeploy**(payload [ , details ]) => _Promise < DeclareDeployUDCResponse >_
 
 @param object **_payload_** DeclareDeployContractPayload
 
@@ -291,7 +289,6 @@ High level wrapper for declare & deploy. Doesn't require waitForTransaction. Fun
 - optional constructorCalldata: constructor calldata
 - optional salt: address salt - default random
 - optional unique: bool if true ensure unique salt - default true
-- optional additionalCalls - optional additional calls array to support multi-call
 
 @param object **details** InvocationsDetails
 
@@ -299,10 +296,11 @@ High level wrapper for declare & deploy. Doesn't require waitForTransaction. Fun
 - optional version
 - optional maxFee
 
-@returns Promise object DeclareDeployContractResponse
+@returns Promise DeclareDeployUDCResponse
 
 - declare: CommonTransactionReceiptResponse
   - transaction_hash
+  - class_hash
 - deploy: DeployContractUDCResponse;
   - contract_address
   - transaction_hash


### PR DESCRIPTION
## Motivation and Resolution
Fix https://github.com/0xs34n/starknet.js/issues/442
add the precalculated address on the deploy return.

## Usage-related changes
added support for multi-deploy with singular payload. We had it before but the user would need to open the source code copy function body and basically create a call by himself and pass that to the additional parameter.



## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
