### PR TITLE
fix: rpc deployAccountContract request, rpc nonce hotfix

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -187,9 +187,9 @@ export class Account extends Provider implements AccountInterface {
       constructorCalldata = [],
       contractAddress: providedContractAddress,
     }: DeployAccountContractPayload,
-    { blockIdentifier, nonce: providedNonce }: EstimateFeeDetails = {}
+    { blockIdentifier }: EstimateFeeDetails = {}
   ): Promise<EstimateFee> {
-    const nonce = toBN(providedNonce ?? (await this.getNonce()));
+    const nonce = '0x0';
     const version = toBN(feeTransactionVersion);
     const chainId = await this.getChainId();
     const contractAddress =

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -400,7 +400,7 @@ export class Account extends Provider implements AccountInterface {
     }: DeployAccountContractPayload,
     transactionsDetail: InvocationsDetails = {}
   ): Promise<DeployContractResponse> {
-    const nonce = toBN(transactionsDetail.nonce ?? (await this.getNonce()));
+    const nonce = '0x0';
     const version = toBN(transactionVersion);
     const chainId = await this.getChainId();
 

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -77,10 +77,12 @@ export abstract class AccountInterface extends ProviderInterface {
   /**
    * Estimate Fee for executing a DEPLOY_ACCOUNT transaction on starknet
    *
-   * @param contractPayload the payload object containing:
+   * @param contractPayload -
    * - contract - the compiled contract to be deployed
    * - classHash - the class hash of the compiled contract. This can be obtained by using starknet-cli.
-   *
+   * @param estimateFeeDetails -
+   * - optional blockIdentifier
+   * - constant nonce = 0
    * @returns response from estimate_fee
    */
   public abstract estimateAccountDeployFee(

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -236,7 +236,7 @@ export abstract class AccountInterface extends ProviderInterface {
   - optional address salt  
   - optional contractAddress
    * @param transactionsDetail Invocation Details containing:
-  - optional nonce
+  - constant nonce = 0
   - optional version
   - optional maxFee
    * @returns a confirmation of sending a transaction on the starknet contract

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -84,22 +84,15 @@ export class RpcProvider implements ProviderInterface {
     }
   }
 
-  protected deviationHandler(method: string, { error, result }: any): any {
-    // for non-existing address Sequencer return '0x0' rpc return error.
-    if (method === 'starknet_getNonce' && error.code === 20) return '0x0';
-
-    this.errorHandler(error);
-    return result;
-  }
-
   protected async fetchEndpoint<T extends keyof RPC.Methods>(
     method: T,
     params?: RPC.Methods[T]['params']
   ): Promise<RPC.Methods[T]['result']> {
     try {
-      const rawResponse = await this.fetch(method, params);
-      const response = await rawResponse.json();
-      return this.deviationHandler(method, response) as RPC.Methods[T]['result'];
+      const rawResult = await this.fetch(method, params);
+      const { error, result } = await rawResult.json();
+      this.errorHandler(error);
+      return result as RPC.Methods[T]['result'];
     } catch (error: any) {
       this.errorHandler(error?.response?.data);
       throw error;

--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -500,7 +500,9 @@ export namespace OPENRPC {
       errors: Errors.INVALID_CONTRACT_CLASS;
     };
     starknet_addDeployAccountTransaction: {
-      params: BROADCASTED_DEPLOY_ACCOUNT_TXN;
+      params: {
+        deploy_account_transaction: BROADCASTED_DEPLOY_ACCOUNT_TXN;
+      };
       result: {
         transaction_hash: TXN_HASH;
         contract_address: FELT;


### PR DESCRIPTION
## Motivation and Resolution
RPC deployAccountContract has misformatted request data.
~~RPC nonce for non-existing account return error and sequencer return "0x0" which cause a problem when deploying account true RPC.~~
Fixture deploy Account nonce to 0
Fixture estimateAccountDeployFee nonce to 0

### RPC version (if applicable)
0.2.1

## Usage related changes
RPC deployAccount fixed

## Development related changes
~~Include hotfix for RPC-spec deviation (but this will be discussed for standardization)~~

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [x] All tests are passing
