### PR TITLE
fix: add max_fee to sequencer getSimulateTransaction

### DIFF
--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -595,6 +595,7 @@ export class SequencerProvider implements ProviderInterface {
         signature: signatureToDecimalArray(invocation.signature),
         version: toHex(invocationDetails?.version || 1),
         nonce: toHex(invocationDetails.nonce),
+        max_fee: toHex(invocationDetails?.maxFee || 0),
       }
     ).then(this.responseParser.parseFeeSimulateTransactionResponse);
   }

--- a/src/types/api/sequencer.ts
+++ b/src/types/api/sequencer.ts
@@ -258,7 +258,7 @@ export namespace Sequencer {
     fee_estimation: Sequencer.EstimateFeeResponse;
   };
 
-  export type SimulateTransaction = Omit<InvokeFunctionTransaction, 'max_fee' | 'entry_point_type'>;
+  export type SimulateTransaction = Omit<InvokeFunctionTransaction, 'entry_point_type'>;
 
   export type EstimateFeeRequestBulk = AllowArray<
     InvokeEstimateFee | DeclareEstimateFee | DeployEstimateFee | DeployAccountEstimateFee


### PR DESCRIPTION
## Motivation and Resolution

Adding `max_fee` to `getSimulateTransaction`. I don't know why it is not present, I assume it's a bug and this is the fix.
It is required to get the trace of a  transaction before submitting it. 

Waiting for sequencer v0.11 to skip validation is also not a viable solution as one might need validation to be performed. (and the transaction hash to be correct). Or worse doing another signature without the max_fee field

## Usage related changes

- No more  ```Signature (xx, xx), is invalid, with respect to the public key xx, and the message hash xx.``` when using `simulate_transaction`
