### PR TITLE
RpcProvider: Fix default invoke tx version

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -358,7 +358,7 @@ export class RpcProvider implements ProviderInterface {
         calldata: parseCalldata(functionInvocation.calldata),
         type: 'INVOKE',
         max_fee: toHex(toBN(details.maxFee || 0)),
-        version: toHex(toBN(details.version || 0)),
+        version: toHex(toBN(details.version || 1)),
         signature: bigNumberishArrayToHexadecimalStringArray(functionInvocation.signature || []),
         nonce: toHex(toBN(details.nonce)),
       },


### PR DESCRIPTION
## Motivation and Resolution

`RpcProvider.invokeFunction` throws an error complaining `unknown field 'sender_address'` because its request payload follows V1 but version is set V0. Actually, it is correctly written as 1 in `SequencerProvider`.

### RPC version (if applicable)

## Usage related changes

Invoke Tx will be successfully broadcasted even though user don't specify `version` explicitly.

## Development related changes


## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [ ] All tests are passing