### PR TITLE
Feature/move-starkname-to-provider

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -293,7 +293,7 @@ describe('deploy and test Wallet', () => {
       const address = await account.getAddressFromStarkName('ben.stark', namingAddress);
       expect(hexToDecimalString(address as string)).toEqual(hexToDecimalString(account.address));
 
-      const name = await account.getStarkName(namingAddress);
+      const name = await account.getStarkName(undefined, namingAddress);
       expect(name).toEqual('ben.stark');
     });
   });

--- a/__tests__/utils/starknetId.test.ts
+++ b/__tests__/utils/starknetId.test.ts
@@ -28,6 +28,10 @@ describe('Should tets StarknetId utils', () => {
     }
   });
 
+  test('Should test useEncoded and useDecoded hook with an empty string', () => {
+    expect(useDecoded([])).toBe('');
+  });
+
   test('Should test useDecoded and useEncoded hook with an encoded number', () => {
     for (let index = 0; index < 2500; index += 1) {
       const decoded = useDecoded([new BN(index)]);

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -25,6 +25,7 @@ import { BigNumberish } from '../utils/number';
 import { ProviderInterface } from './interface';
 import { RpcProvider, RpcProviderOptions } from './rpc';
 import { SequencerProvider, SequencerProviderOptions } from './sequencer';
+import { getAddressFromStarkName, getStarkName } from './starknetId';
 import { BlockIdentifier } from './utils';
 
 export interface ProviderOptions {
@@ -206,5 +207,13 @@ export class Provider implements ProviderInterface {
 
   public async getStateUpdate(blockIdentifier?: BlockIdentifier): Promise<StateUpdateResponse> {
     return this.provider.getStateUpdate(blockIdentifier);
+  }
+
+  public async getStarkName(address: BigNumberish, StarknetIdContract?: string): Promise<string> {
+    return getStarkName(this, address, StarknetIdContract);
+  }
+
+  public async getAddressFromStarkName(name: string, StarknetIdContract?: string): Promise<string> {
+    return getAddressFromStarkName(this, name, StarknetIdContract);
   }
 }

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -31,6 +31,7 @@ import { parseCalldata, wait } from '../utils/provider';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 import { LibraryError } from './errors';
 import { ProviderInterface } from './interface';
+import { getAddressFromStarkName, getStarkName } from './starknetId';
 import { Block, BlockIdentifier } from './utils';
 
 export type RpcProviderOptions = {
@@ -499,5 +500,13 @@ export class RpcProvider implements ProviderInterface {
     _blockIdentifier?: BlockIdentifier
   ): Promise<TransactionSimulationResponse> {
     throw new Error('RPC does not implement simulateTransaction function');
+  }
+
+  public async getStarkName(address: BigNumberish, StarknetIdContract?: string): Promise<string> {
+    return getStarkName(this, address, StarknetIdContract);
+  }
+
+  public async getAddressFromStarkName(name: string, StarknetIdContract?: string): Promise<string> {
+    return getAddressFromStarkName(this, name, StarknetIdContract);
   }
 }

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -44,6 +44,7 @@ import { randomAddress } from '../utils/stark';
 import { buildUrl } from '../utils/url';
 import { GatewayError, HttpError, LibraryError } from './errors';
 import { ProviderInterface } from './interface';
+import { getAddressFromStarkName, getStarkName } from './starknetId';
 import { Block, BlockIdentifier } from './utils';
 
 type NetworkName = 'mainnet-alpha' | 'goerli-alpha' | 'goerli-alpha-2';
@@ -604,5 +605,13 @@ export class SequencerProvider implements ProviderInterface {
   ): Promise<Sequencer.BlockTransactionTracesResponse> {
     const args = new Block(blockIdentifier).sequencerIdentifier;
     return this.fetchEndpoint('get_block_traces', { ...args });
+  }
+
+  public async getStarkName(address: BigNumberish, StarknetIdContract?: string): Promise<string> {
+    return getStarkName(this, address, StarknetIdContract);
+  }
+
+  public async getAddressFromStarkName(name: string, StarknetIdContract?: string): Promise<string> {
+    return getAddressFromStarkName(this, name, StarknetIdContract);
   }
 }

--- a/src/provider/starknetId.ts
+++ b/src/provider/starknetId.ts
@@ -1,0 +1,64 @@
+import { BN } from 'bn.js';
+
+import { BigNumberish, hexToDecimalString, toBN, toHex } from '../utils/number';
+import { compileCalldata } from '../utils/stark';
+import { getStarknetIdContract, useDecoded, useEncoded } from '../utils/starknetId';
+import { ProviderInterface } from './interface';
+
+export async function getStarkName(
+  provider: ProviderInterface,
+  address: BigNumberish,
+  StarknetIdContract?: string
+): Promise<string> {
+  const chainId = await provider.getChainId();
+  const contract = StarknetIdContract ?? getStarknetIdContract(chainId);
+
+  try {
+    const hexDomain = await provider.callContract({
+      contractAddress: contract,
+      entrypoint: 'address_to_domain',
+      calldata: compileCalldata({
+        address: toHex(toBN(address)),
+      }),
+    });
+    const decimalDomain = hexDomain.result
+      .map((element) => new BN(hexToDecimalString(element)))
+      .slice(1);
+
+    const stringDomain = useDecoded(decimalDomain);
+
+    if (!stringDomain) {
+      throw Error('Starkname not found');
+    }
+
+    return stringDomain;
+  } catch (e) {
+    if (e instanceof Error && e.message === 'Starkname not found') {
+      throw e;
+    }
+    throw Error('Could not get stark name');
+  }
+}
+
+export async function getAddressFromStarkName(
+  provider: ProviderInterface,
+  name: string,
+  StarknetIdContract?: string
+): Promise<string> {
+  const chainId = await provider.getChainId();
+  const contract = StarknetIdContract ?? getStarknetIdContract(chainId);
+
+  try {
+    const addressData = await provider.callContract({
+      contractAddress: contract,
+      entrypoint: 'domain_to_address',
+      calldata: compileCalldata({
+        domain: [useEncoded(name.replace('.stark', '')).toString(10)],
+      }),
+    });
+
+    return addressData.result[0];
+  } catch {
+    throw Error('Could not get address from stark name');
+  }
+}

--- a/src/utils/starknetId.ts
+++ b/src/utils/starknetId.ts
@@ -52,6 +52,11 @@ export function useDecoded(encoded: BN[]): string {
           : bigAlphabet[bigAlphabet.length - 1].repeat((k - 1) / 2 + 1));
     decoded += '.';
   });
+
+  if (!decoded) {
+    return decoded;
+  }
+
   return decoded.concat('stark');
 }
 

--- a/www/docs/API/Provider/provider.md
+++ b/www/docs/API/Provider/provider.md
@@ -253,6 +253,30 @@ Wait for the transaction to be accepted on L2 or L1.
 
 ---
 
+### getStarkName()
+
+provider.**getStarkName**(address, StarknetIdContract) => _Promise<string | Error>_
+
+Gets starknet.id stark name with the address provided
+
+The _StarknetIdContract_ argument can be undefined, if it is, the function will automatically use official starknet id contracts of your network.
+
+Returns directly a string (Example: `vitalik.stark`).
+
+---
+
+### getAddressFromStarkName()
+
+provider.**getAddressFromStarkName**(name, StarknetIdContract) => _Promise<string | Error>_
+
+Gets account address with the starknet id stark name.
+
+The _StarknetIdContract_ argument can be undefined, if it is, the function will automatically use official starknet id contracts of your network.
+
+Returns directly the address in a string (Example: `0xff...34`).
+
+---
+
 ### getStateUpdate()
 
 provider.**getStateUpdate**(blockIdentifier) => _Promise < StateUpdateResponse >_

--- a/www/docs/API/account.md
+++ b/www/docs/API/account.md
@@ -525,25 +525,13 @@ The _details_ object may include any of:
 
 ### getStarkName()
 
-account.**getStarkName**(StarknetIdContract) => _Promise<string | Error>_
+account.**getStarkName**(address, StarknetIdContract) => _Promise<string | Error>_
 
-Gets starknet.id stark name with the address of the account
+Gets starknet.id stark name with the address provided, if `undefined` uses the address of the account
 
-The _StarknetIdContract_ argument can be undefined, if it is, the function will automatically use official starknet id contracts of your network (It currently supports TESTNET 1 only).
+The _StarknetIdContract_ argument can be undefined, if it is, the function will automatically use official starknet id contracts of your network.
 
 Returns directly a string (Example: `vitalik.stark`).
-
----
-
-### getAddressFromStarkName()
-
-account.**getAddressFromStarkName**(name, StarknetIdContract) => _Promise<string | Error>_
-
-Gets account address with the starknet id stark name.
-
-The _StarknetIdContract_ argument can be undefined, if it is, the function will automatically use official starknet id contracts of your network (It currently supports TESTNET 1 only).
-
-Returns directly the address in a string (Example: `0xff...34`).
 
 ---
 


### PR DESCRIPTION
## Motivation and Resolution

Starkname should be available in the provider to use.

## Usage related changes

- Provider has `getStarkName` and `getAddressFromStarkName` now
- Account changes from `getStarkName(contract?: BigNumberish)` to `getStarkName(address?: BigNumberish, contract?: BigNumberish)`
- fixes #519

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes
- [x] Updated the docs (www)
- [x] Updated the tests
- [x] All tests are passing
