### PR TITLE
Feat: support get_block_traces in sequencer provider

### DIFF
--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -144,11 +144,21 @@ describeIfSequencer('SequencerProvider', () => {
     test(`getBlockTraces(blockHash=${exampleBlockHash}, blockNumber=undefined)`, async () => {
       const blockTraces = await sequencerProvider.getBlockTraces(exampleBlockHash);
       expect(blockTraces).toHaveProperty('traces');
+      expect(blockTraces.traces[0]).toHaveProperty('validate_invocation');
+      expect(blockTraces.traces[0]).toHaveProperty('function_invocation');
+      expect(blockTraces.traces[0]).toHaveProperty('fee_transfer_invocation');
+      expect(blockTraces.traces[0]).toHaveProperty('signature');
+      expect(blockTraces.traces[0]).toHaveProperty('transaction_hash');
     });
 
     test(`getBlockTraces(blockHash=undefined, blockNumber=${exampleBlockNumber})`, async () => {
       const blockTraces = await sequencerProvider.getBlockTraces(exampleBlockNumber);
       expect(blockTraces).toHaveProperty('traces');
+      expect(blockTraces.traces[0]).toHaveProperty('validate_invocation');
+      expect(blockTraces.traces[0]).toHaveProperty('function_invocation');
+      expect(blockTraces.traces[0]).toHaveProperty('fee_transfer_invocation');
+      expect(blockTraces.traces[0]).toHaveProperty('signature');
+      expect(blockTraces.traces[0]).toHaveProperty('transaction_hash');
     });
   });
 });

--- a/__tests__/sequencerProvider.test.ts
+++ b/__tests__/sequencerProvider.test.ts
@@ -1,4 +1,11 @@
-import { Contract, Provider, SequencerProvider, stark } from '../src';
+import {
+  BlockNumber,
+  Contract,
+  GetBlockResponse,
+  Provider,
+  SequencerProvider,
+  stark,
+} from '../src';
 import { toBN } from '../src/utils/number';
 import { encodeShortString } from '../src/utils/shortString';
 import {
@@ -16,6 +23,15 @@ describeIfSequencer('SequencerProvider', () => {
   const account = getTestAccount(sequencerProvider);
   let customSequencerProvider: Provider;
   let exampleContractAddress: string;
+  let exampleBlock: GetBlockResponse;
+  let exampleBlockNumber: BlockNumber;
+  let exampleBlockHash: string;
+
+  beforeAll(async () => {
+    exampleBlock = await sequencerProvider.getBlock('latest');
+    exampleBlockHash = exampleBlock.block_hash;
+    exampleBlockNumber = exampleBlock.block_number;
+  });
 
   describe('Gateway specific methods', () => {
     let exampleTransactionHash: string;
@@ -121,6 +137,18 @@ describeIfSequencer('SequencerProvider', () => {
       const [res] = result;
       expect(res.low).toStrictEqual(toBN(1000));
       expect(res).toStrictEqual(result.balance);
+    });
+  });
+
+  describe('getBlockTraces', () => {
+    test(`getBlockTraces(blockHash=${exampleBlockHash}, blockNumber=undefined)`, async () => {
+      const blockTraces = await sequencerProvider.getBlockTraces(exampleBlockHash);
+      expect(blockTraces).toHaveProperty('traces');
+    });
+
+    test(`getBlockTraces(blockHash=undefined, blockNumber=${exampleBlockNumber})`, async () => {
+      const blockTraces = await sequencerProvider.getBlockTraces(exampleBlockNumber);
+      expect(blockTraces).toHaveProperty('traces');
     });
   });
 });

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -602,6 +602,7 @@ export class SequencerProvider implements ProviderInterface {
   public async getBlockTraces(
     blockIdentifier: BlockIdentifier = this.blockIdentifier
   ): Promise<Sequencer.BlockTransactionTracesResponse> {
-    return this.fetchEndpoint('get_block_traces', { blockIdentifier });
+    const args = new Block(blockIdentifier).sequencerIdentifier;
+    return this.fetchEndpoint('get_block_traces', { ...args });
   }
 }

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -587,4 +587,11 @@ export class SequencerProvider implements ProviderInterface {
       }
     ).then(this.responseParser.parseFeeSimulateTransactionResponse);
   }
+
+  // consider adding an optional trace retrieval parameter to the getBlock method
+  public async getBlockTraces(
+    blockIdentifier: BlockIdentifier = this.blockIdentifier
+  ): Promise<Sequencer.BlockTransactionTracesResponse> {
+    return this.fetchEndpoint('get_block_traces', { blockIdentifier });
+  }
 }

--- a/src/types/api/sequencer.ts
+++ b/src/types/api/sequencer.ts
@@ -282,9 +282,9 @@ export namespace Sequencer {
 
   export type EstimateFeeResponseBulk = AllowArray<EstimateFeeResponse>;
 
-  export type BlockTransactionTracesResponse = Array<
-    TransactionTraceResponse & { transaction_hash: string }
-  >;
+  export type BlockTransactionTracesResponse = {
+    traces: Array<TransactionTraceResponse & { transaction_hash: string }>;
+  };
 
   export type StateUpdateResponse = {
     block_hash: string;
@@ -437,7 +437,8 @@ export namespace Sequencer {
     };
     get_block_traces: {
       QUERY: {
-        blockIdentifier: BlockIdentifier;
+        blockHash?: string;
+        blockNumber?: BlockNumber;
       };
       REQUEST: never;
       RESPONSE: BlockTransactionTracesResponse;

--- a/src/types/api/sequencer.ts
+++ b/src/types/api/sequencer.ts
@@ -260,6 +260,10 @@ export namespace Sequencer {
 
   export type EstimateFeeResponseBulk = AllowArray<EstimateFeeResponse>;
 
+  export type BlockTransactionTracesResponse = Array<
+    TransactionTraceResponse & { transaction_hash: string }
+  >;
+
   export type Endpoints = {
     get_contract_addresses: {
       QUERY: never;
@@ -393,6 +397,13 @@ export namespace Sequencer {
       };
       REQUEST: EstimateFeeRequestBulk;
       RESPONSE: EstimateFeeResponseBulk;
+    };
+    get_block_traces: {
+      QUERY: {
+        blockIdentifier: BlockIdentifier;
+      };
+      REQUEST: never;
+      RESPONSE: BlockTransactionTracesResponse;
     };
   };
 }

--- a/www/docs/API/Provider/sequencerProvider.md
+++ b/www/docs/API/Provider/sequencerProvider.md
@@ -156,3 +156,44 @@ Gets the transaction trace from a tx hash.
   };
 }
 ```
+
+---
+
+### getBlockTraces()
+
+provider.**getBlockTraces**(blockIdentifier) => _Promise < BlockTransactionTracesResponse >_
+
+Gets the transaction traces of an entire block
+
+###### _BlockTransactionTracesResponse_
+
+```typescript
+
+Array<TransactionTraceResponse & { transaction_hash: string }>
+
+{
+  TransactionTraceResponse: {
+    validate_invocation?: FunctionInvocation;
+    function_invocation?: FunctionInvocation;
+    fee_transfer_invocation?: FunctionInvocation;
+    signature: Signature;
+  }
+
+  FunctionInvocation: {
+    caller_address: string;
+    contract_address: string;
+    calldata: {
+      [inputName: string]: string | string[] | { type: 'struct'; [k: string]: BigNumberish };
+    };
+    call_type?: string;
+    class_hash?: string;
+    selector?: string;
+    entry_point_type?: EntryPointType;
+    result: Array<any>;
+    execution_resources: ExecutionResources;
+    internal_calls: Array<FunctionInvocation>;
+    events: Array<any>;
+    messages: Array<any>;
+  };
+}
+```

--- a/www/docs/API/Provider/sequencerProvider.md
+++ b/www/docs/API/Provider/sequencerProvider.md
@@ -169,7 +169,9 @@ Gets the transaction traces of an entire block
 
 ```typescript
 
-Array<TransactionTraceResponse & { transaction_hash: string }>
+{
+    traces: Array<TransactionTraceResponse & { transaction_hash: string }>;
+}
 
 {
   TransactionTraceResponse: {
@@ -177,7 +179,7 @@ Array<TransactionTraceResponse & { transaction_hash: string }>
     function_invocation?: FunctionInvocation;
     fee_transfer_invocation?: FunctionInvocation;
     signature: Signature;
-  }
+  };
 
   FunctionInvocation: {
     caller_address: string;


### PR DESCRIPTION
## Motivation and Resolution

Close #253 
Add support for `get_block_traces` endpoint in Sequencer Provider. 

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
