### PR TITLE
Modified errors in erc20.md and add file multiCall.md

### DIFF
--- a/www/guides/erc20.md
+++ b/www/guides/erc20.md
@@ -102,9 +102,14 @@ const executeHash = await account.execute(
   {
     contractAddress: erc20Address,
     entrypoint: 'transfer',
-    calldata: stark.compileCalldata({
+    calldata: 
+      // Use a simple array to pass args in calldata
+      // [reciverAddress, '10', '0']
+      
+      // Use compiled calldata to pass args in calldata
+      stark.compileCalldata({
       recipient: recieverAddress,
-      amount: ['10']
+      amount: {type: 'struct', low: '10', high: '0',}
     })
   }
 );

--- a/www/guides/erc20.md
+++ b/www/guides/erc20.md
@@ -89,7 +89,7 @@ erc20.connect(account);
 
 const { transaction_hash: mintTxHash } = await erc20.transfer(
   recieverAddress,
-  ['0', '10'], // send 10 tokens as Uint256
+  ['10', '0'], // send 10 tokens as Uint256
 );
 
 await provider.waitForTransaction(mintTxHash);

--- a/www/guides/multiCall.md
+++ b/www/guides/multiCall.md
@@ -1,0 +1,3 @@
+---
+sidebar_position: 4
+---

--- a/www/guides/multiCall.md
+++ b/www/guides/multiCall.md
@@ -1,3 +1,56 @@
 ---
 sidebar_position: 4
 ---
+
+# Interact with more than one contract within one transaction
+
+Interacting with more than one contract with one transaction is one of starknet's feature. To use this feature, two contracts are required.
+
+## Setup
+
+Set up basic stuff before multicall.
+
+```javascript
+// devnet private key from Account #0 if generated with --seed 0
+const starkKeyPair = ec.getKeyPair("0xe3e70682c2094cac629f6fbed82c07cd");
+const accountAddress = "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a";
+
+// Ether token contract address
+const contractAddress_1 = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7';
+
+// Ether bridge contract address
+const contractAddress_2 = '0x073314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82';
+
+const account = new Account(
+    provider,
+    accountAddress,
+    starkKeyPair
+  );
+```
+
+## Interact with contracts
+
+```javascript
+const multiCall = await account.execute(
+	[{
+        contractAddress: contractAddress_1,
+            entrypoint: "approve", 
+        	// approve 1 wei for bridge
+            calldata: stark.compileCalldata({
+                spender: contractAddress_2,
+                amount: {type: 'struct', low: '1', high: '0'},
+              })
+          },
+          {
+            contractAddress: contractAddress_2,
+            entrypoint: "initiate_withdraw",
+            // bridge 1 wei to L1
+            calldata: stark.compileCalldata({
+                l1_recipient: `reciver address here`,
+            	amount: {type: 'struct', low: '1', high: '0'},
+            })
+          }]
+)
+await provider.waitForTransaction(multiCall.transaction_hash);
+```
+

--- a/www/guides/multiCall.md
+++ b/www/guides/multiCall.md
@@ -18,8 +18,8 @@ const accountAddress = "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd37
 // Ether token contract address
 const contractAddress_1 = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7';
 
-// Ether bridge contract address
-const contractAddress_2 = '0x073314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82';
+// contract address which require ether
+const contractAddress_2 = '0x078f36c1d59dd29e00a0bb60aa2a9409856f4f9841c47f165aba5bab4225aa6b';
 
 const account = new Account(
     provider,
@@ -30,27 +30,31 @@ const account = new Account(
 
 ## Interact with contracts
 
+Interact with more than one contract by using `account.execute([calls])`. Example is as follows.
+
 ```javascript
 const multiCall = await account.execute(
-	[{
-        contractAddress: contractAddress_1,
-            entrypoint: "approve", 
-        	// approve 1 wei for bridge
-            calldata: stark.compileCalldata({
-                spender: contractAddress_2,
-                amount: {type: 'struct', low: '1', high: '0'},
-              })
-          },
-          {
-            contractAddress: contractAddress_2,
-            entrypoint: "initiate_withdraw",
-            // bridge 1 wei to L1
-            calldata: stark.compileCalldata({
-                l1_recipient: `reciver address here`,
-            	amount: {type: 'struct', low: '1', high: '0'},
-            })
-          }]
+	[
+    // Calling the first contract
+    {
+    contractAddress: contractAddress_1,
+    entrypoint: "approve", 
+    // approve 1 wei for bridge
+    calldata: stark.compileCalldata({
+        spender: contractAddress_2,
+        amount: {type: 'struct', low: '1', high: '0'},
+      })
+    },
+    // Calling the second contract
+    {
+      contractAddress: contractAddress_2,
+      entrypoint: "transfer_ether",
+      // transfer 1 wei to the contract address
+      calldata: stark.compileCalldata({
+          amount: {type: 'struct', low: '1', high: '0'},
+      })
+    }
+  ]
 )
 await provider.waitForTransaction(multiCall.transaction_hash);
 ```
-

--- a/www/guides/multiCall.md
+++ b/www/guides/multiCall.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Interact with more than one contract within one transaction
 
-Interacting with more than one contract with one transaction is one of starknet's feature. To use this feature, two contracts are required.
+Interacting with more than one contract with one transaction is one of StarkNet's features. To use this feature, two contracts are required.
 
 ## Setup
 


### PR DESCRIPTION
## Motivation and Resolution

When I was checking the Erc20 token guide in doc, I found an error in sample code. 

- In cairo language, the uint256 contains two felts, in js, the first element of the array is low 128 bits, the second element of the array is high 128 bits. Sample in docs is transfering way more than 10 tokens.
- Using compileCalldata for `uint256` will add an element of array length to the `uint256 array`, which will cause error when passing args. Treating `uint256` stuff as a struct solves the problem.
- When I want to check how to interact more than one contract within one transaction, there is no refer in the doc. After I worked it out, I'm trying to add it to the doc for others to check.

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
  Modify errors in erc20.md.
- Change 2.
  Add multiCall sample code to the guide section in multiCall.md.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
