### PR TITLE
Feat/contract factory deploy args

### DIFF
--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -223,12 +223,24 @@ describe('class ContractFactory {}', () => {
   });
   test('deployment of new contract', async () => {
     const factory = new ContractFactory(compiledErc20, classHash, account);
-    const erc20 = await factory.deploy(constructorCalldata);
+    const erc20 = await factory.deploy(
+      compileCalldata({
+        name: encodeShortString('Token'),
+        symbol: encodeShortString('ERC20'),
+        recipient: wallet,
+      })
+    );
     expect(erc20 instanceof Contract);
   });
   test('wait for deployment transaction', async () => {
     const factory = new ContractFactory(compiledErc20, classHash, account);
-    const contract = await factory.deploy(constructorCalldata);
+    const contract = await factory.deploy(
+      compileCalldata({
+        name: encodeShortString('Token'),
+        symbol: encodeShortString('ERC20'),
+        recipient: wallet,
+      })
+    );
     expect(contract.deployed()).resolves.not.toThrow();
   });
   test('attach new contract', async () => {

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -385,7 +385,6 @@ export class Account extends Provider implements AccountInterface {
     return { declare: { ...declare, class_hash: classHash }, deploy };
   }
 
-
   public async deployAccount(
     {
       classHash,

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -11,7 +11,6 @@ import {
   AsyncContractFunction,
   BlockTag,
   Call,
-  Calldata,
   ContractFunction,
   FunctionAbi,
   InvokeFunctionResponse,
@@ -20,7 +19,8 @@ import {
   Result,
   StructAbi,
 } from '../types';
-import { BigNumberish, toBN, toFelt } from '../utils/number';
+import { CheckCallData } from '../utils/calldata';
+import { BigNumberish, toBN } from '../utils/number';
 import { ContractInterface } from './interface';
 
 function parseFelt(candidate: string): BN {
@@ -122,6 +122,8 @@ export class Contract implements ContractInterface {
 
   readonly [key: string]: AsyncContractFunction | any;
 
+  private checkCalldata: CheckCallData;
+
   /**
    * Contract class to handle contract methods
    *
@@ -146,6 +148,7 @@ export class Contract implements ContractInterface {
         }),
         {}
       );
+    this.checkCalldata = new CheckCallData(abi);
 
     Object.defineProperty(this, 'functions', {
       enumerable: true,
@@ -242,11 +245,11 @@ export class Contract implements ContractInterface {
     assert(this.address !== null, 'contract is not connected to an address');
 
     // validate method and args
-    this.validateMethodAndArgs('CALL', method, args);
+    this.checkCalldata.validateMethodAndArgs('CALL', method, args);
     const { inputs } = this.abi.find((abi) => abi.name === method) as FunctionAbi;
 
     // compile calldata
-    const calldata = this.compileCalldata(args, inputs);
+    const calldata = this.checkCalldata.compileCalldata(args, inputs);
     return this.providerOrAccount
       .callContract(
         {
@@ -267,7 +270,7 @@ export class Contract implements ContractInterface {
     // ensure contract is connected
     assert(this.address !== null, 'contract is not connected to an address');
     // validate method and args
-    this.validateMethodAndArgs('INVOKE', method, args);
+    this.checkCalldata.validateMethodAndArgs('INVOKE', method, args);
 
     const { inputs } = this.abi.find((abi) => abi.name === method) as FunctionAbi;
     const inputsLength = inputs.reduce((acc, input) => {
@@ -283,7 +286,7 @@ export class Contract implements ContractInterface {
       );
     }
     // compile calldata
-    const calldata = this.compileCalldata(args, inputs);
+    const calldata = this.checkCalldata.compileCalldata(args, inputs);
 
     const invocation = {
       contractAddress: this.address,
@@ -320,7 +323,7 @@ export class Contract implements ContractInterface {
     assert(this.address !== null, 'contract is not connected to an address');
 
     // validate method and args
-    this.validateMethodAndArgs('INVOKE', method, args);
+    this.checkCalldata.validateMethodAndArgs('INVOKE', method, args);
     const invocation = this.populateTransaction[method](...args);
     if ('estimateInvokeFee' in this.providerOrAccount) {
       return this.providerOrAccount.estimateInvokeFee(invocation);
@@ -333,165 +336,8 @@ export class Contract implements ContractInterface {
     return {
       contractAddress: this.address,
       entrypoint: method,
-      calldata: this.compileCalldata(args, inputs),
+      calldata: this.checkCalldata.compileCalldata(args, inputs),
     };
-  }
-
-  /**
-   * Deep parse of the object that has been passed to the method
-   *
-   * @param struct - struct that needs to be calculated
-   * @return {number} - number of members for the given struct
-   */
-  private calculateStructMembers(struct: string): number {
-    return this.structs[struct].members.reduce((acc, member) => {
-      if (member.type === 'felt') {
-        return acc + 1;
-      }
-      return acc + this.calculateStructMembers(member.type);
-    }, 0);
-  }
-
-  /**
-   * Validates if all arguments that are passed to the method are corresponding to the ones in the abi
-   *
-   * @param type - type of the method
-   * @param method  - name of the method
-   * @param args - arguments that are passed to the method
-   */
-  protected validateMethodAndArgs(type: 'INVOKE' | 'CALL', method: string, args: Array<any> = []) {
-    // ensure provided method exists
-    const invokeableFunctionNames = this.abi
-      .filter((abi) => {
-        if (abi.type !== 'function') return false;
-        const isView = abi.stateMutability === 'view';
-        return type === 'INVOKE' ? !isView : isView;
-      })
-      .map((abi) => abi.name);
-    assert(
-      invokeableFunctionNames.includes(method),
-      `${type === 'INVOKE' ? 'invokeable' : 'viewable'} method not found in abi`
-    );
-
-    // ensure args match abi type
-    const methodAbi = this.abi.find(
-      (abi) => abi.name === method && abi.type === 'function'
-    ) as FunctionAbi;
-    let argPosition = 0;
-    methodAbi.inputs.forEach((input) => {
-      if (/_len$/.test(input.name)) {
-        return;
-      }
-      if (input.type === 'felt') {
-        assert(
-          typeof args[argPosition] === 'string' ||
-            typeof args[argPosition] === 'number' ||
-            args[argPosition] instanceof BN,
-          `arg ${input.name} should be a felt (string, number, BigNumber)`
-        );
-        argPosition += 1;
-      } else if (input.type in this.structs && typeof args[argPosition] === 'object') {
-        if (Array.isArray(args[argPosition])) {
-          const structMembersLength = this.calculateStructMembers(input.type);
-          assert(
-            args[argPosition].length === structMembersLength,
-            `arg should be of length ${structMembersLength}`
-          );
-        } else {
-          this.structs[input.type].members.forEach(({ name }) => {
-            assert(
-              Object.keys(args[argPosition]).includes(name),
-              `arg should have a property ${name}`
-            );
-          });
-        }
-        argPosition += 1;
-      } else {
-        assert(Array.isArray(args[argPosition]), `arg ${input.name} should be an Array`);
-        if (input.type === 'felt*') {
-          args[argPosition].forEach((felt: BigNumberish) => {
-            assert(
-              typeof felt === 'string' || typeof felt === 'number' || felt instanceof BN,
-              `arg ${input.name} should be an array of string, number or BigNumber`
-            );
-          });
-          argPosition += 1;
-        } else if (/\(felt/.test(input.type)) {
-          const tupleLength = input.type.split(',').length;
-          assert(
-            args[argPosition].length === tupleLength,
-            `arg ${input.name} should have ${tupleLength} elements in tuple`
-          );
-          args[argPosition].forEach((felt: BigNumberish) => {
-            assert(
-              typeof felt === 'string' || typeof felt === 'number' || felt instanceof BN,
-              `arg ${input.name} should be an array of string, number or BigNumber`
-            );
-          });
-          argPosition += 1;
-        } else {
-          const arrayType = input.type.replace('*', '');
-          args[argPosition].forEach((struct: any) => {
-            this.structs[arrayType].members.forEach(({ name }) => {
-              if (Array.isArray(struct)) {
-                const structMembersLength = this.calculateStructMembers(arrayType);
-                assert(
-                  struct.length === structMembersLength,
-                  `arg should be of length ${structMembersLength}`
-                );
-              } else {
-                assert(
-                  Object.keys(struct).includes(name),
-                  `arg ${input.name} should be an array of ${arrayType}`
-                );
-              }
-            });
-          });
-          argPosition += 1;
-        }
-      }
-    });
-  }
-
-  /**
-   * Deep parse of the object that has been passed to the method
-   *
-   * @param element - element that needs to be parsed
-   * @param type  - name of the method
-   * @return {string | string[]} - parsed arguments in format that contract is expecting
-   */
-
-  protected parseCalldataValue(
-    element: ParsedStruct | BigNumberish | BigNumberish[],
-    type: string
-  ): string | string[] {
-    if (element === undefined) {
-      throw Error('Missing element in calldata');
-    }
-    if (Array.isArray(element)) {
-      const structMemberNum = this.calculateStructMembers(type);
-      if (element.length !== structMemberNum) {
-        throw Error('Missing element in calldata');
-      }
-      return element.map((el) => toFelt(el));
-    }
-    // checking if the passed element is struct or element in struct
-    if (this.structs[type] && this.structs[type].members.length) {
-      // going through all the members of the struct and parsing the value
-      return this.structs[type].members.reduce((acc, member: AbiEntry) => {
-        // if the member of the struct is another struct this will return array of the felts if not it will be single felt
-        // TODO: refactor types so member name can be used as keyof ParsedStruct
-        /* @ts-ignore */
-        const parsedData = this.parseCalldataValue(element[member.name], member.type);
-        if (typeof parsedData === 'string') {
-          acc.push(parsedData);
-        } else {
-          acc.push(...parsedData);
-        }
-        return acc;
-      }, [] as string[]);
-    }
-    return toFelt(element as BigNumberish);
   }
 
   /**
@@ -514,67 +360,6 @@ export class Contract implements ContractInterface {
       }, {} as any);
     }
     return parseFelt(responseIterator.next().value);
-  }
-
-  /**
-   * Parse one field of the calldata by using input field from the abi for that method
-   *
-   * @param args - value of the field
-   * @param input  - input(field) information from the abi that will be used to parse the data
-   * @return {string | string[]} - parsed arguments in format that contract is expecting
-   */
-  protected parseCalldataField(argsIterator: Iterator<any>, input: AbiEntry): string | string[] {
-    const { name, type } = input;
-    const { value } = argsIterator.next();
-
-    const parsedCalldata: string[] = [];
-    switch (true) {
-      case /\*/.test(type):
-        if (Array.isArray(value)) {
-          parsedCalldata.push(toFelt(value.length));
-          return (value as (BigNumberish | ParsedStruct)[]).reduce((acc, el) => {
-            if (/felt/.test(type)) {
-              acc.push(toFelt(el as BigNumberish));
-            } else {
-              acc.push(...this.parseCalldataValue(el, type.replace('*', '')));
-            }
-            return acc;
-          }, parsedCalldata);
-        }
-        throw Error(`Expected ${name} to be array`);
-      case type in this.structs:
-        return this.parseCalldataValue(value as ParsedStruct | BigNumberish[], type);
-      case /\(felt/.test(type):
-        if (Array.isArray(value)) {
-          return value.map((el) => toFelt(el as BigNumberish));
-        }
-        throw Error(`Expected ${name} to be array`);
-      default:
-        return toFelt(value as BigNumberish);
-    }
-  }
-
-  /**
-   * Parse the calldata by using input fields from the abi for that method
-   *
-   * @param args - arguments passed the the method
-   * @param inputs  - list of inputs(fields) that are in the abi
-   * @return {Calldata} - parsed arguments in format that contract is expecting
-   */
-  protected compileCalldata(args: Array<any>, inputs: AbiEntry[]): Calldata {
-    const argsIterator = args[Symbol.iterator]();
-    return inputs.reduce((acc, input) => {
-      if (/_len$/.test(input.name)) {
-        return acc;
-      }
-      const parsedData = this.parseCalldataField(argsIterator, input);
-      if (Array.isArray(parsedData)) {
-        acc.push(...parsedData);
-      } else {
-        acc.push(parsedData);
-      }
-      return acc;
-    }, [] as Calldata);
   }
 
   /**

--- a/src/utils/calldata.ts
+++ b/src/utils/calldata.ts
@@ -1,0 +1,250 @@
+import BN from 'bn.js';
+import assert from 'minimalistic-assert';
+
+import { Abi, AbiEntry, Calldata, FunctionAbi, ParsedStruct, StructAbi } from '../types';
+import { BigNumberish, toFelt } from './number';
+
+export class CheckCallData {
+  abi: Abi;
+
+  protected readonly structs: { [name: string]: StructAbi };
+
+  constructor(abi: Abi) {
+    this.abi = abi;
+    this.structs = abi
+      .filter((abiEntry) => abiEntry.type === 'struct')
+      .reduce(
+        (acc, abiEntry) => ({
+          ...acc,
+          [abiEntry.name]: abiEntry,
+        }),
+        {}
+      );
+  }
+
+  /**
+   * Parse the calldata by using input fields from the abi for that method
+   *
+   * @param args - arguments passed the the method
+   * @param inputs  - list of inputs(fields) that are in the abi
+   * @return {Calldata} - parsed arguments in format that contract is expecting
+   */
+  public compileCalldata(args: Array<any>, inputs: AbiEntry[]): Calldata {
+    const argsIterator = args[Symbol.iterator]();
+    return inputs.reduce((acc, input) => {
+      if (/_len$/.test(input.name)) {
+        return acc;
+      }
+      const parsedData = this.parseCalldataField(argsIterator, input);
+      if (Array.isArray(parsedData)) {
+        acc.push(...parsedData);
+      } else {
+        acc.push(parsedData);
+      }
+      return acc;
+    }, [] as Calldata);
+  }
+
+  /**
+   * Validates if all arguments that are passed to the method are corresponding to the ones in the abi
+   *
+   * @param type - type of the method
+   * @param method  - name of the method
+   * @param args - arguments that are passed to the method
+   */
+  public validateMethodAndArgs(
+    type: 'INVOKE' | 'CALL' | 'DEPLOY',
+    method: string,
+    args: Array<any> = []
+  ) {
+    // ensure provided method exists
+    if (type !== 'DEPLOY') {
+      const invokeableFunctionNames = this.abi
+        .filter((abi) => {
+          if (abi.type !== 'function') return false;
+          const isView = abi.stateMutability === 'view';
+          return type === 'INVOKE' ? !isView : isView;
+        })
+        .map((abi) => abi.name);
+      assert(
+        invokeableFunctionNames.includes(method),
+        `${type === 'INVOKE' ? 'invokeable' : 'viewable'} method not found in abi`
+      );
+    }
+
+    // ensure args match abi type
+    const methodAbi = this.abi.find((abi) =>
+      type === 'DEPLOY'
+        ? abi.name === method && abi.type === method
+        : abi.name === method && abi.type === 'function'
+    ) as FunctionAbi;
+    let argPosition = 0;
+    methodAbi.inputs.forEach((input) => {
+      if (/_len$/.test(input.name)) {
+        return;
+      }
+      if (input.type === 'felt') {
+        assert(
+          typeof args[argPosition] === 'string' ||
+            typeof args[argPosition] === 'number' ||
+            args[argPosition] instanceof BN,
+          `arg ${input.name} should be a felt (string, number, BigNumber)`
+        );
+        argPosition += 1;
+      } else if (input.type in this.structs && typeof args[argPosition] === 'object') {
+        if (Array.isArray(args[argPosition])) {
+          const structMembersLength = this.calculateStructMembers(input.type);
+          assert(
+            args[argPosition].length === structMembersLength,
+            `arg should be of length ${structMembersLength}`
+          );
+        } else {
+          this.structs[input.type].members.forEach(({ name }) => {
+            assert(
+              Object.keys(args[argPosition]).includes(name),
+              `arg should have a property ${name}`
+            );
+          });
+        }
+        argPosition += 1;
+      } else {
+        assert(Array.isArray(args[argPosition]), `arg ${input.name} should be an Array`);
+        if (input.type === 'felt*') {
+          args[argPosition].forEach((felt: BigNumberish) => {
+            assert(
+              typeof felt === 'string' || typeof felt === 'number' || felt instanceof BN,
+              `arg ${input.name} should be an array of string, number or BigNumber`
+            );
+          });
+          argPosition += 1;
+        } else if (/\(felt/.test(input.type)) {
+          const tupleLength = input.type.split(',').length;
+          assert(
+            args[argPosition].length === tupleLength,
+            `arg ${input.name} should have ${tupleLength} elements in tuple`
+          );
+          args[argPosition].forEach((felt: BigNumberish) => {
+            assert(
+              typeof felt === 'string' || typeof felt === 'number' || felt instanceof BN,
+              `arg ${input.name} should be an array of string, number or BigNumber`
+            );
+          });
+          argPosition += 1;
+        } else {
+          const arrayType = input.type.replace('*', '');
+          args[argPosition].forEach((struct: any) => {
+            this.structs[arrayType].members.forEach(({ name }) => {
+              if (Array.isArray(struct)) {
+                const structMembersLength = this.calculateStructMembers(arrayType);
+                assert(
+                  struct.length === structMembersLength,
+                  `arg should be of length ${structMembersLength}`
+                );
+              } else {
+                assert(
+                  Object.keys(struct).includes(name),
+                  `arg ${input.name} should be an array of ${arrayType}`
+                );
+              }
+            });
+          });
+          argPosition += 1;
+        }
+      }
+    });
+  }
+
+  /**
+   * Parse one field of the calldata by using input field from the abi for that method
+   *
+   * @param args - value of the field
+   * @param input  - input(field) information from the abi that will be used to parse the data
+   * @return {string | string[]} - parsed arguments in format that contract is expecting
+   */
+  protected parseCalldataField(argsIterator: Iterator<any>, input: AbiEntry): string | string[] {
+    const { name, type } = input;
+    const { value } = argsIterator.next();
+
+    const parsedCalldata: string[] = [];
+    switch (true) {
+      case /\*/.test(type):
+        if (Array.isArray(value)) {
+          parsedCalldata.push(toFelt(value.length));
+          return (value as (BigNumberish | ParsedStruct)[]).reduce((acc, el) => {
+            if (/felt/.test(type)) {
+              acc.push(toFelt(el as BigNumberish));
+            } else {
+              acc.push(...this.parseCalldataValue(el, type.replace('*', '')));
+            }
+            return acc;
+          }, parsedCalldata);
+        }
+        throw Error(`Expected ${name} to be array`);
+      case type in this.structs:
+        return this.parseCalldataValue(value as ParsedStruct | BigNumberish[], type);
+      case /\(felt/.test(type):
+        if (Array.isArray(value)) {
+          return value.map((el) => toFelt(el as BigNumberish));
+        }
+        throw Error(`Expected ${name} to be array`);
+      default:
+        return toFelt(value as BigNumberish);
+    }
+  }
+
+  /**
+   * Deep parse of the object that has been passed to the method
+   *
+   * @param element - element that needs to be parsed
+   * @param type  - name of the method
+   * @return {string | string[]} - parsed arguments in format that contract is expecting
+   */
+
+  protected parseCalldataValue(
+    element: ParsedStruct | BigNumberish | BigNumberish[],
+    type: string
+  ): string | string[] {
+    if (element === undefined) {
+      throw Error('Missing element in calldata');
+    }
+    if (Array.isArray(element)) {
+      const structMemberNum = this.calculateStructMembers(type);
+      if (element.length !== structMemberNum) {
+        throw Error('Missing element in calldata');
+      }
+      return element.map((el) => toFelt(el));
+    }
+    // checking if the passed element is struct or element in struct
+    if (this.structs[type] && this.structs[type].members.length) {
+      // going through all the members of the struct and parsing the value
+      return this.structs[type].members.reduce((acc, member: AbiEntry) => {
+        // if the member of the struct is another struct this will return array of the felts if not it will be single felt
+        // TODO: refactor types so member name can be used as keyof ParsedStruct
+        /* @ts-ignore */
+        const parsedData = this.parseCalldataValue(element[member.name], member.type);
+        if (typeof parsedData === 'string') {
+          acc.push(parsedData);
+        } else {
+          acc.push(...parsedData);
+        }
+        return acc;
+      }, [] as string[]);
+    }
+    return toFelt(element as BigNumberish);
+  }
+
+  /**
+   * Deep parse of the object that has been passed to the method
+   *
+   * @param struct - struct that needs to be calculated
+   * @return {number} - number of members for the given struct
+   */
+  private calculateStructMembers(struct: string): number {
+    return this.structs[struct].members.reduce((acc, member) => {
+      if (member.type === 'felt') {
+        return acc + 1;
+      }
+      return acc + this.calculateStructMembers(member.type);
+    }, 0);
+  }
+}

--- a/www/docs/API/contractFactory.md
+++ b/www/docs/API/contractFactory.md
@@ -34,8 +34,8 @@ Return an instance of a _Contract_ attached to address. This is the same as usin
 
 <hr />
 
-contractFactory.**deploy**( constructorCalldata, addressSalt ) ⇒ _Promise < Contract >_
+contractFactory.**deploy**( args, addressSalt ) ⇒ _Promise < Contract >_
 
-Uses the provider to deploy the Contract with _constructorCalldata_ passed into the constructor and returns a _Contract_ which is attached to the address where this contract will be deployed.
+Uses the provider to deploy the Contract with _args_ passed into the constructor and returns a _Contract_ which is attached to the address where this contract will be deployed.
 
 The transaction hash can be found at _contract.deployTransactionHash_, and no interactions should be made until the transaction is resolved.

--- a/www/docs/API/utils.md
+++ b/www/docs/API/utils.md
@@ -369,6 +369,6 @@ Parse the calldata by using input fields from the abi for that method.
 
 ### validate
 
-`validateMethodAndArgs(type: 'INVOKE' | 'CALL' | 'DEPLOY', method: string, args: Array<any> = []`
+`validateMethodAndArgs(type: 'INVOKE' | 'CALL' | 'DEPLOY', method: string, args: Array<any> = [])`
 
 Validates if all arguments that are passed to the method are corresponding to the ones in the abi.

--- a/www/docs/API/utils.md
+++ b/www/docs/API/utils.md
@@ -354,3 +354,21 @@ keyPair should be an KeyPair with a valid public key.
 sig should be an Signature.
 
 Returns true if the verification succeeds.
+
+<hr />
+
+## **calldata**
+
+Functions to compile and validate arguments passed in invoke, call and deploy functions.
+
+### compile
+
+`compileCalldata(args: Array<any>, inputs: AbiEntry[]): Calldata`
+
+Parse the calldata by using input fields from the abi for that method.
+
+### validate
+
+`validateMethodAndArgs(type: 'INVOKE' | 'CALL' | 'DEPLOY', method: string, args: Array<any> = []`
+
+Validates if all arguments that are passed to the method are corresponding to the ones in the abi.


### PR DESCRIPTION
## Motivation and Resolution

Feat #180 
Updates arguments of `ContractFactory.deploy` from RawCallData to args and convert them to RawCallData internally

## Usage related changes

Moved `compileCalldata`, `validateMethodAndArgs` functions (and related protected functions) into a `utils/calldata.ts` so functions could be used in `Contract` and `ContractFactory` class.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
