### PR TITLE
fix: remove hex prefix should work insensitive, for both 0x and 0X

### DIFF
--- a/__tests__/utils/shortString.test.ts
+++ b/__tests__/utils/shortString.test.ts
@@ -1,3 +1,4 @@
+import { removeHexPrefix } from '../../src/utils/encode';
 import { decodeShortString, encodeShortString } from '../../src/utils/shortString';
 
 describe('shortString', () => {
@@ -37,5 +38,10 @@ describe('shortString', () => {
     expect(() => decodeShortString('Test')).toThrowErrorMatchingInlineSnapshot(
       `"Test is not Hex or decimal"`
     );
+  });
+
+  test('explicitly test removeHexPrefix', () => {
+    expect(removeHexPrefix('0x01')).toBe('01');
+    expect(removeHexPrefix('0X01')).toBe('01');
   });
 });

--- a/__tests__/utils/shortString.test.ts
+++ b/__tests__/utils/shortString.test.ts
@@ -20,11 +20,11 @@ describe('shortString', () => {
   });
 
   test('should convert hex number string to string', () => {
-    expect(decodeShortString('0x68656c6c6f')).toMatchInlineSnapshot(`"hello"`);
+    expect(JSON.stringify(decodeShortString('0x68656c6c6f'))).toBe('"hello"');
   });
 
   test('should convert decimal number string to string', () => {
-    expect(decodeShortString('448378203247')).toMatch(`hello`);
+    expect(JSON.stringify(decodeShortString('448378203247'))).toBe('"hello"');
   });
 
   test('should throw if decode input is not ascii chars', () => {

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -21,7 +21,7 @@ export function buf2hex(buffer: Uint8Array) {
  */
 
 export function removeHexPrefix(hex: string): string {
-  return hex.replace(/^0x/, '');
+  return hex.replace(/^0x/i, '');
 }
 
 export function addHexPrefix(hex: string): string {


### PR DESCRIPTION
## Motivation and Resolution
Fix https://github.com/0xs34n/starknet.js/pull/508
Mentioned PR contains change so that call on function decodeShortString can handle both hex and decimal string, usage-related change.
```decodeShortString(value.toString(16)) -> decodeShortString(value)```
But removeHexPrefix removes only `0x` and not `0X`. That produces a hidden character on the string that encodes, visible with JSON.stringify.
The issue is that removeHexPrefix should be able to remove both, not just in the mentioned PR but in case someone does an uppercase transformation before the call.
...

### RPC version (if applicable)

...

## Usage related changes
removeHexPrefix is case insensitive `0x` and `0X`

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [x] All tests are passing
