### PR TITLE
build: make the CDN entry points more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "JavaScript library for StarkNet",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "browser": "dist/index.global.js",
+  "jsdelivr": "dist/index.global.js",
+  "unpkg": "dist/index.global.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
This addresses an issue reported through Telegram where a bundling process using `browserify` internally is running into issues by attempting to rebundle the `iife` build. Normally it wouldn't make sense to address the issue in this module, however, this change should both resolve that issue and maintain the relevant functionality.