### PR TITLE
refactor: remove type union from BROADCASTED_TXN_COMMON_PROPERTIES

### DIFF
--- a/src/types/api/openrpc.ts
+++ b/src/types/api/openrpc.ts
@@ -105,8 +105,9 @@ type FUNCTION_CALL = {
   entry_point_selector?: FELT;
   calldata?: Array<FELT>;
 };
-type INVOKE_TXN = COMMON_TXN_PROPERTIES & (INVOKE_TXN_V0 | INVOKE_TXN_V1);
+type INVOKE_TXN = COMMON_TXN_PROPERTIES & { type: 'INVOKE' } & (INVOKE_TXN_V0 | INVOKE_TXN_V1);
 type DECLARE_TXN = COMMON_TXN_PROPERTIES & {
+  type: 'DECLARE';
   class_hash: FELT;
   sender_address: ADDRESS;
 };
@@ -118,6 +119,7 @@ type DEPLOY_TXN = {
 type DEPLOY_ACCOUNT_TXN = COMMON_TXN_PROPERTIES & DEPLOY_ACCOUNT_TXN_PROPERTIES;
 
 type DEPLOY_ACCOUNT_TXN_PROPERTIES = {
+  type: 'DEPLOY_ACCOUNT';
   contract_address_salt: FELT;
   constructor_calldata: Array<FELT>;
   class_hash: FELT;
@@ -127,14 +129,10 @@ type DEPLOY_ACCOUNT_TXN_RECEIPT = DEPLOY_TXN_RECEIPT;
 
 type TXN = INVOKE_TXN | L1_HANDLER_TXN | DECLARE_TXN | DEPLOY_TXN | DEPLOY_ACCOUNT_TXN;
 
-enum L1_HANDLER {
-  'L1_HANDLER',
-}
-
 type L1_HANDLER_TXN = {
+  type: 'L1_HANDLER';
   transaction_hash: TXN_HASH;
   version: NUM_AS_HEX;
-  type: L1_HANDLER;
   nonce: NUM_AS_HEX;
 } & FUNCTION_CALL;
 
@@ -147,10 +145,12 @@ type BROADCASTED_TXN =
   | BROADCASTED_DEPLOY_TXN
   | BROADCASTED_DEPLOY_ACCOUNT_TXN;
 
-type BROADCASTED_INVOKE_TXN = BROADCASTED_TXN_COMMON_PROPERTIES & (INVOKE_TXN_V0 | INVOKE_TXN_V1);
+type BROADCASTED_INVOKE_TXN = BROADCASTED_TXN_COMMON_PROPERTIES & { type: 'INVOKE' } & (
+    | INVOKE_TXN_V0
+    | INVOKE_TXN_V1
+  );
 
 type BROADCASTED_TXN_COMMON_PROPERTIES = {
-  type: TXN_TYPE;
   max_fee: FELT;
   version: NUM_AS_HEX;
   signature: SIGNATURE;
@@ -158,6 +158,7 @@ type BROADCASTED_TXN_COMMON_PROPERTIES = {
 };
 
 type BROADCASTED_DECLARE_TXN = {
+  type: 'DECLARE';
   contract_class: CONTRACT_CLASS;
   sender_address: ADDRESS;
 } & BROADCASTED_TXN_COMMON_PROPERTIES;
@@ -167,8 +168,8 @@ type BROADCASTED_DEPLOY_TXN = {
 } & DEPLOY_TXN_PROPERTIES;
 
 type DEPLOY_TXN_PROPERTIES = {
+  type: 'DEPLOY';
   version: NUM_AS_HEX;
-  type: TXN_TYPE;
   contract_address_salt: FELT;
   constructor_calldata: Array<FELT>;
 };


### PR DESCRIPTION
## Motivation and Resolution

Currently all TXNs have shared `type` defined as union:
```ts
type TXN_TYPE = 'DECLARE' | 'DEPLOY' | 'DEPLOY_ACCOUNT' | 'INVOKE' | 'L1_HANDLER';

type BROADCASTED_TXN_COMMON_PROPERTIES = {
  type: TXN_TYPE;
  // ...
};
```

This is convenient to write, however it doesn't allow for type narrowing:
```ts
import type { RPC } from './types';

export const test = (tx: RPC.Transaction) => {
  if (tx.type === 'DEPLOY_ACCOUNT') {
    console.log(tx.contract_address_salt); // <- this will fail, contract_address_salt is part of DEPLOY_ACCOUNT TXN, but because union is used it can't be narrowed down.
  }
};
```

Because of this DX is impacted as you can't do simple check to see what properties you can access (https://github.com/snapshot-labs/checkpoint/issues/176)

To make type narrowing work `type` has to be a constant string, defined separately for each TXN type.

## Usage related changes

- When working with `TXN` or `BROADCASTED_TXN` type narrowing can now be used. Once `tx.type` is checked exact TXN variant will be available.

## Test plan

Create this file:
```ts
import type { RPC } from './types';

export const test = (tx: RPC.Transaction) => {
  if (tx.type === 'DEPLOY_ACCOUNT') {
    console.log(tx.contract_address_salt);
  }
};
```

No errors should be reported, change `tx.type` to check against `"INVOKE"` - now error is shown because `contract_address_salt` is not defined for that type.


## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [x] All tests are passing
