### PR TITLE
test: remove todo tests in rpcProvider

### DIFF
--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -128,9 +128,5 @@ describeIfRpc('RPCProvider', () => {
       expect(contractClass).toHaveProperty('program');
       expect(contractClass).toHaveProperty('entry_points_by_type');
     });
-
-    test.todo('getEstimateFee');
-
-    test.todo('invokeFunction');
   });
 });


### PR DESCRIPTION
## Motivation and Resolution

test #317 
Deleted the todo tests for `getEstimateFee` and `invokeFunction` in `rpcProvider.test.ts` as they should not be called without an account. 

## Checklist:

- [ ] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
