### PR TITLE
Change "StarkNet" to "Starknet"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 <!-- tag line -->
-<h4 align='center'> JavaScript library for StarkNet.</h4>
+<h4 align='center'> JavaScript library for Starknet.</h4>
 
 <!-- primary badges -->
 <p align="center">

--- a/www/docs/API/Provider/provider.md
+++ b/www/docs/API/Provider/provider.md
@@ -4,7 +4,7 @@ title: Provider
 id: 'provider'
 ---
 
-The **Provider** API allows you to interact with the StarkNet network, without signing transactions or messages.
+The **Provider** API allows you to interact with the Starknet network, without signing transactions or messages.
 
 Typically, these are _read_ calls on the blockchain.
 
@@ -67,7 +67,7 @@ Returns the chain Id for the current network.
 
 provider.**callContract**(call [ , blockIdentifier ]) => _Promise < CallContractResponse >_
 
-Calls a function on the StarkNet contract.
+Calls a function on the Starknet contract.
 
 The call object structure:
 

--- a/www/docs/API/contract.md
+++ b/www/docs/API/contract.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Contract
 
-Contracts can do data transformations in JavaScript based on an ABI. They can also call and invoke to StarkNet through a provided Signer.
+Contracts can do data transformations in JavaScript based on an ABI. They can also call and invoke to Starknet through a provided Signer.
 
 Contracts allow you to transform Cairo values, like `Uint256` to `BigNumber`. It could also allow users to pass their own transformers, similar to `JSON.parse`.
 

--- a/www/docs/API/contractFactory.md
+++ b/www/docs/API/contractFactory.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Contract Factory
 
-Contract Factory allows you to deploy contracts to StarkNet. To deploy a Contract, additional information is needed that is not available on a Contract object itself.
+Contract Factory allows you to deploy contracts to Starknet. To deploy a Contract, additional information is needed that is not available on a Contract object itself.
 
 ## Creating an instance
 

--- a/www/docs/API/index.md
+++ b/www/docs/API/index.md
@@ -1,3 +1,3 @@
-# StarkNet.js API
+# Starknet.js API
 
 This API is based on the <ins>[Starknet.js V3](https://github.com/0xs34n/starknet.js/discussions/102)</ins> Interface write up by <ins>[Janek](https://twitter.com/0xjanek)</ins> of <ins>[Argent](https://www.argent.xyz/)</ins>

--- a/www/docs/API/signer.md
+++ b/www/docs/API/signer.md
@@ -24,7 +24,7 @@ Returns the public key of the signer.
 
 signer.**signTransaction**(transactions, transactionsDetail [ , abi ]) => _Promise < Signature >_
 
-Signs a transaction with the StarkNet private key and returns the signature.
+Signs a transaction with the Starknet private key and returns the signature.
 
 The _transactions_ object for write methods may include any of:
 
@@ -46,7 +46,7 @@ string[]
 
 signer.**signMessage**(typedData, accountAddress) => _Promise < Signature >_
 
-Sign an JSON object for off-chain usage with the StarkNet private key and return the signature. This adds a message prefix so it can't be interchanged with transactions.
+Sign an JSON object for off-chain usage with the Starknet private key and return the signature. This adds a message prefix so it can't be interchanged with transactions.
 
 _typedData_ - JSON object to be signed
 _accountAddress_ - calldata to be passed in deploy constructor
@@ -63,7 +63,7 @@ string[]
 
 signer.**signDeployAccountTransaction**(transaction) => _Promise < Signature >_
 
-Signs a DEPLOY_ACCOUNT transaction with the StarkNet private key and returns the signature.
+Signs a DEPLOY_ACCOUNT transaction with the Starknet private key and returns the signature.
 
 The _transactions_ object for write methods may include any of:
 
@@ -87,7 +87,7 @@ string[]
 
 signer.**signDeclareTransaction**(transaction, transactionsDetail [ , abi ]) => _Promise < Signature >_
 
-Signs a DECLARE transaction with the StarkNet private key and returns the signature.
+Signs a DECLARE transaction with the Starknet private key and returns the signature.
 
 The _transaction_ object for write methods may include any of:
 

--- a/www/docs/API/utils.md
+++ b/www/docs/API/utils.md
@@ -264,7 +264,7 @@ Returns a string.
 
 `calculateTransactionHashCommon(txHashPrefix: TransactionHashPrefix, version: BigNumberish,contractAddress: BigNumberish, entryPointSelector: BigNumberish, calldata: BigNumberish[], maxFee: BigNumberish, chainId: StarknetChainId, additionalData: BigNumberish[] = []): string`
 
-Calculates the transaction hash in the StarkNet network - a unique identifier of the transaction.
+Calculates the transaction hash in the Starknet network - a unique identifier of the transaction.
 
 Called internally in `calculateDeployTransactionHash` and `calculateTransactionHash`.
 
@@ -272,7 +272,7 @@ Called internally in `calculateDeployTransactionHash` and `calculateTransactionH
 
 `calculateDeployTransactionHash(contractAddress: BigNumberish, constructorCalldata: BigNumberish[], version: BigNumberish, chainId: StarknetChainId): string`
 
-Function that calculates the deployment transaction hash in the StarkNet network.
+Function that calculates the deployment transaction hash in the Starknet network.
 
 Internally calls `calculateTransactionHashCommon` with `TransactionHashPrefix.DEPLOY`.
 

--- a/www/docs/guides/L1message.md
+++ b/www/docs/guides/L1message.md
@@ -6,9 +6,9 @@ sidebar_position: 13
 
 You can exchange messages between L1 & L2 networks :
 
-- L2 StarkNet mainnet ↔️ L1 Ethereum.
-- L2 StarkNet testnet 1 & 2 ↔️ L1 Goerli ETH testnet.
-- L2 local StarkNet devnet ↔️ L1 local ETH testnet (Ganache, ...).
+- L2 Starknet mainnet ↔️ L1 Ethereum.
+- L2 Starknet testnet 1 & 2 ↔️ L1 Goerli ETH testnet.
+- L2 local Starknet devnet ↔️ L1 local ETH testnet (Ganache, ...).
 
 You can find explanation of the global mechanism [here](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/).
 
@@ -16,7 +16,7 @@ Most of the code for this message process will be written in Cairo, but Starknet
 
 ## L1 ➡️ L2 messages
 
-To send a message from L1 to L2, you need a solidity smart contract in the L1 network, calling the `SendMessageToL2` function of the StarkNet core contract. The interface of this function :
+To send a message from L1 to L2, you need a solidity smart contract in the L1 network, calling the `SendMessageToL2` function of the Starknet core contract. The interface of this function :
 
 ```solidity
 /**

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -4,11 +4,11 @@ sidebar_position: 8
 
 # Create account
 
-Since there are no Externally Owned Accounts (EOA) in StarkNet, all Accounts in StarkNet are contracts.
+Since there are no Externally Owned Accounts (EOA) in Starknet, all Accounts in Starknet are contracts.
 
-Unlike in Ethereum where a wallet is created with a public and private key pair, StarkNet Accounts are the only way to sign transactions and messages, and verify signatures. Therefore a Account - Contract interface is needed.
+Unlike in Ethereum where a wallet is created with a public and private key pair, Starknet Accounts are the only way to sign transactions and messages, and verify signatures. Therefore a Account - Contract interface is needed.
 
-Account contracts on StarkNet cannot be deployed without paying a fee.
+Account contracts on Starknet cannot be deployed without paying a fee.
 Create an account is a bit tricky ; you have several steps :
 
 1. Decide on your account type (OpenZeppelin, Argent, ...).
@@ -57,7 +57,7 @@ Then you have to fund this address!
 How to proceed is out of the scope of this guide, by you can for example :
 
 - Transfer ETH from another wallet.
-- Bridge ETH to this StarkNet address.
+- Bridge ETH to this Starknet address.
 - Use a faucet. (https://faucet.goerli.starknet.io/)
 - Mint ETH on starknet-devnet, like so:
 
@@ -237,4 +237,4 @@ await provider.waitForTransaction(transaction_hash);
 console.log('✅ New customized account created.\n   address =', contract_address);
 ```
 
-The pre-computed address has been funded automatically by minting new dummy ETH in StarkNet devnet!
+The pre-computed address has been funded automatically by minting new dummy ETH in Starknet devnet!

--- a/www/docs/guides/create_contract.md
+++ b/www/docs/guides/create_contract.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 When you have compiled your new Cairo contract, you can deploy it in the network.
 
-In StarkNet, a new contract has to be added in two phases :
+In Starknet, a new contract has to be added in two phases :
 
 1. Create the contract class.
 2. Deploy an instance of the contract.

--- a/www/docs/guides/estimate_fees.md
+++ b/www/docs/guides/estimate_fees.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 # Estimate fees
 
-By default, all non free StarkNet commands (declare, deploy, invoke) work without any limitation of cost.
+By default, all non free Starknet commands (declare, deploy, invoke) work without any limitation of cost.
 
 Nevertheless, you might want to inform the DAPP user of the cost of the incoming transaction before proceeding, and request its validation.
 

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -4,7 +4,7 @@ sidebar_position: 12
 
 # Reading emitted events
 
-## StarkNet events
+## Starknet events
 
 A contract may emit events throughout its execution. Each event contains the following fields:
 

--- a/www/docs/guides/intro.md
+++ b/www/docs/guides/intro.md
@@ -57,9 +57,9 @@ npm install # install docusaurus
 npm run start # fires up a local documentation site
 ```
 
-## Compiling StarkNet Contracts
+## Compiling Starknet Contracts
 
-Please check the StarkNet documentation <ins>[here](https://www.cairo-lang.org/docs/hello_starknet/intro.html)</ins> to compile StarkNet contracts.
+Please check the Starknet documentation <ins>[here](https://www.cairo-lang.org/docs/hello_starknet/intro.html)</ins> to compile Starknet contracts.
 
 Additional helpful resources can also be found at <ins>[OpenZeppelin](https://docs.openzeppelin.com/contracts-cairo/0.5.0/)</ins> documentation site.
 

--- a/www/docs/guides/multiCall.md
+++ b/www/docs/guides/multiCall.md
@@ -4,7 +4,7 @@ sidebar_position: 15
 
 # Interact with more than one contract within one transaction
 
-Interacting with more than one contract with one transaction is one of StarkNet's features. To use this feature, two contracts are required.
+Interacting with more than one contract with one transaction is one of Starknet's features. To use this feature, two contracts are required.
 
 ## Setup
 

--- a/www/docs/guides/use_ERC20.md
+++ b/www/docs/guides/use_ERC20.md
@@ -27,7 +27,7 @@ This way, the ERC20 contract is absolutely sure that the caller of the transfer 
 
 ## ETH token is an ERC20 in Starknet
 
-In opposition with Ethereum, the ETH token is an ERC20 in StarkNet, as all other tokens. In all networks, it's ERC20 contract address is :
+In opposition with Ethereum, the ETH token is an ERC20 in Starknet, as all other tokens. In all networks, it's ERC20 contract address is :
 
 ```typescript
 const addrETH = "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
@@ -56,7 +56,7 @@ Declaration and deployment of the ERC20 contract :
 
 ```typescript
 // Deploy an ERC20 contract
-console.log("Deployment Tx - ERC20 Contract to StarkNet...");
+console.log("Deployment Tx - ERC20 Contract to Starknet...");
 const compiledErc20mintable = json.parse(fs.readFileSync("compiled_contracts/ERC20MintableOZ051.json").toString("ascii"));
 const ERC20mintableClassHash = "0x795be772eab12ee65d5f3d9e8922d509d6672039978acc98697c0a563669e8";
 const initialTk = { low: 100, high: 0 };
@@ -92,7 +92,7 @@ Here we will read the balance, mint new tokens, and transfer tokens :
 
 ```typescript
 // Check balance - should be 100
-console.log(`Calling StarkNet for account balance...`);
+console.log(`Calling Starknet for account balance...`);
 const balanceInitial = await erc20.balanceOf(account0.address);
 console.log("account0 has a balance of :", uint256.uint256ToBN(balanceInitial.balance).toString());
 
@@ -105,12 +105,12 @@ const { transaction_hash: mintTxHash } = await erc20.mint(
 	{ maxFee: 900_000_000_000_000 }
 );
 
-// Wait for the invoke transaction to be accepted on StarkNet
-console.log(`Waiting for Tx to be Accepted on StarkNet - Minting...`);
+// Wait for the invoke transaction to be accepted on Starknet
+console.log(`Waiting for Tx to be Accepted on Starknet - Minting...`);
 await provider.waitForTransaction(mintTxHash);
 
 // Check balance - should be 1100
-console.log(`Calling StarkNet for account balance...`);
+console.log(`Calling Starknet for account balance...`);
 const balanceBeforeTransfer = await erc20.balanceOf(account0.address);
 console.log("account0 has a balance of :", uint256.uint256ToBN(balanceBeforeTransfer.balance).toString());
 
@@ -130,12 +130,12 @@ const { transaction_hash: transferTxHash } = await account0.execute({
 	{ maxFee: 900_000_000_000_000 }
 );
 
-// Wait for the invoke transaction to be accepted on StarkNet
-console.log(`Waiting for Tx to be Accepted on StarkNet - Transfer...`);
+// Wait for the invoke transaction to be accepted on Starknet
+console.log(`Waiting for Tx to be Accepted on Starknet - Transfer...`);
 await provider.waitForTransaction(transferTxHash);
 
 // Check balance after transfer - should be 1090
-console.log(`Calling StarkNet for account balance...`);
+console.log(`Calling Starknet for account balance...`);
 const balanceAfterTransfer = await erc20.balanceOf(account0.address);
 console.log("account0 has a balance of :", uint256.uint256ToBN(balanceAfterTransfer.balance).toString());
 console.log("✅ Script completed.");

--- a/www/docs/guides/what_s_starknet.js.md
+++ b/www/docs/guides/what_s_starknet.js.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # What is Starknet.js ?
 
-Starknet.js is a library that helps to connect your website or your Decentralized Application (DAPP) to the blockchain-based StarkNet network, using Javascript / Typescript language.
+Starknet.js is a library that helps to connect your website or your Decentralized Application (DAPP) to the blockchain-based Starknet network, using Javascript / Typescript language.
 
 ## Overview
 
@@ -14,14 +14,14 @@ Some important topics that have to be understood:
 
 - You can connect your DAPP to several networks :
 
-  - [StarkNet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
-  - [StarkNet testnet 1](https://testnet.starkscan.co/) & [testnet 2](https://testnet-2.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
-  - [StarkNet-devnet](https://shard-labs.github.io/starknet-devnet/docs/intro) (your local Starknet network, for developers).
+  - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
+  - [Starknet testnet 1](https://testnet.starkscan.co/) & [testnet 2](https://testnet-2.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
+  - [Starknet-devnet](https://shard-labs.github.io/starknet-devnet/docs/intro) (your local Starknet network, for developers).
 
   and also to some more specific solutions :
 
-  - private customized version of StarkNet.
-  - local StarkNet node (connected to mainnet or testnet).
+  - private customized version of Starknet.
+  - local Starknet node (connected to mainnet or testnet).
 
 - Only the `Provider` object is talking directly to the network - your DAPP will talk mainly to `Account` and `Contract` objects. You will define with the `Provider` with which network you want to work. You can ask the Provider some low level data of the network (block, timestamp, ...).
 - `Signer` and `Utils` objects contain many useful functions for the interaction with Starknet.js.


### PR DESCRIPTION
## Motivation and Resolution

Changes the spelling of "StarkNet" from "StarkNet" to "Starknet" everywhere in the doc following the recommendations in [this SNIP](https://community.starknet.io/t/snip-naming-convention-starknet-not-starknet).

## Checklist:

- [x] Updated the docs (www)