### PR TITLE
fix: ec.verify with Starknet pub key.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,22 @@ npm run build
 
 Run linters and tests:
 
+In a separate console, launch a Starknet devnet
+
+```bash
+starknet-devnet --seed 0
+```
+
+> If you do not include `seed 0`, you need to export account and private key of preseeded accounts from devnet :  
+> `export TEST_ACCOUNT_ADDRESS=0x0....`  
+> `export TEST_ACCOUNT_PRIVATE_KEY=123...`
+
+- to test sequencer : `export TEST_PROVIDER_BASE_URL=http://127.0.0.1:5050/`
+- to test rpc : `export TEST_RPC_URL=http://127.0.0.1:5050/rpc`
+- you can check if devnet is reachable : open page `http://127.0.0.1:5050/is_alive`
+
+Launch tests :
+
 ```bash
 npm test
 ```

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -1,5 +1,5 @@
 import typedDataExample from '../__mocks__/typedDataExample.json';
-import { Account, Contract, Provider, TransactionStatus, ec, stark } from '../src';
+import { Account, Contract, Provider, TransactionStatus, ec, hash, stark } from '../src';
 import { uint256 } from '../src/utils/calldata/cairo';
 import { parseUDCEvent } from '../src/utils/events';
 import { calculateContractAddressFromHash, feeTransactionVersion } from '../src/utils/hash';
@@ -243,8 +243,8 @@ describe('deploy and test Wallet', () => {
         '1893860513534673656759973582609638731665558071107553163765293299136715951024';
       const whitelistingPrivateKey =
         '301579081698031303837612923223391524790804435085778862878979120159194507372';
-      const hashed = ec.starkCurve.pedersen(
-        ec.starkCurve.pedersen(toBigInt('18925'), toBigInt('1922775124')),
+      const hashed = hash.pedersen(
+        hash.pedersen(toBigInt('18925'), toBigInt('1922775124')),
         toBigInt(account.address)
       );
       const signed = ec.starkCurve.sign(hashed, toHex(whitelistingPrivateKey));

--- a/__tests__/utils/__snapshots__/ellipticalCurve.test.ts.snap
+++ b/__tests__/utils/__snapshots__/ellipticalCurve.test.ts.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`pedersen() 1`] = `"0x5ed2703dfdb505c587700ce2ebfcab5b3515cd7e6114817e6026ec9d4b364ca"`;
-
-exports[`pedersen() with 0 1`] = `"0x1a5c561f97b52c17a19f34c4499a745cd4e8412e29e4ed5e91e4481c7d53935"`;

--- a/__tests__/utils/__snapshots__/hash.test.ts.snap
+++ b/__tests__/utils/__snapshots__/hash.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Hash Tester pedersen() 1`] = `"0x5ed2703dfdb505c587700ce2ebfcab5b3515cd7e6114817e6026ec9d4b364ca"`;
+
+exports[`Hash Tester pedersen() with 0 1`] = `"0x1a5c561f97b52c17a19f34c4499a745cd4e8412e29e4ed5e91e4481c7d53935"`;

--- a/__tests__/utils/ellipticalCurve.test.ts
+++ b/__tests__/utils/ellipticalCurve.test.ts
@@ -1,85 +1,36 @@
-import { ec } from '../../src';
-import { StarknetChainId } from '../../src/constants';
-import {
-  calculateTransactionHash,
-  computeHashOnElements,
-  transactionVersion,
-} from '../../src/utils/hash';
-import { fromCallsToExecuteCalldataWithNonce } from '../../src/utils/transaction';
+import { ec, hash } from '../../src';
 
-test('getKeyPair()', () => {
+test('getStarkKey()', () => {
   const privateKey = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
   const starkKey = ec.starkCurve.getStarkKey(privateKey);
-  // somehow needed, returns error else
   expect(starkKey).toBe('0x33f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d99745');
 });
 
-test('pedersen()', () => {
-  const own = ec.starkCurve.pedersen('0x12773', '0x872362');
-  expect(own).toMatchSnapshot();
-});
-
-test('pedersen() with 0', () => {
-  const own = ec.starkCurve.pedersen('0x12773', '0x0');
-  expect(own).toMatchSnapshot();
-});
-
-test('computeHashOnElements()', () => {
-  const array = ['1', '2', '3', '4'];
-  expect(computeHashOnElements(array)).toBe(
-    '0x66bd4335902683054d08a0572747ea78ebd9e531536fb43125424ca9f902084'
-  );
-  expect(array).toStrictEqual(['1', '2', '3', '4']);
-
-  expect(computeHashOnElements(['1', '2'])).toBe(
-    '0x501a3a8e6cd4f5241c639c74052aaa34557aafa84dd4ba983d6443c590ab7df'
-  );
-});
-
-test('hashMessage()', () => {
+test('getPublicKey()', () => {
   const privateKey = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
-  const account = '2007067565103695475819120104515800035851923905855118399071773059478896040938';
-  const transactions = [
-    {
-      contractAddress:
-        '3290661298119599979891444342541795905081168856323302956721669397616389152866',
-      entrypoint: 'set_number',
-      calldata: ['47'],
-    },
-  ];
-  const nonce = '3';
-  const maxFee = '0';
-  const calldata = fromCallsToExecuteCalldataWithNonce(transactions, nonce);
-
-  const hashMsg = calculateTransactionHash(
-    account,
-    transactionVersion,
-    calldata,
-    maxFee,
-    StarknetChainId.SN_GOERLI,
-    nonce
-  );
-
-  expect(hashMsg).toMatchInlineSnapshot(
-    `"0x6d1706bd3d1ba7c517be2a2a335996f63d4738e2f182144d078a1dd9997062e"`
-  );
-
-  const { r, s } = ec.starkCurve.sign(hashMsg, privateKey);
-
-  expect(r.toString()).toMatchInlineSnapshot(
-    `"1427981024487605678086498726488552139932400435436186597196374630267616399345"`
-  );
-  expect(s.toString()).toMatchInlineSnapshot(
-    `"1853664302719670721837677288395394946745467311923401353018029119631574115563"`
+  const fullPubKey = ec.starkCurve.getPublicKey(privateKey);
+  // somehow needed, returns error else
+  expect(fullPubKey).toBe(
+    '0x04033f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d997450319d0f53f6ca077c4fa5207819144a2a4165daef6ee47a7c1d06c0dcaa3e456'
   );
 });
 
-test('verify signed message()', () => {
-  const pk = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+test('verify signed message with full public key()', () => {
+  const privk = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
   const account = '0x33f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d99745';
   const price = '1';
-  const hashMsg = ec.starkCurve.pedersen(account, price);
-  const signature = ec.starkCurve.sign(hashMsg, pk);
-  const pubKey = ec.starkCurve.getPublicKey(pk);
-  expect(ec.starkCurve.verify(signature.toDERHex(), hashMsg, pubKey)).toBe(true);
+  const hashMsg = hash.pedersen(account, price);
+  const signature = ec.starkCurve.sign(hashMsg, privk);
+  const pubKey = ec.starkCurve.getPublicKey(privk);
+  expect(ec.starkCurve.verify(signature, hashMsg, pubKey)).toBe(true);
+});
+
+test('verify signed message with Starknet public Key()', () => {
+  const privk = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+  const account = '0x33f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d99745';
+  const price = '1';
+  const hashMsg = hash.pedersen(account, price);
+  const signature = ec.starkCurve.sign(hashMsg, privk);
+  const pubKey = ec.starkCurve.getStarkKey(privk);
+  expect(ec.starkCurve.verify(signature, hashMsg, pubKey)).toBe(true);
 });

--- a/__tests__/utils/ellipticalCurveV4.test.ts
+++ b/__tests__/utils/ellipticalCurveV4.test.ts
@@ -1,0 +1,34 @@
+import { ec, hash } from '../../src';
+import { removeHexPrefix } from '../../src/utils/encode';
+
+// Test of all deprecated ec functions from V4
+
+test('genKeyPair()', () => {
+  const pair = ec.genKeyPair();
+  expect(pair.constructor.name).toBe('KeyPair');
+});
+
+test('getKeyPair() & getStarkKey() & Keypair.getPrivate()', () => {
+  const privateKey = '0x19800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+  const pair = ec.getKeyPair(privateKey);
+  expect(ec.getStarkKey(pair)).toBe(
+    '0x033f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d99745'
+  );
+
+  expect(pair.getPrivate('hex')).toBe(privateKey);
+});
+
+test('verify signed message()', () => {
+  const pk = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+  const account = '0x33f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d99745';
+  const price = '1';
+  const hashMsg = hash.pedersen(account, price);
+  const keyPair = ec.getKeyPair(pk);
+  const signature = ec.sign(keyPair, removeHexPrefix(hashMsg));
+  const pubKey = keyPair.getPublic('hex');
+  expect(pubKey).toBe(
+    '0x4033f45f07e1bd1a51b45fc24ec8c8c9908db9e42191be9e169bfcac0c0d997450319d0f53f6ca077c4fa5207819144a2a4165daef6ee47a7c1d06c0dcaa3e456'
+  );
+  const pubKeyPair = ec.getKeyPairFromPublicKey(pubKey);
+  expect(ec.verify(pubKeyPair, removeHexPrefix(hashMsg), signature)).toBe(true);
+});

--- a/__tests__/utils/hash.test.ts
+++ b/__tests__/utils/hash.test.ts
@@ -1,4 +1,4 @@
-import { computeContractClassHash, getSelectorFromName } from '../../src/utils/hash';
+import { constants, ec, hash, num, transaction } from '../../src';
 import {
   compiledErc20,
   compiledOpenZeppelinAccount,
@@ -7,14 +7,26 @@ import {
 } from '../fixtures';
 
 describe('Hash Tester', () => {
+  test('keccakBn', () => {
+    const data = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+    const ha = hash.keccakBn(data);
+    expect(ha).toBe('0x134d917421787dc6f797e97ebf96ef55fda2e0c22433544cb90da656ebb5a1c');
+  });
+
+  test('starknetKeccak', () => {
+    const data = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+    const ha = hash.starknetKeccak(data);
+    expect(num.toHex(ha)).toBe('0x2fb0ce11acb684c1354cac9d3349dda7bf6cc71fde4267dab6b7e92c9631ff');
+  });
+
   test('Test getSelectorFromName', () => {
-    const hash = getSelectorFromName('__validate__');
-    expect(hash).toEqual('0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775');
+    const hash0 = hash.getSelectorFromName('__validate__');
+    expect(hash0).toEqual('0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775');
   });
 
   describe('Compute ClassHash of various contracts', () => {
     test('ERC20 Contract ClassHash', () => {
-      const classHash = computeContractClassHash(compiledErc20);
+      const classHash = hash.computeContractClassHash(compiledErc20);
 
       expect(classHash).toEqual(erc20ClassHash);
       expect(classHash).toMatchInlineSnapshot(
@@ -23,7 +35,7 @@ describe('Hash Tester', () => {
     });
 
     test('OZ ERC20 Contract ClassHash', () => {
-      const classHash = computeContractClassHash(compiledOpenZeppelinAccount);
+      const classHash = hash.computeContractClassHash(compiledOpenZeppelinAccount);
 
       expect(classHash).toMatchInlineSnapshot(
         `"0x58d97f7d76e78f44905cc30cb65b91ea49a4b908a76703c54197bca90f81773"`
@@ -31,11 +43,106 @@ describe('Hash Tester', () => {
     });
 
     test('Test DApp Contract ClassHash', () => {
-      const classHash = computeContractClassHash(compiledTestDapp);
+      const classHash = hash.computeContractClassHash(compiledTestDapp);
 
       expect(classHash).toMatchInlineSnapshot(
         `"0x4367b26fbb92235e8d1137d19c080e6e650a6889ded726d00658411cc1046f5"`
       );
     });
+  });
+  test('pedersen()', () => {
+    const own = hash.pedersen('0x12773', '0x872362');
+    expect(own).toMatchSnapshot();
+  });
+
+  test('pedersen() with 0', () => {
+    const own = hash.pedersen('0x12773', '0x0');
+    expect(own).toMatchSnapshot();
+  });
+
+  test('computeHashOnElements()', () => {
+    const array = ['1', '2', '3', '4'];
+    expect(hash.computeHashOnElements(array)).toBe(
+      '0x66bd4335902683054d08a0572747ea78ebd9e531536fb43125424ca9f902084'
+    );
+    expect(array).toStrictEqual(['1', '2', '3', '4']);
+
+    expect(hash.computeHashOnElements(['1', '2'])).toBe(
+      '0x501a3a8e6cd4f5241c639c74052aaa34557aafa84dd4ba983d6443c590ab7df'
+    );
+  });
+
+  test('hashMessage()', () => {
+    const privateKey = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
+    const account = '2007067565103695475819120104515800035851923905855118399071773059478896040938';
+    const transactions = [
+      {
+        contractAddress:
+          '3290661298119599979891444342541795905081168856323302956721669397616389152866',
+        entrypoint: 'set_number',
+        calldata: ['47'],
+      },
+    ];
+    const nonce = '3';
+    const maxFee = '0';
+    const calldata = transaction.fromCallsToExecuteCalldataWithNonce(transactions, nonce);
+
+    const hashMsg = hash.calculateTransactionHash(
+      account,
+      hash.transactionVersion,
+      calldata,
+      maxFee,
+      constants.StarknetChainId.SN_GOERLI,
+      nonce
+    );
+
+    expect(hashMsg).toMatchInlineSnapshot(
+      `"0x6d1706bd3d1ba7c517be2a2a335996f63d4738e2f182144d078a1dd9997062e"`
+    );
+
+    const { r, s } = ec.starkCurve.sign(hashMsg, privateKey);
+
+    expect(r.toString()).toMatchInlineSnapshot(
+      `"1427981024487605678086498726488552139932400435436186597196374630267616399345"`
+    );
+    expect(s.toString()).toMatchInlineSnapshot(
+      `"1853664302719670721837677288395394946745467311923401353018029119631574115563"`
+    );
+  });
+});
+
+describe('getSelectorFromName()', () => {
+  test('hash works for value="test"', () => {
+    expect(hash.getSelectorFromName('test')).toBe(
+      '0x22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
+    );
+  });
+  test('hash works for value="initialize"', () => {
+    expect(hash.getSelectorFromName('initialize')).toBe(
+      '0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463'
+    );
+  });
+  test('hash works for value="mint"', () => {
+    expect(hash.getSelectorFromName('mint')).toBe(
+      '0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354'
+    );
+  });
+});
+describe('computeHashOnElements()', () => {
+  test('should return valid hash for empty array', () => {
+    const res = hash.computeHashOnElements([]);
+    expect(res).toMatchInlineSnapshot(
+      `"0x49ee3eba8c1600700ee1b87eb599f16716b0b1022947733551fde4050ca6804"`
+    );
+  });
+  test('should return valid hash for valid array', () => {
+    const res = hash.computeHashOnElements([
+      num.toBigInt(123782376),
+      num.toBigInt(213984),
+      num.toBigInt(128763521321),
+    ]);
+    expect(res).toMatchInlineSnapshot(
+      `"0x7b422405da6571242dfc245a43de3b0fe695e7021c148b918cd9cdb462cac59"`
+    );
   });
 });

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { constants, ec, hash, num, stark } from '../../src';
+import { constants, hash, num, stark } from '../../src';
 import { Block } from '../../src/provider/utils';
 
 const { IS_BROWSER } = constants;
@@ -31,41 +31,6 @@ describe('makeAddress()', () => {
   });
 });
 
-describe('getSelectorFromName()', () => {
-  test('hash works for value="test"', () => {
-    expect(hash.getSelectorFromName('test')).toBe(
-      '0x22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658'
-    );
-  });
-  test('hash works for value="initialize"', () => {
-    expect(hash.getSelectorFromName('initialize')).toBe(
-      '0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463'
-    );
-  });
-  test('hash works for value="mint"', () => {
-    expect(hash.getSelectorFromName('mint')).toBe(
-      '0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354'
-    );
-  });
-});
-describe('computeHashOnElements()', () => {
-  test('should return valid hash for empty array', () => {
-    const res = hash.computeHashOnElements([]);
-    expect(res).toMatchInlineSnapshot(
-      `"0x49ee3eba8c1600700ee1b87eb599f16716b0b1022947733551fde4050ca6804"`
-    );
-  });
-  test('should return valid hash for valid array', () => {
-    const res = hash.computeHashOnElements([
-      num.toBigInt(123782376),
-      num.toBigInt(213984),
-      num.toBigInt(128763521321),
-    ]);
-    expect(res).toMatchInlineSnapshot(
-      `"0x7b422405da6571242dfc245a43de3b0fe695e7021c148b918cd9cdb462cac59"`
-    );
-  });
-});
 describe('estimatedFeeToMaxFee()', () => {
   test('should return maxFee for 0', () => {
     const res = stark.estimatedFeeToMaxFee(0, 0.15);
@@ -88,7 +53,7 @@ describe('calculateContractAddressFromHash()', () => {
     const classHash = '0x55187E68C60664A947048E0C9E5322F9BF55F7D435ECDCF17ED75724E77368F';
 
     // Any type of salt can be used. It depends on the dApp what kind of salt it wants to use.
-    const salt = ec.starkCurve.pedersen(ethAddress, daiAddress);
+    const salt = hash.pedersen(ethAddress, daiAddress);
 
     const res = hash.calculateContractAddressFromHash(
       salt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
-        "@noble/curves": "^0.7.1",
-        "ethereum-cryptography": "^1.0.3",
+        "@noble/curves": "^0.7.3",
         "isomorphic-fetch": "^3.0.0",
         "json-bigint": "^1.0.0",
         "pako": "^2.0.4",
@@ -1747,6 +1746,7 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3241,17 +3241,6 @@
         }
       ]
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3481,48 +3470,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
-      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "@noble/hashes": "~1.2.0",
-        "@noble/secp256k1": "~1.7.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
-      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "@noble/hashes": "~1.2.0",
-        "@scure/base": "~1.1.0"
       }
     },
     "node_modules/@semantic-release/changelog": {
@@ -5105,6 +5052,7 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -5119,13 +5067,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5135,6 +5085,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6984,17 +6935,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ethereum-cryptography": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
-      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
-      "dependencies": {
-        "@noble/hashes": "1.2.0",
-        "@noble/secp256k1": "1.7.1",
-        "@scure/bip32": "1.1.5",
-        "@scure/bip39": "1.1.1"
       }
     },
     "node_modules/execa": {
@@ -18691,7 +18631,8 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@commitlint/cli": {
       "version": "17.4.4",
@@ -19797,11 +19738,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
       "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
     },
-    "@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -19981,30 +19917,6 @@
       "requires": {
         "@pnpm/network.ca-file": "^1.0.1",
         "config-chain": "^1.1.11"
-      }
-    },
-    "@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
-    },
-    "@scure/bip32": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
-      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
-      "requires": {
-        "@noble/hashes": "~1.2.0",
-        "@noble/secp256k1": "~1.7.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
-    "@scure/bip39": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
-      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
-      "requires": {
-        "@noble/hashes": "~1.2.0",
-        "@scure/base": "~1.1.0"
       }
     },
     "@semantic-release/changelog": {
@@ -21198,6 +21110,7 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
       "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
@@ -21207,19 +21120,22 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
+          "peer": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -22507,17 +22423,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "ethereum-cryptography": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
-      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
-      "requires": {
-        "@noble/hashes": "1.2.0",
-        "@noble/secp256k1": "1.7.1",
-        "@scure/bip32": "1.1.5",
-        "@scure/bip39": "1.1.1"
-      }
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.6.1",
-    "@noble/curves": "^0.7.1",
-    "ethereum-cryptography": "^1.0.3",
+    "@noble/curves": "^0.7.3",
     "isomorphic-fetch": "^3.0.0",
     "json-bigint": "^1.0.0",
     "pako": "^2.0.4",

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -31,12 +31,12 @@ import {
   UniversalDeployerContractPayload,
 } from '../types';
 import { EstimateFeeBulk, TransactionSimulation } from '../types/account';
-import { starkCurve } from '../utils/ec';
 import { parseUDCEvent } from '../utils/events';
 import {
   calculateContractAddressFromHash,
   computeContractClassHash,
   feeTransactionVersion,
+  pedersen,
   transactionVersion,
 } from '../utils/hash';
 import { BigNumberish, toBigInt, toCairoBool, toHex } from '../utils/num';
@@ -368,7 +368,7 @@ export class Account extends Provider implements AccountInterface {
           ],
         },
         address: calculateContractAddressFromHash(
-          unique ? starkCurve.pedersen(this.address, deploySalt) : deploySalt,
+          unique ? pedersen(this.address, deploySalt) : deploySalt,
           classHash,
           compiledConstructorCallData,
           unique ? UDC.ADDRESS : 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,15 +21,19 @@ export * as merkle from './utils/merkle';
 export * as uint256 from './utils/uint256';
 export * as shortString from './utils/shortString';
 export * as typedData from './utils/typedData';
-export * as ec from './utils/ec';
+export * as cairo from './utils/calldata/cairo';
+export * as ec from './utils/ec/ec';
 export * from './utils/address';
 export * from './utils/url';
+
+// eslint-disable-next-line import/first, prettier/prettier
+import { felt } from './utils/calldata/cairo';
+// eslint-disable-next-line import/first, prettier/prettier
+import * as n from './utils/num';
 
 /**
  * Deprecated
  */
-/* eslint-disable import/first */
-import * as num from './utils/num';
 
 /** @deprecated prefer the 'num' naming */
-export const number = num;
+export const number = { ...n, toFelt: felt };

--- a/src/signer/default.ts
+++ b/src/signer/default.ts
@@ -1,6 +1,6 @@
 import { Abi, Call, DeclareSignerDetails, InvocationsSignerDetails, Signature } from '../types';
 import { DeployAccountSignerDetails } from '../types/signer';
-import { starkCurve } from '../utils/ec';
+import { starkCurve } from '../utils/ec/ec';
 import { buf2hex } from '../utils/encode';
 import {
   calculateDeclareTransactionHash,

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -1,4 +1,4 @@
-import { weierstrass } from '../utils/ec';
+import { weierstrass } from '../utils/ec/ec';
 import type { BigNumberish } from '../utils/num';
 import { RPC } from './api/rpc';
 

--- a/src/utils/ec.ts
+++ b/src/utils/ec.ts
@@ -1,2 +1,0 @@
-export * as starkCurve from '@noble/curves/stark';
-export * as weierstrass from '@noble/curves/abstract/weierstrass';

--- a/src/utils/ec/ec.ts
+++ b/src/utils/ec/ec.ts
@@ -1,0 +1,158 @@
+import {
+  getPublicKey,
+  getStarkKey as getStarkKeyNoble,
+  sign as signNoble,
+  utils,
+  verify as verifyNoble,
+} from '@noble/curves/stark';
+
+import { MAX_ECDSA_VAL, ZERO } from '../../constants';
+import { addHexPrefix, buf2hex, sanitizeHex } from '../encode';
+import { BigNumberish, assertInRange, toHex } from '../num';
+
+export * as starkCurve from './ecAdaptNoble';
+export * as weierstrass from '@noble/curves/abstract/weierstrass';
+
+// here the 8 methods with V4 interface
+
+/**
+ * class that handle a key pair private/public.
+ * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+ */
+export class KeyPair {
+  private readonly privateKey: bigint;
+
+  private publicKey: bigint;
+
+  constructor(privKey: BigNumberish) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    !privKey
+      ? (this.privateKey = BigInt(buf2hex(utils.randomPrivateKey())))
+      : (this.privateKey = BigInt(privKey));
+
+    this.publicKey =
+      BigInt(privKey) === 0n
+        ? 0n
+        : BigInt(addHexPrefix(buf2hex(getPublicKey(toHex(this.privateKey)))));
+  }
+
+  /**
+   * get full public key
+   * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+   * Replaced by `ec.starkCurve.getPublicKey`
+   * @param enc - optional. if 'hex' returns hex string, else returns a numString
+   * @returns an Hex string with `0x04` prefix, or a numString.
+   */
+  public getPublic(enc?: string): string {
+    if (enc === 'hex') {
+      return toHex(this.publicKey);
+    }
+    return this.publicKey.toString();
+  }
+
+  /**
+   *
+   * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+   */
+  public setPublic(pubK: BigNumberish) {
+    this.publicKey = BigInt(pubK);
+  }
+
+  /**
+   * get private key
+   * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+   * @param enc - optional. if 'hex' returns hex string, else returns a numString
+   * @returns an Hex string with `0x` prefix, or a numString.
+   */
+  public getPrivate(enc?: string): string {
+    if (enc === 'hex') {
+      return toHex(this.privateKey);
+    }
+    return this.privateKey.toString();
+  }
+}
+
+/**
+ * get a key pair from a private key
+ * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+ * @param pk - private key
+ * @returns key pair
+ */
+export function getKeyPair(pk: BigNumberish): KeyPair {
+  return new KeyPair(BigInt(pk));
+}
+
+/**
+ * get a key pair from a random private key
+ * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+ * @returns key pair
+ */
+export function genKeyPair(): KeyPair {
+  return getKeyPair(addHexPrefix(buf2hex(utils.randomPrivateKey())));
+}
+
+/**
+ * get the Starknet public key, from a KeyPair.
+ * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+ * Replaced by `ec.starkCurve.getStarkKey`
+ * @param keyPair
+ * @returns a Starknet public key (only X part of the 512 bits public key, without HEAD)
+ */
+export function getStarkKey(keyPair: KeyPair): string {
+  // this method needs to be run to generate the .pub property used below
+  // the result can be dumped
+  return sanitizeHex(getStarkKeyNoble(keyPair.getPrivate('hex')));
+}
+
+/**
+ * Takes a public key and casts it into `elliptic` KeyPair format.
+ * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+ * @param publicKey - public key which should get casted to a KeyPair
+ * @returns keyPair with public key only, which can be used to verify signatures, but cant sign anything
+ */
+export function getKeyPairFromPublicKey(publicKey: BigNumberish): KeyPair {
+  const keyPair = new KeyPair('0x00');
+  keyPair.setPublic(BigInt(publicKey));
+  return keyPair;
+}
+
+/**
+ * Signs a message using the provided key.
+ *
+ * @deprecated Only for migration V4 -> V5. Do not use in new code using V5 onwards.
+ * Replaced by `ec.starkCurve.sign`
+ * @param keyPair should be an KeyPair with a valid private key.
+ * @returns a Signature.
+ */
+export function sign(keyPair: KeyPair, msgHash: string): string {
+  const msgHashBi = BigInt(addHexPrefix(msgHash));
+  // Verify message hash has valid length.
+  assertInRange(msgHashBi, ZERO, BigInt(addHexPrefix(MAX_ECDSA_VAL)), 'msgHash');
+  return signNoble(msgHash, keyPair.getPrivate('hex')).toDERHex();
+}
+
+/**
+ * Verifies a message using the provided key.
+ * @deprecated Only for migration V4 -> V5.
+ * Do not use in new code using V5 onwards.
+ * Replaced by `ec.starkCurve.verify`
+ * @param keyPair should be an KeyPair with a valid public key.
+ * @param sig should be an Signature.
+ * @returns true if the verification succeeds.
+ */
+export function verify(
+  keyPair: KeyPair | KeyPair[],
+  msgHash: string,
+  sig: string | string[]
+): boolean {
+  const keyPairArray = Array.isArray(keyPair) ? keyPair : [keyPair];
+  const sigArray = Array.isArray(sig) ? sig : [sig];
+  const msgHashBi = BigInt(addHexPrefix(msgHash));
+  if (sig.length % 2 !== 0) throw new Error('Signature must be an array of length dividable by 2');
+  assertInRange(msgHashBi, ZERO, BigInt(addHexPrefix(MAX_ECDSA_VAL)), 'msgHash');
+  if (keyPairArray.length !== sigArray.length)
+    throw new Error('Signature and keyPair length must be equal');
+  return sigArray.every((singleSignature, i) => {
+    return verifyNoble(singleSignature, msgHash, keyPairArray[i].getPublic('hex')) ?? false;
+  });
+}

--- a/src/utils/ec/ecAdaptNoble.ts
+++ b/src/utils/ec/ecAdaptNoble.ts
@@ -1,0 +1,83 @@
+import { Hex } from '@noble/curves/abstract/utils';
+import { SignatureType } from '@noble/curves/abstract/weierstrass';
+import {
+  CURVE,
+  getPublicKey as getPublicKeyNoble,
+  verify as verifyNoble,
+} from '@noble/curves/stark';
+
+import { addHexPrefix, buf2hex } from '../encode';
+import { BigNumberish, toHex } from '../num';
+
+/**
+ * Verifies a message using the provided public key
+ * @param signature - signature of the hashed message
+ * @param msgHash - Hash of the message
+ * @param pubKey - public key. 512 bits full public key or 256 bits compressed (Starknet, without 0x02 or 0x03 head)
+ * @returns true if the message is verified
+ */
+export function verify(signature: SignatureType | Hex, msgHash: Hex, pubKey: Hex): boolean {
+  // adapted because Noble verify() do not handle Starknet public key.
+
+  /**
+   * y² = x³ + ax + b: Short weierstrass curve formula
+   * @returns y²
+   */
+  function weierstrassEquation(x: bigint): bigint {
+    const { a, b } = CURVE;
+    return x * x * x + a * x + b;
+  }
+
+  function isValidFieldElement(num: bigint): boolean {
+    return CURVE.Fp.ZERO < num && num < CURVE.Fp.ORDER; // 0 is banned since it's not invertible FE
+  }
+
+  const pubKeyHex =
+    typeof pubKey === 'string' ? addHexPrefix(pubKey) : addHexPrefix(buf2hex(pubKey));
+  if (pubKeyHex.slice(2, 4) === '04') {
+    // full public key (512 bits)
+    return verifyNoble(signature, msgHash, pubKeyHex);
+  }
+  const x = BigInt(pubKeyHex);
+  if (!isValidFieldElement(x))
+    throw new Error('Public key provided not valid : Point is not on curve');
+  const y2 = weierstrassEquation(x); // y² = x³ + ax + b
+  const y = CURVE.Fp.sqrt(y2); // y = y² ^ (p+1)/4
+  const yneg = CURVE.Fp.neg(y); // to use if HEAD and y do not have same parity
+  // HEAD (0x02 or 0x03) is unknown (not provided by Starknet).
+  // So both solutions (y and neg y) have to try to verify the result.
+  // if one succeeds, verification is TRUE.
+  // eslint-disable-next-line prefer-template
+  const pubKeySolution1 = '0x040' + x.toString(16) + '0' + y.toString(16);
+  // eslint-disable-next-line prefer-template
+  const pubKeySolution2 = '0x040' + x.toString(16) + '0' + yneg.toString(16);
+
+  const verif1 = verifyNoble(signature, msgHash, pubKeySolution1);
+  const verif2 = verifyNoble(signature, msgHash, pubKeySolution2);
+  return verif1 || verif2;
+}
+
+/**
+ * Provides a hex public key, from a Hex private key.
+ * @param privKey - private key, on 32 bytes.
+ * @param isCompressed - optional format of key. Normaly not used with Starknet.
+ * @returns Hex string of the full public key (64 bytes), with 0x prefix.
+ */
+export function getPublicKey(privKey: BigNumberish, isCompressed = false): string {
+  // adapted due to Uint8Array return from Noble getPublicKey.
+  const privKeyHex = toHex(BigInt(privKey));
+  return addHexPrefix(buf2hex(getPublicKeyNoble(privKeyHex, isCompressed)));
+}
+
+export {
+  getSharedSecret,
+  sign,
+  CURVE,
+  ProjectivePoint,
+  Signature,
+  utils,
+  grindKey,
+  getStarkKey,
+  ethSigToPrivate,
+  getAccountPath,
+} from '@noble/curves/stark';

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,30 +1,28 @@
 /* eslint-disable no-param-reassign */
-/* eslint-disable import/extensions */
-import { keccak256 } from 'ethereum-cryptography/keccak.js';
-import { hexToBytes } from 'ethereum-cryptography/utils.js';
+import { Hex } from '@noble/curves/abstract/utils';
+import { computeHashOnElements as computeHashOnElementsNoble, keccak } from '@noble/curves/stark';
 
 import { API_VERSION, MASK_250, StarknetChainId, TransactionHashPrefix } from '../constants';
 import { CompiledContract, RawCalldata } from '../types/lib';
 import { felt } from './calldata/cairo';
-import { starkCurve } from './ec';
-import { addHexPrefix, buf2hex, removeHexPrefix, utf8ToArray } from './encode';
+import { addHexPrefix, removeHexPrefix, utf8ToArray } from './encode';
 import { parse, stringify } from './json';
-import { BigNumberish, isHex, isStringWholeNumber, toBigInt, toHex, toHexString } from './num';
+import { BigNumberish, hexToBytes, isHex, isStringWholeNumber, toHex, toHexString } from './num';
 import { encodeShortString } from './shortString';
-
-export * as poseidon from '@noble/curves/abstract/poseidon';
 
 export const transactionVersion = 1n;
 export const feeTransactionVersion = 2n ** 128n + transactionVersion;
 
+export type PedersenArg = Hex | bigint | number;
+
 export function keccakBn(value: BigNumberish): string {
   const hexWithoutPrefix = removeHexPrefix(toHex(BigInt(value)));
   const evenHex = hexWithoutPrefix.length % 2 === 0 ? hexWithoutPrefix : `0${hexWithoutPrefix}`;
-  return addHexPrefix(buf2hex(keccak256(hexToBytes(evenHex))));
+  return addHexPrefix(keccak(hexToBytes(addHexPrefix(evenHex))).toString(16));
 }
 
 function keccakHex(value: string): string {
-  return addHexPrefix(buf2hex(keccak256(utf8ToArray(value))));
+  return addHexPrefix(keccak(utf8ToArray(value)).toString(16));
 }
 
 /**
@@ -67,10 +65,13 @@ export function getSelector(value: string) {
   return getSelectorFromName(value);
 }
 
+export { keccak };
+
+export { pedersen } from '@noble/curves/stark';
+
 export function computeHashOnElements(data: BigNumberish[]): string {
-  return [...data, data.length]
-    .reduce((x: BigNumberish, y: BigNumberish) => starkCurve.pedersen(toBigInt(x), toBigInt(y)), 0)
-    .toString();
+  const adaptedData: bigint[] = data.map(BigInt);
+  return computeHashOnElementsNoble(adaptedData) as string;
 }
 
 // following implementation is based on this python implementation:
@@ -241,7 +242,7 @@ export default function computeHintedClassHash(compiledContract: CompiledContrac
       [false, '']
     )[1];
 
-  return addHexPrefix(starkCurve.keccak(utf8ToArray(serialisedJson)).toString(16));
+  return addHexPrefix(keccak(utf8ToArray(serialisedJson)).toString(16));
 }
 
 // Computes the class hash of a given contract class
@@ -281,3 +282,18 @@ export function computeContractClassHash(contract: CompiledContract | string) {
     dataHash,
   ]);
 }
+
+// for Pedersen
+export { hashChain } from '@noble/curves/stark';
+
+// for Poseidon
+export {
+  Fp251,
+  Fp253,
+  _poseidonMDS,
+  PoseidonOpts,
+  poseidonBasic,
+  poseidonCreate,
+  poseidonHash,
+} from '@noble/curves/stark';
+export * as poseidon from '@noble/curves/abstract/poseidon';

--- a/src/utils/merkle.ts
+++ b/src/utils/merkle.ts
@@ -1,4 +1,4 @@
-import { starkCurve } from './ec';
+import { pedersen } from './hash';
 import { toBigInt } from './num';
 
 export class MerkleTree {
@@ -33,7 +33,7 @@ export class MerkleTree {
 
   static hash(a: string, b: string) {
     const [aSorted, bSorted] = [toBigInt(a), toBigInt(b)].sort((x, y) => (x >= y ? 1 : -1));
-    return starkCurve.pedersen(aSorted, bSorted);
+    return pedersen(aSorted, bSorted);
   }
 
   public getProof(leaf: string, branch = this.leaves, hashPath: string[] = []): string[] {

--- a/src/utils/num.ts
+++ b/src/utils/num.ts
@@ -1,5 +1,7 @@
+import { hexToBytes as hexToBytesNoble } from '@noble/curves/abstract/utils';
+
 import assert from './assert';
-import { addHexPrefix } from './encode';
+import { addHexPrefix, removeHexPrefix } from './encode';
 
 export type BigNumberish = string | number | bigint;
 
@@ -88,3 +90,18 @@ export function getHexStringArray(value: Array<string>) {
 }
 
 export const toCairoBool = (value: boolean): string => (+value).toString();
+
+/**
+ * Convert a hex string to an array of Bytes (Uint8Array)
+ * @param value hex string
+ * @returns an array of Bytes
+ */
+export function hexToBytes(value: string): Uint8Array {
+  if (!isHex(value)) throw new Error(`${value} need to be a hex-string`);
+
+  let adaptedValue: string = removeHexPrefix(value);
+  if (adaptedValue.length % 2 !== 0) {
+    adaptedValue = `0${adaptedValue}`;
+  }
+  return hexToBytesNoble(adaptedValue);
+}

--- a/www/docs/guides/compiled_contracts/Account_0_5_1.json
+++ b/www/docs/guides/compiled_contracts/Account_0_5_1.json
@@ -1,0 +1,4319 @@
+{
+  "abi": [
+    {
+      "members": [
+        { "name": "to", "offset": 0, "type": "felt" },
+        { "name": "selector", "offset": 1, "type": "felt" },
+        { "name": "data_offset", "offset": 2, "type": "felt" },
+        { "name": "data_len", "offset": 3, "type": "felt" }
+      ],
+      "name": "AccountCallArray",
+      "size": 4,
+      "type": "struct"
+    },
+    {
+      "inputs": [{ "name": "publicKey", "type": "felt" }],
+      "name": "constructor",
+      "outputs": [],
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "getPublicKey",
+      "outputs": [{ "name": "publicKey", "type": "felt" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "name": "interfaceId", "type": "felt" }],
+      "name": "supportsInterface",
+      "outputs": [{ "name": "success", "type": "felt" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "name": "newPublicKey", "type": "felt" }],
+      "name": "setPublicKey",
+      "outputs": [],
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "name": "hash", "type": "felt" },
+        { "name": "signature_len", "type": "felt" },
+        { "name": "signature", "type": "felt*" }
+      ],
+      "name": "isValidSignature",
+      "outputs": [{ "name": "isValid", "type": "felt" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "name": "call_array_len", "type": "felt" },
+        { "name": "call_array", "type": "AccountCallArray*" },
+        { "name": "calldata_len", "type": "felt" },
+        { "name": "calldata", "type": "felt*" }
+      ],
+      "name": "__validate__",
+      "outputs": [],
+      "type": "function"
+    },
+    {
+      "inputs": [{ "name": "class_hash", "type": "felt" }],
+      "name": "__validate_declare__",
+      "outputs": [],
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "name": "class_hash", "type": "felt" },
+        { "name": "salt", "type": "felt" },
+        { "name": "publicKey", "type": "felt" }
+      ],
+      "name": "__validate_deploy__",
+      "outputs": [],
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "name": "call_array_len", "type": "felt" },
+        { "name": "call_array", "type": "AccountCallArray*" },
+        { "name": "calldata_len", "type": "felt" },
+        { "name": "calldata", "type": "felt*" }
+      ],
+      "name": "__execute__",
+      "outputs": [
+        { "name": "response_len", "type": "felt" },
+        { "name": "response", "type": "felt*" }
+      ],
+      "type": "function"
+    }
+  ],
+  "entry_points_by_type": {
+    "CONSTRUCTOR": [
+      {
+        "offset": "0x16e",
+        "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+      }
+    ],
+    "EXTERNAL": [
+      {
+        "offset": "0x1cd",
+        "selector": "0xbc0eb87884ab91e330445c3584a50d7ddf4b568f02fbeb456a6242cce3f5d9"
+      },
+      {
+        "offset": "0x2bb",
+        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+      },
+      {
+        "offset": "0x224",
+        "selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775"
+      },
+      {
+        "offset": "0x191",
+        "selector": "0x1a6c6a0bdec86cc645c91997d8eea83e87148659e3e61122f72361fd5e94079"
+      },
+      {
+        "offset": "0x1f4",
+        "selector": "0x213dfe25e2ca309c4d615a09cfc95fdb2fc7dc73fbcad12c450fe93b1f2ff9e"
+      },
+      {
+        "offset": "0x25f",
+        "selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3"
+      },
+      {
+        "offset": "0x1b2",
+        "selector": "0x29e211664c0b63c79638fbea474206ca74016b3e9a3dc4f9ac300ffd8bdf2cd"
+      },
+      {
+        "offset": "0x285",
+        "selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895"
+      }
+    ],
+    "L1_HANDLER": []
+  },
+  "program": {
+    "attributes": [
+      {
+        "accessible_scopes": [
+          "openzeppelin.account.library",
+          "openzeppelin.account.library.Account",
+          "openzeppelin.account.library.Account.assert_only_self"
+        ],
+        "end_pc": 192,
+        "flow_tracking_data": { "ap_tracking": { "group": 16, "offset": 12 }, "reference_ids": {} },
+        "name": "error_message",
+        "start_pc": 191,
+        "value": "Account: caller is not this account"
+      },
+      {
+        "accessible_scopes": [
+          "openzeppelin.account.library",
+          "openzeppelin.account.library.Account",
+          "openzeppelin.account.library.Account.execute"
+        ],
+        "end_pc": 269,
+        "flow_tracking_data": { "ap_tracking": { "group": 21, "offset": 9 }, "reference_ids": {} },
+        "name": "error_message",
+        "start_pc": 259,
+        "value": "Account: deprecated tx version"
+      },
+      {
+        "accessible_scopes": [
+          "openzeppelin.account.library",
+          "openzeppelin.account.library.Account",
+          "openzeppelin.account.library.Account.execute"
+        ],
+        "end_pc": 274,
+        "flow_tracking_data": { "ap_tracking": { "group": 21, "offset": 49 }, "reference_ids": {} },
+        "name": "error_message",
+        "start_pc": 272,
+        "value": "Account: reentrant call"
+      }
+    ],
+    "builtins": ["pedersen", "range_check", "ecdsa", "bitwise"],
+    "compiler_version": "0.10.2",
+    "data": [
+      "0x40780017fff7fff",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x20780017fff7ffd",
+      "0x3",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480080007fff8000",
+      "0x400080007ffd7fff",
+      "0x482480017ffd8001",
+      "0x1",
+      "0x482480017ffd8001",
+      "0x1",
+      "0xa0680017fff7ffe",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+      "0x402a7ffc7ffd7fff",
+      "0x208b7fff7fff7ffe",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x484480017fff8000",
+      "0x2aaaaaaaaaaaab05555555555555556",
+      "0x48307fff7ffd8000",
+      "0x480280027ffb8000",
+      "0x480280037ffb8000",
+      "0x484480017fff8000",
+      "0x4000000000000088000000000000001",
+      "0x48307fff7ffd8000",
+      "0xa0680017fff8000",
+      "0xe",
+      "0x480680017fff8000",
+      "0x800000000000011000000000000000000000000000000000000000000000000",
+      "0x48287ffc80007fff",
+      "0x40307ffc7ff87fff",
+      "0x48297ffd80007ffc",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x48507fff7ffe8000",
+      "0x40507ff97ff57fff",
+      "0x482680017ffb8000",
+      "0x4",
+      "0x208b7fff7fff7ffe",
+      "0xa0680017fff8000",
+      "0xc",
+      "0x480680017fff8000",
+      "0x800000000000011000000000000000000000000000000000000000000000000",
+      "0x48287ffd80007fff",
+      "0x48327fff7ffc8000",
+      "0x40307ffa7ff67fff",
+      "0x48527ffe7ffc8000",
+      "0x40507ff97ff57fff",
+      "0x482680017ffb8000",
+      "0x4",
+      "0x208b7fff7fff7ffe",
+      "0x40317ffd7ff97ffd",
+      "0x48297ffc80007ffd",
+      "0x48527fff7ffc8000",
+      "0x40507ffb7ff77fff",
+      "0x40780017fff7fff",
+      "0x2",
+      "0x482680017ffb8000",
+      "0x4",
+      "0x208b7fff7fff7ffe",
+      "0x48297ffd80007ffc",
+      "0x20680017fff7fff",
+      "0x4",
+      "0x402780017ffc7ffc",
+      "0x1",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcc",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x43616c6c436f6e7472616374",
+      "0x400280007ff97fff",
+      "0x400380017ff97ffa",
+      "0x400380027ff97ffb",
+      "0x400380037ff97ffc",
+      "0x400380047ff97ffd",
+      "0x482680017ff98000",
+      "0x7",
+      "0x480280057ff98000",
+      "0x480280067ff98000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x47657443616c6c657241646472657373",
+      "0x400280007ffd7fff",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x480280017ffd8000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x476574436f6e747261637441646472657373",
+      "0x400280007ffd7fff",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x480280017ffd8000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53746f7261676552656164",
+      "0x400280007ffc7fff",
+      "0x400380017ffc7ffd",
+      "0x482680017ffc8000",
+      "0x3",
+      "0x480280027ffc8000",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x53746f726167655772697465",
+      "0x400280007ffb7fff",
+      "0x400380017ffb7ffc",
+      "0x400380027ffb7ffd",
+      "0x482680017ffb8000",
+      "0x3",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x4765745478496e666f",
+      "0x400280007ffd7fff",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x480280017ffd8000",
+      "0x208b7fff7fff7ffe",
+      "0x400380017ff97ffa",
+      "0x400380007ff97ffb",
+      "0x482680017ff98000",
+      "0x2",
+      "0x208b7fff7fff7ffe",
+      "0xa0680017fff8000",
+      "0xc",
+      "0x40780017fff7fff",
+      "0x6",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8c",
+      "0x480680017fff8000",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb1",
+      "0x480680017fff8000",
+      "0x0",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x480680017fff8000",
+      "0x1379ac0624b939ceb9dede92211d7db5ee174fe28be72245b0a1a2abd81c98f",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
+      "0x480a7ffb7fff8000",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc6",
+      "0x48127ffe7fff8000",
+      "0x48127ff57fff8000",
+      "0x48127ff57fff8000",
+      "0x48127ffc7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+      "0x480a7ffa7fff8000",
+      "0x48127ffe7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc0",
+      "0x48127ff67fff8000",
+      "0x48127ff67fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffa4",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff9a",
+      "0x40127fff7fff7ff9",
+      "0x48127ffe7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd5",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffe00365a",
+      "0x20680017fff7fff",
+      "0x8",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480680017fff8000",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffff59942a8c",
+      "0x20680017fff7fff",
+      "0x8",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480680017fff8000",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd7",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbf",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff77fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a7ffa7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffac",
+      "0x480a7ff97fff8000",
+      "0x480a7ffb7fff8000",
+      "0x48127ffd7fff8000",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff87",
+      "0x48127ff47fff8000",
+      "0x48127ff47fff8000",
+      "0x48127ffd7fff8000",
+      "0x48127ff37fff8000",
+      "0x480680017fff8000",
+      "0x1",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x3",
+      "0x480a7ff57fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff74",
+      "0x480a7ff97fff8000",
+      "0x480680017fff8000",
+      "0x1",
+      "0x480080007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff7a",
+      "0x480680017fff8000",
+      "0x1",
+      "0x40127fff7fff7ffe",
+      "0x40137ffd7fff8000",
+      "0x48127fdc7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff49",
+      "0x400680017fff7fff",
+      "0x0",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffeef",
+      "0x40137fff7fff8001",
+      "0x48127ffb7fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x480a80017fff8000",
+      "0x1104800180018000",
+      "0x35",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffee5",
+      "0x40137fff7fff8002",
+      "0x48127ffc7fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a80017fff8000",
+      "0x480a80027fff8000",
+      "0x1104800180018000",
+      "0xa",
+      "0x48127ffe7fff8000",
+      "0x480a7ff67fff8000",
+      "0x480a7ff77fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a80007fff8000",
+      "0x48127ffa7fff8000",
+      "0x480a80027fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x3",
+      "0x20780017fff7ffb",
+      "0x6",
+      "0x480a7ffa7fff8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480280007ffc8000",
+      "0x480280017ffc8000",
+      "0x480280027ffc8000",
+      "0x480280037ffc8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff11",
+      "0x40137ffe7fff8000",
+      "0x40137fff7fff8001",
+      "0x40137ffd7fff8002",
+      "0x480a7ffd7fff8000",
+      "0x480a80017fff8000",
+      "0x480a80007fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffec2",
+      "0x480a80027fff8000",
+      "0x482680017ffb8000",
+      "0x800000000000011000000000000000000000000000000000000000000000000",
+      "0x482680017ffc8000",
+      "0x4",
+      "0x482a80007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe4",
+      "0x48127ffe7fff8000",
+      "0x482880007ffe8000",
+      "0x208b7fff7fff7ffe",
+      "0x20780017fff7ffa",
+      "0x4",
+      "0x480a7ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480280007ffb8000",
+      "0x400280007ffd7fff",
+      "0x480280017ffb8000",
+      "0x400280017ffd7fff",
+      "0x480280037ffb8000",
+      "0x400280027ffd7fff",
+      "0x480280027ffb8000",
+      "0x48327fff7ffc8000",
+      "0x400280037ffd7fff",
+      "0x480a7ff97fff8000",
+      "0x482680017ffa8000",
+      "0x800000000000011000000000000000000000000000000000000000000000000",
+      "0x482680017ffb8000",
+      "0x4",
+      "0x480a7ffc7fff8000",
+      "0x482680017ffd8000",
+      "0x4",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffec",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff48",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff3",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480280037ffb8000",
+      "0x480280047ffb8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff3e",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x4003800080007ffc",
+      "0x4826800180008000",
+      "0x1",
+      "0x480a7ffd7fff8000",
+      "0x4828800080007ffe",
+      "0x480a80007fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x402b7ffd7ffc7ffd",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+      "0x48127ff47fff8000",
+      "0x48127ff47fff8000",
+      "0x48127ffb7fff8000",
+      "0x480280037ffb8000",
+      "0x480280047ffb8000",
+      "0x48127ff97fff8000",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff23",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x4003800080007ffc",
+      "0x4826800180008000",
+      "0x1",
+      "0x480a7ffd7fff8000",
+      "0x4828800080007ffe",
+      "0x480a80007fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffea",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+      "0x48127ff47fff8000",
+      "0x48127ff47fff8000",
+      "0x48127ffb7fff8000",
+      "0x480280037ffb8000",
+      "0x480280047ffb8000",
+      "0x48127ff97fff8000",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff19",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff3",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffc7fff8000",
+      "0x480280037ffb8000",
+      "0x480280047ffb8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff77fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff04",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x4003800080007ffc",
+      "0x4826800180008000",
+      "0x1",
+      "0x480a7ffd7fff8000",
+      "0x4828800080007ffe",
+      "0x480a80007fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480280027ffb8000",
+      "0x480280017ffd8000",
+      "0x400080007ffe7fff",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x480280017ffd8000",
+      "0x48307fff7ffe8000",
+      "0x402a7ffd7ffc7fff",
+      "0x480280027ffb8000",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280037ffb8000",
+      "0x482480017ffc8000",
+      "0x1",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x482680017ffd8000",
+      "0x2",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdc",
+      "0x48127ffe7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe3",
+      "0x48127ff37fff8000",
+      "0x48127ff37fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ff27fff8000",
+      "0x480280047ffb8000",
+      "0x48127ff97fff8000",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff67fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe61",
+      "0x48127ffe7fff8000",
+      "0x480a7ff77fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480080057ffb8000",
+      "0x480080037ffa8000",
+      "0x480080047ff98000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffecf",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x400080007ffe7fff",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x480280007ffd8000",
+      "0x484480017fff8000",
+      "0x4",
+      "0x48307fff7ffd8000",
+      "0x480280027ffb8000",
+      "0x480080007ffe8000",
+      "0x400080017ffe7fff",
+      "0x482480017ffd8000",
+      "0x1",
+      "0x480080007ffc8000",
+      "0x48307fff7ffe8000",
+      "0x402a7ffd7ffc7fff",
+      "0x480280027ffb8000",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280037ffb8000",
+      "0x482480017ffc8000",
+      "0x2",
+      "0x480280007ffd8000",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x480080007ff38000",
+      "0x482480017ff28000",
+      "0x1",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd3",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffa7fff8000",
+      "0x480280047ffb8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff97fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe26",
+      "0x48127ffe7fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480080057ffb8000",
+      "0x480080037ffa8000",
+      "0x480080047ff98000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe94",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280037ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe8",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffa7fff8000",
+      "0x480280047ffb8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff77fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe00",
+      "0x48127ffe7fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480080057ffb8000",
+      "0x480080037ffa8000",
+      "0x480080047ff98000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe6e",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x482680017ffd8000",
+      "0x3",
+      "0x402a7ffd7ffc7fff",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280037ffb8000",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x480280017ffd8000",
+      "0x480280027ffd8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe6",
+      "0x40780017fff7fff",
+      "0x1",
+      "0x48127ffb7fff8000",
+      "0x48127ffb7fff8000",
+      "0x48127ffc7fff8000",
+      "0x48127ffa7fff8000",
+      "0x480280047ffb8000",
+      "0x480680017fff8000",
+      "0x0",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x480a7ff57fff8000",
+      "0x480a7ff67fff8000",
+      "0x480a7ff77fff8000",
+      "0x480a7ff87fff8000",
+      "0x480a7ff97fff8000",
+      "0x480a7ffa7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe5a",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x3",
+      "0x4003800080007ffb",
+      "0x400380007ffd7ffb",
+      "0x402780017ffd8001",
+      "0x1",
+      "0x4826800180008000",
+      "0x1",
+      "0x40297ffb7fff8002",
+      "0x4826800180008000",
+      "0x1",
+      "0x480a7ffc7fff8000",
+      "0x480a7ffb7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd4f",
+      "0x480a80017fff8000",
+      "0x4829800080008002",
+      "0x480a80007fff8000",
+      "0x208b7fff7fff7ffe",
+      "0x40780017fff7fff",
+      "0x4",
+      "0x480280027ffb8000",
+      "0x480280007ffd8000",
+      "0x400080007ffe7fff",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x480280007ffd8000",
+      "0x484480017fff8000",
+      "0x4",
+      "0x48307fff7ffd8000",
+      "0x480280027ffb8000",
+      "0x480080007ffe8000",
+      "0x400080017ffe7fff",
+      "0x482480017ffd8000",
+      "0x1",
+      "0x480080007ffc8000",
+      "0x48307fff7ffe8000",
+      "0x402a7ffd7ffc7fff",
+      "0x480280027ffb8000",
+      "0x480280007ffb8000",
+      "0x480280017ffb8000",
+      "0x480280037ffb8000",
+      "0x480280047ffb8000",
+      "0x482480017ffb8000",
+      "0x2",
+      "0x480280007ffd8000",
+      "0x482680017ffd8000",
+      "0x1",
+      "0x480080007ff28000",
+      "0x482480017ff18000",
+      "0x1",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc2",
+      "0x40137ff97fff8000",
+      "0x40137ffa7fff8001",
+      "0x40137ffb7fff8002",
+      "0x40137ffc7fff8003",
+      "0x48127ffd7fff8000",
+      "0x1104800180018000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc7",
+      "0x480a80007fff8000",
+      "0x480a80017fff8000",
+      "0x48127ffb7fff8000",
+      "0x480a80027fff8000",
+      "0x480a80037fff8000",
+      "0x48127ff97fff8000",
+      "0x48127ff97fff8000",
+      "0x208b7fff7fff7ffe"
+    ],
+    "hints": {
+      "0": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.alloc",
+            "starkware.cairo.common.alloc.alloc"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": { "ap_tracking": { "group": 0, "offset": 0 }, "reference_ids": {} }
+        }
+      ],
+      "6": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.memcpy",
+            "starkware.cairo.common.memcpy.memcpy"
+          ],
+          "code": "vm_enter_scope({'n': ids.len})",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 1, "offset": 0 },
+            "reference_ids": { "starkware.cairo.common.memcpy.memcpy.len": 0 }
+          }
+        }
+      ],
+      "14": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.memcpy",
+            "starkware.cairo.common.memcpy.memcpy"
+          ],
+          "code": "n -= 1\nids.continue_copying = 1 if n > 0 else 0",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 1, "offset": 5 },
+            "reference_ids": { "starkware.cairo.common.memcpy.memcpy.continue_copying": 1 }
+          }
+        }
+      ],
+      "17": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.memcpy",
+            "starkware.cairo.common.memcpy.memcpy"
+          ],
+          "code": "vm_exit_scope()",
+          "flow_tracking_data": { "ap_tracking": { "group": 1, "offset": 6 }, "reference_ids": {} }
+        }
+      ],
+      "18": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_le_felt"
+          ],
+          "code": "import itertools\n\nfrom starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\n# Find an arc less than PRIME / 3, and another less than PRIME / 2.\nlengths_and_indices = [(a, 0), (b - a, 1), (PRIME - 1 - b, 2)]\nlengths_and_indices.sort()\nassert lengths_and_indices[0][0] <= PRIME // 3 and lengths_and_indices[1][0] <= PRIME // 2\nexcluded = lengths_and_indices[2][1]\n\nmemory[ids.range_check_ptr + 1], memory[ids.range_check_ptr + 0] = (\n    divmod(lengths_and_indices[0][0], ids.PRIME_OVER_3_HIGH))\nmemory[ids.range_check_ptr + 3], memory[ids.range_check_ptr + 2] = (\n    divmod(lengths_and_indices[1][0], ids.PRIME_OVER_2_HIGH))",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 2, "offset": 0 },
+            "reference_ids": {
+              "starkware.cairo.common.math.assert_le_felt.a": 2,
+              "starkware.cairo.common.math.assert_le_felt.b": 3,
+              "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 4
+            }
+          }
+        }
+      ],
+      "28": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_le_felt"
+          ],
+          "code": "memory[ap] = 1 if excluded != 0 else 0",
+          "flow_tracking_data": { "ap_tracking": { "group": 2, "offset": 8 }, "reference_ids": {} }
+        }
+      ],
+      "42": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_le_felt"
+          ],
+          "code": "memory[ap] = 1 if excluded != 1 else 0",
+          "flow_tracking_data": { "ap_tracking": { "group": 2, "offset": 9 }, "reference_ids": {} }
+        }
+      ],
+      "54": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_le_felt"
+          ],
+          "code": "assert excluded == 2",
+          "flow_tracking_data": { "ap_tracking": { "group": 2, "offset": 10 }, "reference_ids": {} }
+        }
+      ],
+      "63": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math",
+            "starkware.cairo.common.math.assert_lt_felt"
+          ],
+          "code": "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 3, "offset": 0 },
+            "reference_ids": {
+              "starkware.cairo.common.math.assert_lt_felt.a": 5,
+              "starkware.cairo.common.math.assert_lt_felt.b": 6
+            }
+          }
+        }
+      ],
+      "81": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.call_contract"
+          ],
+          "code": "syscall_handler.call_contract(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 4, "offset": 1 },
+            "reference_ids": { "starkware.starknet.common.syscalls.call_contract.syscall_ptr": 7 }
+          }
+        }
+      ],
+      "89": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.get_caller_address"
+          ],
+          "code": "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 5, "offset": 1 },
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr": 8
+            }
+          }
+        }
+      ],
+      "96": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.get_contract_address"
+          ],
+          "code": "syscall_handler.get_contract_address(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 6, "offset": 1 },
+            "reference_ids": {
+              "starkware.starknet.common.syscalls.get_contract_address.syscall_ptr": 9
+            }
+          }
+        }
+      ],
+      "104": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_read"
+          ],
+          "code": "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 7, "offset": 1 },
+            "reference_ids": { "starkware.starknet.common.syscalls.storage_read.syscall_ptr": 10 }
+          }
+        }
+      ],
+      "113": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.storage_write"
+          ],
+          "code": "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 8, "offset": 1 },
+            "reference_ids": { "starkware.starknet.common.syscalls.storage_write.syscall_ptr": 11 }
+          }
+        }
+      ],
+      "119": [
+        {
+          "accessible_scopes": [
+            "starkware.starknet.common.syscalls",
+            "starkware.starknet.common.syscalls.get_tx_info"
+          ],
+          "code": "syscall_handler.get_tx_info(segments=segments, syscall_ptr=ids.syscall_ptr)",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 9, "offset": 1 },
+            "reference_ids": { "starkware.starknet.common.syscalls.get_tx_info.syscall_ptr": 12 }
+          }
+        }
+      ],
+      "123": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.signature",
+            "starkware.cairo.common.signature.verify_ecdsa_signature"
+          ],
+          "code": "ecdsa_builtin.add_signature(ids.ecdsa_ptr.address_, (ids.signature_r, ids.signature_s))",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 10, "offset": 0 },
+            "reference_ids": {
+              "starkware.cairo.common.signature.verify_ecdsa_signature.ecdsa_ptr": 15,
+              "starkware.cairo.common.signature.verify_ecdsa_signature.signature_r": 13,
+              "starkware.cairo.common.signature.verify_ecdsa_signature.signature_s": 14
+            }
+          }
+        }
+      ],
+      "128": [
+        {
+          "accessible_scopes": [
+            "starkware.cairo.common.math_cmp",
+            "starkware.cairo.common.math_cmp.is_le_felt"
+          ],
+          "code": "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 11, "offset": 0 },
+            "reference_ids": {
+              "starkware.cairo.common.math_cmp.is_le_felt.a": 16,
+              "starkware.cairo.common.math_cmp.is_le_felt.b": 17
+            }
+          }
+        }
+      ],
+      "375": [
+        {
+          "accessible_scopes": ["__main__", "__main__", "__wrappers__", "__wrappers__.constructor"],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 30, "offset": 35 },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "392": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.getPublicKey_encode_return"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": { "ap_tracking": { "group": 32, "offset": 0 }, "reference_ids": {} }
+        }
+      ],
+      "425": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.supportsInterface_encode_return"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": { "ap_tracking": { "group": 36, "offset": 0 }, "reference_ids": {} }
+        }
+      ],
+      "470": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.setPublicKey"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 40, "offset": 50 },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "491": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.isValidSignature_encode_return"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": { "ap_tracking": { "group": 42, "offset": 0 }, "reference_ids": {} }
+        }
+      ],
+      "579": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.__validate__"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 45, "offset": 77 },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "617": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.__validate_declare__"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 47, "offset": 63 },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "657": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.__validate_deploy__"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": {
+            "ap_tracking": { "group": 49, "offset": 65 },
+            "reference_ids": {}
+          }
+        }
+      ],
+      "680": [
+        {
+          "accessible_scopes": [
+            "__main__",
+            "__main__",
+            "__wrappers__",
+            "__wrappers__.__execute___encode_return"
+          ],
+          "code": "memory[ap] = segments.add()",
+          "flow_tracking_data": { "ap_tracking": { "group": 52, "offset": 0 }, "reference_ids": {} }
+        }
+      ]
+    },
+    "identifiers": {
+      "__main__.Account": {
+        "destination": "openzeppelin.account.library.Account",
+        "type": "alias"
+      },
+      "__main__.AccountCallArray": {
+        "destination": "openzeppelin.account.library.AccountCallArray",
+        "type": "alias"
+      },
+      "__main__.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "__main__.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "__main__.SignatureBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+        "type": "alias"
+      },
+      "__main__.__execute__": { "decorators": ["external"], "pc": 668, "type": "function" },
+      "__main__.__execute__.Args": {
+        "full_name": "__main__.__execute__.Args",
+        "members": {
+          "call_array": {
+            "cairo_type": "openzeppelin.account.library.AccountCallArray*",
+            "offset": 1
+          },
+          "call_array_len": { "cairo_type": "felt", "offset": 0 },
+          "calldata": { "cairo_type": "felt*", "offset": 3 },
+          "calldata_len": { "cairo_type": "felt", "offset": 2 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.__execute__.ImplicitArgs": {
+        "full_name": "__main__.__execute__.ImplicitArgs",
+        "members": {
+          "bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "offset": 3
+          },
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 4 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "__main__.__execute__.Return": {
+        "cairo_type": "(response_len: felt, response: felt*)",
+        "type": "type_definition"
+      },
+      "__main__.__execute__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.__validate__": { "decorators": ["external"], "pc": 531, "type": "function" },
+      "__main__.__validate__.Args": {
+        "full_name": "__main__.__validate__.Args",
+        "members": {
+          "call_array": {
+            "cairo_type": "openzeppelin.account.library.AccountCallArray*",
+            "offset": 1
+          },
+          "call_array_len": { "cairo_type": "felt", "offset": 0 },
+          "calldata": { "cairo_type": "felt*", "offset": 3 },
+          "calldata_len": { "cairo_type": "felt", "offset": 2 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.__validate__.ImplicitArgs": {
+        "full_name": "__main__.__validate__.ImplicitArgs",
+        "members": {
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 3 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.__validate__.Return": { "cairo_type": "()", "type": "type_definition" },
+      "__main__.__validate__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.__validate_declare__": {
+        "decorators": ["external"],
+        "pc": 590,
+        "type": "function"
+      },
+      "__main__.__validate_declare__.Args": {
+        "full_name": "__main__.__validate_declare__.Args",
+        "members": { "class_hash": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.__validate_declare__.ImplicitArgs": {
+        "full_name": "__main__.__validate_declare__.ImplicitArgs",
+        "members": {
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 3 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.__validate_declare__.Return": { "cairo_type": "()", "type": "type_definition" },
+      "__main__.__validate_declare__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.__validate_deploy__": { "decorators": ["external"], "pc": 628, "type": "function" },
+      "__main__.__validate_deploy__.Args": {
+        "full_name": "__main__.__validate_deploy__.Args",
+        "members": {
+          "class_hash": { "cairo_type": "felt", "offset": 0 },
+          "publicKey": { "cairo_type": "felt", "offset": 2 },
+          "salt": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.__validate_deploy__.ImplicitArgs": {
+        "full_name": "__main__.__validate_deploy__.ImplicitArgs",
+        "members": {
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 3 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.__validate_deploy__.Return": { "cairo_type": "()", "type": "type_definition" },
+      "__main__.__validate_deploy__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.constructor": { "decorators": ["constructor"], "pc": 359, "type": "function" },
+      "__main__.constructor.Args": {
+        "full_name": "__main__.constructor.Args",
+        "members": { "publicKey": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.constructor.ImplicitArgs": {
+        "full_name": "__main__.constructor.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.constructor.Return": { "cairo_type": "()", "type": "type_definition" },
+      "__main__.constructor.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.getPublicKey": { "decorators": ["view"], "pc": 386, "type": "function" },
+      "__main__.getPublicKey.Args": {
+        "full_name": "__main__.getPublicKey.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__main__.getPublicKey.ImplicitArgs": {
+        "full_name": "__main__.getPublicKey.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.getPublicKey.Return": {
+        "cairo_type": "(publicKey: felt)",
+        "type": "type_definition"
+      },
+      "__main__.getPublicKey.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.get_tx_info": {
+        "destination": "starkware.starknet.common.syscalls.get_tx_info",
+        "type": "alias"
+      },
+      "__main__.isValidSignature": { "decorators": ["view"], "pc": 481, "type": "function" },
+      "__main__.isValidSignature.Args": {
+        "full_name": "__main__.isValidSignature.Args",
+        "members": {
+          "hash": { "cairo_type": "felt", "offset": 0 },
+          "signature": { "cairo_type": "felt*", "offset": 2 },
+          "signature_len": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.isValidSignature.ImplicitArgs": {
+        "full_name": "__main__.isValidSignature.ImplicitArgs",
+        "members": {
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 3 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "__main__.isValidSignature.Return": {
+        "cairo_type": "(isValid: felt)",
+        "type": "type_definition"
+      },
+      "__main__.isValidSignature.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.setPublicKey": { "decorators": ["external"], "pc": 454, "type": "function" },
+      "__main__.setPublicKey.Args": {
+        "full_name": "__main__.setPublicKey.Args",
+        "members": { "newPublicKey": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.setPublicKey.ImplicitArgs": {
+        "full_name": "__main__.setPublicKey.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.setPublicKey.Return": { "cairo_type": "()", "type": "type_definition" },
+      "__main__.setPublicKey.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__main__.supportsInterface": { "decorators": ["view"], "pc": 418, "type": "function" },
+      "__main__.supportsInterface.Args": {
+        "full_name": "__main__.supportsInterface.Args",
+        "members": { "interfaceId": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "__main__.supportsInterface.ImplicitArgs": {
+        "full_name": "__main__.supportsInterface.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__main__.supportsInterface.Return": {
+        "cairo_type": "(success: felt)",
+        "type": "type_definition"
+      },
+      "__main__.supportsInterface.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.__execute__": { "decorators": ["external"], "pc": 699, "type": "function" },
+      "__wrappers__.__execute__.Args": {
+        "full_name": "__wrappers__.__execute__.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__execute__.ImplicitArgs": {
+        "full_name": "__wrappers__.__execute__.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__execute__.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: starkware.cairo.common.cairo_builtins.SignatureBuiltin*, bitwise_ptr: starkware.cairo.common.cairo_builtins.BitwiseBuiltin*, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__execute__.SIZEOF_LOCALS": { "type": "const", "value": 4 },
+      "__wrappers__.__execute__.__wrapped_func": {
+        "destination": "__main__.__execute__",
+        "type": "alias"
+      },
+      "__wrappers__.__execute___encode_return": { "decorators": [], "pc": 680, "type": "function" },
+      "__wrappers__.__execute___encode_return.Args": {
+        "full_name": "__wrappers__.__execute___encode_return.Args",
+        "members": {
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "ret_value": { "cairo_type": "(response_len: felt, response: felt*)", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "__wrappers__.__execute___encode_return.ImplicitArgs": {
+        "full_name": "__wrappers__.__execute___encode_return.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__execute___encode_return.Return": {
+        "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__execute___encode_return.SIZEOF_LOCALS": { "type": "const", "value": 3 },
+      "__wrappers__.__execute___encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.__validate__": { "decorators": ["external"], "pc": 548, "type": "function" },
+      "__wrappers__.__validate__.Args": {
+        "full_name": "__wrappers__.__validate__.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__validate__.ImplicitArgs": {
+        "full_name": "__wrappers__.__validate__.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__validate__.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: starkware.cairo.common.cairo_builtins.SignatureBuiltin*, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__validate__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.__validate__.__wrapped_func": {
+        "destination": "__main__.__validate__",
+        "type": "alias"
+      },
+      "__wrappers__.__validate___encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.__validate_declare__": {
+        "decorators": ["external"],
+        "pc": 607,
+        "type": "function"
+      },
+      "__wrappers__.__validate_declare__.Args": {
+        "full_name": "__wrappers__.__validate_declare__.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__validate_declare__.ImplicitArgs": {
+        "full_name": "__wrappers__.__validate_declare__.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__validate_declare__.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: starkware.cairo.common.cairo_builtins.SignatureBuiltin*, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__validate_declare__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.__validate_declare__.__wrapped_func": {
+        "destination": "__main__.__validate_declare__",
+        "type": "alias"
+      },
+      "__wrappers__.__validate_declare___encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.__validate_deploy__": {
+        "decorators": ["external"],
+        "pc": 645,
+        "type": "function"
+      },
+      "__wrappers__.__validate_deploy__.Args": {
+        "full_name": "__wrappers__.__validate_deploy__.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__validate_deploy__.ImplicitArgs": {
+        "full_name": "__wrappers__.__validate_deploy__.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.__validate_deploy__.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: starkware.cairo.common.cairo_builtins.SignatureBuiltin*, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.__validate_deploy__.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.__validate_deploy__.__wrapped_func": {
+        "destination": "__main__.__validate_deploy__",
+        "type": "alias"
+      },
+      "__wrappers__.__validate_deploy___encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.constructor": { "decorators": ["constructor"], "pc": 366, "type": "function" },
+      "__wrappers__.constructor.Args": {
+        "full_name": "__wrappers__.constructor.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.constructor.ImplicitArgs": {
+        "full_name": "__wrappers__.constructor.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.constructor.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: felt, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.constructor.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.constructor.__wrapped_func": {
+        "destination": "__main__.constructor",
+        "type": "alias"
+      },
+      "__wrappers__.constructor_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.getPublicKey": { "decorators": ["view"], "pc": 401, "type": "function" },
+      "__wrappers__.getPublicKey.Args": {
+        "full_name": "__wrappers__.getPublicKey.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.getPublicKey.ImplicitArgs": {
+        "full_name": "__wrappers__.getPublicKey.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.getPublicKey.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: felt, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.getPublicKey.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.getPublicKey.__wrapped_func": {
+        "destination": "__main__.getPublicKey",
+        "type": "alias"
+      },
+      "__wrappers__.getPublicKey_encode_return": {
+        "decorators": [],
+        "pc": 392,
+        "type": "function"
+      },
+      "__wrappers__.getPublicKey_encode_return.Args": {
+        "full_name": "__wrappers__.getPublicKey_encode_return.Args",
+        "members": {
+          "range_check_ptr": { "cairo_type": "felt", "offset": 1 },
+          "ret_value": { "cairo_type": "(publicKey: felt)", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__wrappers__.getPublicKey_encode_return.ImplicitArgs": {
+        "full_name": "__wrappers__.getPublicKey_encode_return.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.getPublicKey_encode_return.Return": {
+        "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.getPublicKey_encode_return.SIZEOF_LOCALS": { "type": "const", "value": 1 },
+      "__wrappers__.getPublicKey_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.isValidSignature": { "decorators": ["view"], "pc": 500, "type": "function" },
+      "__wrappers__.isValidSignature.Args": {
+        "full_name": "__wrappers__.isValidSignature.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.isValidSignature.ImplicitArgs": {
+        "full_name": "__wrappers__.isValidSignature.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.isValidSignature.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: starkware.cairo.common.cairo_builtins.SignatureBuiltin*, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.isValidSignature.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.isValidSignature.__wrapped_func": {
+        "destination": "__main__.isValidSignature",
+        "type": "alias"
+      },
+      "__wrappers__.isValidSignature_encode_return": {
+        "decorators": [],
+        "pc": 491,
+        "type": "function"
+      },
+      "__wrappers__.isValidSignature_encode_return.Args": {
+        "full_name": "__wrappers__.isValidSignature_encode_return.Args",
+        "members": {
+          "range_check_ptr": { "cairo_type": "felt", "offset": 1 },
+          "ret_value": { "cairo_type": "(isValid: felt)", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__wrappers__.isValidSignature_encode_return.ImplicitArgs": {
+        "full_name": "__wrappers__.isValidSignature_encode_return.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.isValidSignature_encode_return.Return": {
+        "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.isValidSignature_encode_return.SIZEOF_LOCALS": { "type": "const", "value": 1 },
+      "__wrappers__.isValidSignature_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.setPublicKey": { "decorators": ["external"], "pc": 461, "type": "function" },
+      "__wrappers__.setPublicKey.Args": {
+        "full_name": "__wrappers__.setPublicKey.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.setPublicKey.ImplicitArgs": {
+        "full_name": "__wrappers__.setPublicKey.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.setPublicKey.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: felt, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.setPublicKey.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.setPublicKey.__wrapped_func": {
+        "destination": "__main__.setPublicKey",
+        "type": "alias"
+      },
+      "__wrappers__.setPublicKey_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "__wrappers__.supportsInterface": { "decorators": ["view"], "pc": 434, "type": "function" },
+      "__wrappers__.supportsInterface.Args": {
+        "full_name": "__wrappers__.supportsInterface.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.supportsInterface.ImplicitArgs": {
+        "full_name": "__wrappers__.supportsInterface.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.supportsInterface.Return": {
+        "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, ecdsa_ptr: felt, bitwise_ptr: felt, size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.supportsInterface.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "__wrappers__.supportsInterface.__wrapped_func": {
+        "destination": "__main__.supportsInterface",
+        "type": "alias"
+      },
+      "__wrappers__.supportsInterface_encode_return": {
+        "decorators": [],
+        "pc": 425,
+        "type": "function"
+      },
+      "__wrappers__.supportsInterface_encode_return.Args": {
+        "full_name": "__wrappers__.supportsInterface_encode_return.Args",
+        "members": {
+          "range_check_ptr": { "cairo_type": "felt", "offset": 1 },
+          "ret_value": { "cairo_type": "(success: felt)", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "__wrappers__.supportsInterface_encode_return.ImplicitArgs": {
+        "full_name": "__wrappers__.supportsInterface_encode_return.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "__wrappers__.supportsInterface_encode_return.Return": {
+        "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+        "type": "type_definition"
+      },
+      "__wrappers__.supportsInterface_encode_return.SIZEOF_LOCALS": { "type": "const", "value": 1 },
+      "__wrappers__.supportsInterface_encode_return.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Account": { "type": "namespace" },
+      "openzeppelin.account.library.Account.Args": {
+        "full_name": "openzeppelin.account.library.Account.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "openzeppelin.account.library.Account._execute_list": {
+        "decorators": [],
+        "pc": 301,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account._execute_list.Args": {
+        "full_name": "openzeppelin.account.library.Account._execute_list.Args",
+        "members": {
+          "calls": { "cairo_type": "openzeppelin.account.library.Call*", "offset": 1 },
+          "calls_len": { "cairo_type": "felt", "offset": 0 },
+          "response": { "cairo_type": "felt*", "offset": 2 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account._execute_list.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account._execute_list.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account._execute_list.Return": {
+        "cairo_type": "(response_len: felt)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account._execute_list.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 3
+      },
+      "openzeppelin.account.library.Account._from_call_array_to_call": {
+        "decorators": [],
+        "pc": 335,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account._from_call_array_to_call.Args": {
+        "full_name": "openzeppelin.account.library.Account._from_call_array_to_call.Args",
+        "members": {
+          "call_array": {
+            "cairo_type": "openzeppelin.account.library.AccountCallArray*",
+            "offset": 1
+          },
+          "call_array_len": { "cairo_type": "felt", "offset": 0 },
+          "calldata": { "cairo_type": "felt*", "offset": 2 },
+          "calls": { "cairo_type": "openzeppelin.account.library.Call*", "offset": 3 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account._from_call_array_to_call.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account._from_call_array_to_call.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account._from_call_array_to_call.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account._from_call_array_to_call.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account.assert_only_self": {
+        "decorators": [],
+        "pc": 185,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.assert_only_self.Args": {
+        "full_name": "openzeppelin.account.library.Account.assert_only_self.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.assert_only_self.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.assert_only_self.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.assert_only_self.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.assert_only_self.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account.execute": {
+        "decorators": [],
+        "pc": 254,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.execute.Args": {
+        "full_name": "openzeppelin.account.library.Account.execute.Args",
+        "members": {
+          "call_array": {
+            "cairo_type": "openzeppelin.account.library.AccountCallArray*",
+            "offset": 1
+          },
+          "call_array_len": { "cairo_type": "felt", "offset": 0 },
+          "calldata": { "cairo_type": "felt*", "offset": 3 },
+          "calldata_len": { "cairo_type": "felt", "offset": 2 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.execute.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.execute.ImplicitArgs",
+        "members": {
+          "bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "offset": 3
+          },
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 4 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.execute.Return": {
+        "cairo_type": "(response_len: felt, response: felt*)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.execute.SIZEOF_LOCALS": { "type": "const", "value": 3 },
+      "openzeppelin.account.library.Account.get_public_key": {
+        "decorators": [],
+        "pc": 194,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.get_public_key.Args": {
+        "full_name": "openzeppelin.account.library.Account.get_public_key.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.get_public_key.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.get_public_key.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.get_public_key.Return": {
+        "cairo_type": "(public_key: felt)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.get_public_key.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account.initializer": {
+        "decorators": [],
+        "pc": 178,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.initializer.Args": {
+        "full_name": "openzeppelin.account.library.Account.initializer.Args",
+        "members": { "_public_key": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.initializer.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.initializer.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.initializer.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.initializer.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account.is_valid_signature": {
+        "decorators": [],
+        "pc": 235,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.is_valid_signature.Args": {
+        "full_name": "openzeppelin.account.library.Account.is_valid_signature.Args",
+        "members": {
+          "hash": { "cairo_type": "felt", "offset": 0 },
+          "signature": { "cairo_type": "felt*", "offset": 2 },
+          "signature_len": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.is_valid_signature.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.is_valid_signature.ImplicitArgs",
+        "members": {
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 2
+          },
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 3 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.is_valid_signature.Return": {
+        "cairo_type": "(is_valid: felt)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.is_valid_signature.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account.set_public_key": {
+        "decorators": [],
+        "pc": 226,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.set_public_key.Args": {
+        "full_name": "openzeppelin.account.library.Account.set_public_key.Args",
+        "members": { "new_public_key": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.set_public_key.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.set_public_key.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.set_public_key.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.set_public_key.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account.supports_interface": {
+        "decorators": [],
+        "pc": 200,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account.supports_interface.Args": {
+        "full_name": "openzeppelin.account.library.Account.supports_interface.Args",
+        "members": { "interface_id": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.supports_interface.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account.supports_interface.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account.supports_interface.Return": {
+        "cairo_type": "(success: felt)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account.supports_interface.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.AccountCallArray": {
+        "full_name": "openzeppelin.account.library.AccountCallArray",
+        "members": {
+          "data_len": { "cairo_type": "felt", "offset": 3 },
+          "data_offset": { "cairo_type": "felt", "offset": 2 },
+          "selector": { "cairo_type": "felt", "offset": 1 },
+          "to": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key": { "type": "namespace" },
+      "openzeppelin.account.library.Account_public_key.Args": {
+        "full_name": "openzeppelin.account.library.Account_public_key.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Account_public_key.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account_public_key.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account_public_key.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account_public_key.addr": {
+        "decorators": [],
+        "pc": 148,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account_public_key.addr.Args": {
+        "full_name": "openzeppelin.account.library.Account_public_key.addr.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.addr.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account_public_key.addr.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 0
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.addr.Return": {
+        "cairo_type": "(res: felt)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account_public_key.addr.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account_public_key.hash2": {
+        "destination": "starkware.cairo.common.hash.hash2",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Account_public_key.normalize_address": {
+        "destination": "starkware.starknet.common.storage.normalize_address",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Account_public_key.read": {
+        "decorators": [],
+        "pc": 153,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account_public_key.read.Args": {
+        "full_name": "openzeppelin.account.library.Account_public_key.read.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.read.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account_public_key.read.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.read.Return": {
+        "cairo_type": "(public_key: felt)",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account_public_key.read.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.Account_public_key.storage_read": {
+        "destination": "starkware.starknet.common.syscalls.storage_read",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Account_public_key.storage_write": {
+        "destination": "starkware.starknet.common.syscalls.storage_write",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Account_public_key.write": {
+        "decorators": [],
+        "pc": 166,
+        "type": "function"
+      },
+      "openzeppelin.account.library.Account_public_key.write.Args": {
+        "full_name": "openzeppelin.account.library.Account_public_key.write.Args",
+        "members": { "value": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.write.ImplicitArgs": {
+        "full_name": "openzeppelin.account.library.Account_public_key.write.ImplicitArgs",
+        "members": {
+          "pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "offset": 1
+          },
+          "range_check_ptr": { "cairo_type": "felt", "offset": 2 },
+          "syscall_ptr": { "cairo_type": "felt*", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.Account_public_key.write.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "openzeppelin.account.library.Account_public_key.write.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "openzeppelin.account.library.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Call": {
+        "full_name": "openzeppelin.account.library.Call",
+        "members": {
+          "calldata": { "cairo_type": "felt*", "offset": 3 },
+          "calldata_len": { "cairo_type": "felt", "offset": 2 },
+          "selector": { "cairo_type": "felt", "offset": 1 },
+          "to": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "openzeppelin.account.library.FALSE": {
+        "destination": "starkware.cairo.common.bool.FALSE",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.IACCOUNT_ID": {
+        "destination": "openzeppelin.utils.constants.library.IACCOUNT_ID",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.IERC165_ID": {
+        "destination": "openzeppelin.utils.constants.library.IERC165_ID",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.SignatureBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.TRANSACTION_VERSION": {
+        "destination": "openzeppelin.utils.constants.library.TRANSACTION_VERSION",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.TRUE": {
+        "destination": "starkware.cairo.common.bool.TRUE",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.Uint256": {
+        "destination": "starkware.cairo.common.uint256.Uint256",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.call_contract": {
+        "destination": "starkware.starknet.common.syscalls.call_contract",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.get_caller_address": {
+        "destination": "starkware.starknet.common.syscalls.get_caller_address",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.get_contract_address": {
+        "destination": "starkware.starknet.common.syscalls.get_contract_address",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.get_fp_and_pc": {
+        "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.get_tx_info": {
+        "destination": "starkware.starknet.common.syscalls.get_tx_info",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.is_le_felt": {
+        "destination": "starkware.cairo.common.math_cmp.is_le_felt",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.split_felt": {
+        "destination": "starkware.cairo.common.math.split_felt",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.verify_ecdsa_signature": {
+        "destination": "starkware.cairo.common.signature.verify_ecdsa_signature",
+        "type": "alias"
+      },
+      "openzeppelin.account.library.verify_eth_signature_uint256": {
+        "destination": "starkware.cairo.common.cairo_secp.signature.verify_eth_signature_uint256",
+        "type": "alias"
+      },
+      "openzeppelin.utils.constants.library.DEFAULT_ADMIN_ROLE": { "type": "const", "value": 0 },
+      "openzeppelin.utils.constants.library.IACCESSCONTROL_ID": {
+        "type": "const",
+        "value": 2036718347
+      },
+      "openzeppelin.utils.constants.library.IACCOUNT_ID": { "type": "const", "value": 2792084853 },
+      "openzeppelin.utils.constants.library.IERC165_ID": { "type": "const", "value": 33540519 },
+      "openzeppelin.utils.constants.library.IERC721_ENUMERABLE_ID": {
+        "type": "const",
+        "value": 2014223715
+      },
+      "openzeppelin.utils.constants.library.IERC721_ID": { "type": "const", "value": 2158778573 },
+      "openzeppelin.utils.constants.library.IERC721_METADATA_ID": {
+        "type": "const",
+        "value": 1532892063
+      },
+      "openzeppelin.utils.constants.library.IERC721_RECEIVER_ID": {
+        "type": "const",
+        "value": 353073666
+      },
+      "openzeppelin.utils.constants.library.INVALID_ID": { "type": "const", "value": 4294967295 },
+      "openzeppelin.utils.constants.library.TRANSACTION_VERSION": { "type": "const", "value": 1 },
+      "openzeppelin.utils.constants.library.UINT8_MAX": { "type": "const", "value": 255 },
+      "starkware.cairo.common.alloc.alloc": { "decorators": [], "pc": 0, "type": "function" },
+      "starkware.cairo.common.alloc.alloc.Args": {
+        "full_name": "starkware.cairo.common.alloc.alloc.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.alloc.alloc.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.alloc.alloc.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.alloc.alloc.Return": {
+        "cairo_type": "(ptr: felt*)",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.alloc.alloc.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "starkware.cairo.common.bitwise.ALL_ONES": {
+        "type": "const",
+        "value": -106710729501573572985208420194530329073740042555888586719234
+      },
+      "starkware.cairo.common.bitwise.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.bool.FALSE": { "type": "const", "value": 0 },
+      "starkware.cairo.common.bool.TRUE": { "type": "const", "value": 1 },
+      "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "members": {
+          "x": { "cairo_type": "felt", "offset": 0 },
+          "x_and_y": { "cairo_type": "felt", "offset": 2 },
+          "x_or_y": { "cairo_type": "felt", "offset": 4 },
+          "x_xor_y": { "cairo_type": "felt", "offset": 3 },
+          "y": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+        "members": {
+          "m": { "cairo_type": "felt", "offset": 4 },
+          "p": { "cairo_type": "starkware.cairo.common.ec_point.EcPoint", "offset": 0 },
+          "q": { "cairo_type": "starkware.cairo.common.ec_point.EcPoint", "offset": 2 },
+          "r": { "cairo_type": "starkware.cairo.common.ec_point.EcPoint", "offset": 5 }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.EcPoint": {
+        "destination": "starkware.cairo.common.ec_point.EcPoint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "members": {
+          "result": { "cairo_type": "felt", "offset": 2 },
+          "x": { "cairo_type": "felt", "offset": 0 },
+          "y": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+        "members": {
+          "input": {
+            "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "offset": 0
+          },
+          "output": {
+            "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "offset": 8
+          }
+        },
+        "size": 16,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+        "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+        "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+        "members": {
+          "message": { "cairo_type": "felt", "offset": 1 },
+          "pub_key": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.BLOCK_SIZE": {
+        "destination": "starkware.cairo.common.cairo_keccak.packed_keccak.BLOCK_SIZE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.BYTES_IN_WORD": { "type": "const", "value": 8 },
+      "starkware.cairo.common.cairo_keccak.keccak.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.KECCAK_CAPACITY_IN_WORDS": {
+        "type": "const",
+        "value": 8
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.KECCAK_FULL_RATE_IN_BYTES": {
+        "type": "const",
+        "value": 136
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.KECCAK_FULL_RATE_IN_WORDS": {
+        "type": "const",
+        "value": 17
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.KECCAK_STATE_SIZE_FELTS": {
+        "type": "const",
+        "value": 25
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.Uint256": {
+        "destination": "starkware.cairo.common.uint256.Uint256",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.assert_lt": {
+        "destination": "starkware.cairo.common.math.assert_lt",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.assert_nn": {
+        "destination": "starkware.cairo.common.math.assert_nn",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.assert_nn_le": {
+        "destination": "starkware.cairo.common.math.assert_nn_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.assert_not_zero": {
+        "destination": "starkware.cairo.common.math.assert_not_zero",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.bitwise_and": {
+        "destination": "starkware.cairo.common.bitwise.bitwise_and",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.bitwise_or": {
+        "destination": "starkware.cairo.common.bitwise.bitwise_or",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.bitwise_xor": {
+        "destination": "starkware.cairo.common.bitwise.bitwise_xor",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.memcpy": {
+        "destination": "starkware.cairo.common.memcpy.memcpy",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.memset": {
+        "destination": "starkware.cairo.common.memset.memset",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.packed_keccak_func": {
+        "destination": "starkware.cairo.common.cairo_keccak.packed_keccak.packed_keccak_func",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.pow": {
+        "destination": "starkware.cairo.common.pow.pow",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.split_felt": {
+        "destination": "starkware.cairo.common.math.split_felt",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.uint256_reverse_endian": {
+        "destination": "starkware.cairo.common.uint256.uint256_reverse_endian",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.keccak.unsigned_div_rem": {
+        "destination": "starkware.cairo.common.math.unsigned_div_rem",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.packed_keccak.ALL_ONES": {
+        "type": "const",
+        "value": -106710729501573572985208420194530329073740042555888586719234
+      },
+      "starkware.cairo.common.cairo_keccak.packed_keccak.BLOCK_SIZE": {
+        "type": "const",
+        "value": 3
+      },
+      "starkware.cairo.common.cairo_keccak.packed_keccak.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.packed_keccak.SHIFTS": {
+        "type": "const",
+        "value": 340282366920938463481821351505477763073
+      },
+      "starkware.cairo.common.cairo_keccak.packed_keccak.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_keccak.packed_keccak.get_fp_and_pc": {
+        "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.BASE": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.BASE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.BigInt3": {
+        "full_name": "starkware.cairo.common.cairo_secp.bigint.BigInt3",
+        "members": {
+          "d0": { "cairo_type": "felt", "offset": 0 },
+          "d1": { "cairo_type": "felt", "offset": 1 },
+          "d2": { "cairo_type": "felt", "offset": 2 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.RC_BOUND": {
+        "destination": "starkware.cairo.common.math_cmp.RC_BOUND",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.Uint256": {
+        "destination": "starkware.cairo.common.uint256.Uint256",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt3": {
+        "full_name": "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt3",
+        "members": {
+          "d0": { "cairo_type": "felt", "offset": 0 },
+          "d1": { "cairo_type": "felt", "offset": 1 },
+          "d2": { "cairo_type": "felt", "offset": 2 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt5": {
+        "full_name": "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt5",
+        "members": {
+          "d0": { "cairo_type": "felt", "offset": 0 },
+          "d1": { "cairo_type": "felt", "offset": 1 },
+          "d2": { "cairo_type": "felt", "offset": 2 },
+          "d3": { "cairo_type": "felt", "offset": 3 },
+          "d4": { "cairo_type": "felt", "offset": 4 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.assert_nn": {
+        "destination": "starkware.cairo.common.math.assert_nn",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.assert_nn_le": {
+        "destination": "starkware.cairo.common.math.assert_nn_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.bigint.unsigned_div_rem": {
+        "destination": "starkware.cairo.common.math.unsigned_div_rem",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.constants.BASE": {
+        "type": "const",
+        "value": 77371252455336267181195264
+      },
+      "starkware.cairo.common.cairo_secp.constants.BETA": { "type": "const", "value": 7 },
+      "starkware.cairo.common.cairo_secp.constants.N0": {
+        "type": "const",
+        "value": 10428087374290690730508609
+      },
+      "starkware.cairo.common.cairo_secp.constants.N1": {
+        "type": "const",
+        "value": 77371252455330678278691517
+      },
+      "starkware.cairo.common.cairo_secp.constants.N2": {
+        "type": "const",
+        "value": 19342813113834066795298815
+      },
+      "starkware.cairo.common.cairo_secp.constants.P0": {
+        "type": "const",
+        "value": 77371252455336262886226991
+      },
+      "starkware.cairo.common.cairo_secp.constants.P1": {
+        "type": "const",
+        "value": 77371252455336267181195263
+      },
+      "starkware.cairo.common.cairo_secp.constants.P2": {
+        "type": "const",
+        "value": 19342813113834066795298815
+      },
+      "starkware.cairo.common.cairo_secp.constants.SECP_REM": {
+        "type": "const",
+        "value": 4294968273
+      },
+      "starkware.cairo.common.cairo_secp.ec.BigInt3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.BigInt3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.ec.EcPoint": {
+        "full_name": "starkware.cairo.common.cairo_secp.ec.EcPoint",
+        "members": {
+          "x": { "cairo_type": "starkware.cairo.common.cairo_secp.bigint.BigInt3", "offset": 0 },
+          "y": { "cairo_type": "starkware.cairo.common.cairo_secp.bigint.BigInt3", "offset": 3 }
+        },
+        "size": 6,
+        "type": "struct"
+      },
+      "starkware.cairo.common.cairo_secp.ec.UnreducedBigInt3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.ec.is_zero": {
+        "destination": "starkware.cairo.common.cairo_secp.field.is_zero",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.ec.nondet_bigint3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.nondet_bigint3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.ec.unreduced_mul": {
+        "destination": "starkware.cairo.common.cairo_secp.field.unreduced_mul",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.ec.unreduced_sqr": {
+        "destination": "starkware.cairo.common.cairo_secp.field.unreduced_sqr",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.ec.verify_zero": {
+        "destination": "starkware.cairo.common.cairo_secp.field.verify_zero",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.BASE": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.BASE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.BigInt3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.BigInt3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.P0": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.P0",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.P1": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.P1",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.P2": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.P2",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.SECP_REM": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.SECP_REM",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.UnreducedBigInt3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.assert_nn_le": {
+        "destination": "starkware.cairo.common.math.assert_nn_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.field.nondet_bigint3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.nondet_bigint3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.BASE": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.BASE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.BETA": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.BETA",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.BigInt3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.BigInt3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.EcPoint": {
+        "destination": "starkware.cairo.common.cairo_secp.ec.EcPoint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.N0": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.N0",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.N1": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.N1",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.N2": {
+        "destination": "starkware.cairo.common.cairo_secp.constants.N2",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.RC_BOUND": {
+        "destination": "starkware.cairo.common.math_cmp.RC_BOUND",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.Uint256": {
+        "destination": "starkware.cairo.common.uint256.Uint256",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.UnreducedBigInt3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.UnreducedBigInt3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.alloc": {
+        "destination": "starkware.cairo.common.alloc.alloc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.assert_nn": {
+        "destination": "starkware.cairo.common.math.assert_nn",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.assert_nn_le": {
+        "destination": "starkware.cairo.common.math.assert_nn_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.assert_not_zero": {
+        "destination": "starkware.cairo.common.math.assert_not_zero",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.bigint_mul": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.bigint_mul",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.bigint_to_uint256": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.bigint_to_uint256",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.ec_add": {
+        "destination": "starkware.cairo.common.cairo_secp.ec.ec_add",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.ec_mul": {
+        "destination": "starkware.cairo.common.cairo_secp.ec.ec_mul",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.ec_negate": {
+        "destination": "starkware.cairo.common.cairo_secp.ec.ec_negate",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.finalize_keccak": {
+        "destination": "starkware.cairo.common.cairo_keccak.keccak.finalize_keccak",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.keccak_uint256s_bigend": {
+        "destination": "starkware.cairo.common.cairo_keccak.keccak.keccak_uint256s_bigend",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.nondet_bigint3": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.nondet_bigint3",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.reduce": {
+        "destination": "starkware.cairo.common.cairo_secp.field.reduce",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.uint256_to_bigint": {
+        "destination": "starkware.cairo.common.cairo_secp.bigint.uint256_to_bigint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.unreduced_mul": {
+        "destination": "starkware.cairo.common.cairo_secp.field.unreduced_mul",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.unreduced_sqr": {
+        "destination": "starkware.cairo.common.cairo_secp.field.unreduced_sqr",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.unsigned_div_rem": {
+        "destination": "starkware.cairo.common.math.unsigned_div_rem",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.validate_reduced_field_element": {
+        "destination": "starkware.cairo.common.cairo_secp.field.validate_reduced_field_element",
+        "type": "alias"
+      },
+      "starkware.cairo.common.cairo_secp.signature.verify_zero": {
+        "destination": "starkware.cairo.common.cairo_secp.field.verify_zero",
+        "type": "alias"
+      },
+      "starkware.cairo.common.dict_access.DictAccess": {
+        "full_name": "starkware.cairo.common.dict_access.DictAccess",
+        "members": {
+          "key": { "cairo_type": "felt", "offset": 0 },
+          "new_value": { "cairo_type": "felt", "offset": 2 },
+          "prev_value": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.ec.EcOpBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.ec.EcPoint": {
+        "destination": "starkware.cairo.common.ec_point.EcPoint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.ec.StarkCurve": { "type": "namespace" },
+      "starkware.cairo.common.ec.StarkCurve.ALPHA": { "type": "const", "value": 1 },
+      "starkware.cairo.common.ec.StarkCurve.Args": {
+        "full_name": "starkware.cairo.common.ec.StarkCurve.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.ec.StarkCurve.BETA": {
+        "type": "const",
+        "value": -476910135076337975234679399815567221425937815956490878998147463828055613816
+      },
+      "starkware.cairo.common.ec.StarkCurve.GEN_X": {
+        "type": "const",
+        "value": 874739451078007766457464989774322083649278607533249481151382481072868806602
+      },
+      "starkware.cairo.common.ec.StarkCurve.GEN_Y": {
+        "type": "const",
+        "value": 152666792071518830868575557812948353041420400780739481342941381225525861407
+      },
+      "starkware.cairo.common.ec.StarkCurve.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.ec.StarkCurve.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.ec.StarkCurve.ORDER": {
+        "type": "const",
+        "value": -96363463615509210819012598251359154898
+      },
+      "starkware.cairo.common.ec.StarkCurve.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.ec.StarkCurve.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "starkware.cairo.common.ec.is_quad_residue": {
+        "destination": "starkware.cairo.common.math.is_quad_residue",
+        "type": "alias"
+      },
+      "starkware.cairo.common.ec_point.EcPoint": {
+        "full_name": "starkware.cairo.common.ec_point.EcPoint",
+        "members": {
+          "x": { "cairo_type": "felt", "offset": 0 },
+          "y": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.hash.HashBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+        "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+        "members": {
+          "s0": { "cairo_type": "felt", "offset": 0 },
+          "s1": { "cairo_type": "felt", "offset": 1 },
+          "s2": { "cairo_type": "felt", "offset": 2 },
+          "s3": { "cairo_type": "felt", "offset": 3 },
+          "s4": { "cairo_type": "felt", "offset": 4 },
+          "s5": { "cairo_type": "felt", "offset": 5 },
+          "s6": { "cairo_type": "felt", "offset": 6 },
+          "s7": { "cairo_type": "felt", "offset": 7 }
+        },
+        "size": 8,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.FALSE": {
+        "destination": "starkware.cairo.common.bool.FALSE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math.TRUE": {
+        "destination": "starkware.cairo.common.bool.TRUE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math.assert_le_felt": {
+        "decorators": ["known_ap_change"],
+        "pc": 18,
+        "type": "function"
+      },
+      "starkware.cairo.common.math.assert_le_felt.Args": {
+        "full_name": "starkware.cairo.common.math.assert_le_felt.Args",
+        "members": {
+          "a": { "cairo_type": "felt", "offset": 0 },
+          "b": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_le_felt.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.math.assert_le_felt.ImplicitArgs",
+        "members": { "range_check_ptr": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_le_felt.PRIME_OVER_2_HIGH": {
+        "type": "const",
+        "value": 5316911983139663648412552867652567041
+      },
+      "starkware.cairo.common.math.assert_le_felt.PRIME_OVER_3_HIGH": {
+        "type": "const",
+        "value": 3544607988759775765608368578435044694
+      },
+      "starkware.cairo.common.math.assert_le_felt.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.math.assert_le_felt.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "starkware.cairo.common.math.assert_le_felt.a": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_le_felt.a",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 2, "offset": 0 },
+            "pc": 18,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_le_felt.b": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_le_felt.b",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 2, "offset": 0 },
+            "pc": 18,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_le_felt.range_check_ptr": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_le_felt.range_check_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 2, "offset": 0 },
+            "pc": 18,
+            "value": "[cast(fp + (-5), felt*)]"
+          },
+          {
+            "ap_tracking_data": { "group": 2, "offset": 8 },
+            "pc": 28,
+            "value": "cast([fp + (-5)] + 4, felt)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_le_felt.skip_exclude_a": { "pc": 42, "type": "label" },
+      "starkware.cairo.common.math.assert_le_felt.skip_exclude_b_minus_a": {
+        "pc": 54,
+        "type": "label"
+      },
+      "starkware.cairo.common.math.assert_lt_felt": {
+        "decorators": ["known_ap_change"],
+        "pc": 63,
+        "type": "function"
+      },
+      "starkware.cairo.common.math.assert_lt_felt.Args": {
+        "full_name": "starkware.cairo.common.math.assert_lt_felt.Args",
+        "members": {
+          "a": { "cairo_type": "felt", "offset": 0 },
+          "b": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_lt_felt.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.math.assert_lt_felt.ImplicitArgs",
+        "members": { "range_check_ptr": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math.assert_lt_felt.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.math.assert_lt_felt.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "starkware.cairo.common.math.assert_lt_felt.a": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_lt_felt.a",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 3, "offset": 0 },
+            "pc": 63,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math.assert_lt_felt.b": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math.assert_lt_felt.b",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 3, "offset": 0 },
+            "pc": 63,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math_cmp.RC_BOUND": {
+        "type": "const",
+        "value": 340282366920938463463374607431768211456
+      },
+      "starkware.cairo.common.math_cmp.assert_le_felt": {
+        "destination": "starkware.cairo.common.math.assert_le_felt",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math_cmp.assert_lt_felt": {
+        "destination": "starkware.cairo.common.math.assert_lt_felt",
+        "type": "alias"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt": {
+        "decorators": ["known_ap_change"],
+        "pc": 128,
+        "type": "function"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt.Args": {
+        "full_name": "starkware.cairo.common.math_cmp.is_le_felt.Args",
+        "members": {
+          "a": { "cairo_type": "felt", "offset": 0 },
+          "b": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.math_cmp.is_le_felt.ImplicitArgs",
+        "members": { "range_check_ptr": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt.Return": {
+        "cairo_type": "felt",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "starkware.cairo.common.math_cmp.is_le_felt.a": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math_cmp.is_le_felt.a",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 11, "offset": 0 },
+            "pc": 128,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt.b": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.math_cmp.is_le_felt.b",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 11, "offset": 0 },
+            "pc": 128,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.math_cmp.is_le_felt.not_le": { "pc": 140, "type": "label" },
+      "starkware.cairo.common.memcpy.memcpy": { "decorators": [], "pc": 3, "type": "function" },
+      "starkware.cairo.common.memcpy.memcpy.Args": {
+        "full_name": "starkware.cairo.common.memcpy.memcpy.Args",
+        "members": {
+          "dst": { "cairo_type": "felt*", "offset": 0 },
+          "len": { "cairo_type": "felt", "offset": 2 },
+          "src": { "cairo_type": "felt*", "offset": 1 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.cairo.common.memcpy.memcpy.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.memcpy.memcpy.ImplicitArgs",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.cairo.common.memcpy.memcpy.LoopFrame": {
+        "full_name": "starkware.cairo.common.memcpy.memcpy.LoopFrame",
+        "members": {
+          "dst": { "cairo_type": "felt*", "offset": 0 },
+          "src": { "cairo_type": "felt*", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.memcpy.memcpy.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.memcpy.memcpy.SIZEOF_LOCALS": { "type": "const", "value": 0 },
+      "starkware.cairo.common.memcpy.memcpy.continue_copying": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.memcpy.memcpy.continue_copying",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 1, "offset": 3 },
+            "pc": 10,
+            "value": "[cast(ap, felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.memcpy.memcpy.len": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.memcpy.memcpy.len",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 1, "offset": 0 },
+            "pc": 3,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.memcpy.memcpy.loop": { "pc": 8, "type": "label" },
+      "starkware.cairo.common.pow.assert_le": {
+        "destination": "starkware.cairo.common.math.assert_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.pow.get_ap": {
+        "destination": "starkware.cairo.common.registers.get_ap",
+        "type": "alias"
+      },
+      "starkware.cairo.common.pow.get_fp_and_pc": {
+        "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.registers.get_ap": {
+        "destination": "starkware.cairo.lang.compiler.lib.registers.get_ap",
+        "type": "alias"
+      },
+      "starkware.cairo.common.registers.get_fp_and_pc": {
+        "destination": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.EcOpBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.EcPoint": {
+        "destination": "starkware.cairo.common.ec_point.EcPoint",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.FALSE": {
+        "destination": "starkware.cairo.common.bool.FALSE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.SignatureBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.StarkCurve": {
+        "destination": "starkware.cairo.common.ec.StarkCurve",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.TRUE": {
+        "destination": "starkware.cairo.common.bool.TRUE",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.ec_add": {
+        "destination": "starkware.cairo.common.ec.ec_add",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.ec_mul": {
+        "destination": "starkware.cairo.common.ec.ec_mul",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.ec_sub": {
+        "destination": "starkware.cairo.common.ec.ec_sub",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.is_x_on_curve": {
+        "destination": "starkware.cairo.common.ec.is_x_on_curve",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.recover_y": {
+        "destination": "starkware.cairo.common.ec.recover_y",
+        "type": "alias"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature": {
+        "decorators": [],
+        "pc": 123,
+        "type": "function"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.Args": {
+        "full_name": "starkware.cairo.common.signature.verify_ecdsa_signature.Args",
+        "members": {
+          "message": { "cairo_type": "felt", "offset": 0 },
+          "public_key": { "cairo_type": "felt", "offset": 1 },
+          "signature_r": { "cairo_type": "felt", "offset": 2 },
+          "signature_s": { "cairo_type": "felt", "offset": 3 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.ImplicitArgs": {
+        "full_name": "starkware.cairo.common.signature.verify_ecdsa_signature.ImplicitArgs",
+        "members": {
+          "ecdsa_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+            "offset": 0
+          }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.ecdsa_ptr": {
+        "cairo_type": "starkware.cairo.common.cairo_builtins.SignatureBuiltin*",
+        "full_name": "starkware.cairo.common.signature.verify_ecdsa_signature.ecdsa_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 10, "offset": 0 },
+            "pc": 123,
+            "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.SignatureBuiltin**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 10, "offset": 0 },
+            "pc": 125,
+            "value": "cast([fp + (-7)] + 2, starkware.cairo.common.cairo_builtins.SignatureBuiltin*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.signature_r": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.signature.verify_ecdsa_signature.signature_r",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 10, "offset": 0 },
+            "pc": 123,
+            "value": "[cast(fp + (-4), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.signature.verify_ecdsa_signature.signature_s": {
+        "cairo_type": "felt",
+        "full_name": "starkware.cairo.common.signature.verify_ecdsa_signature.signature_s",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 10, "offset": 0 },
+            "pc": 123,
+            "value": "[cast(fp + (-3), felt*)]"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.cairo.common.uint256.ALL_ONES": {
+        "type": "const",
+        "value": 340282366920938463463374607431768211455
+      },
+      "starkware.cairo.common.uint256.BitwiseBuiltin": {
+        "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.HALF_SHIFT": {
+        "type": "const",
+        "value": 18446744073709551616
+      },
+      "starkware.cairo.common.uint256.SHIFT": {
+        "type": "const",
+        "value": 340282366920938463463374607431768211456
+      },
+      "starkware.cairo.common.uint256.Uint256": {
+        "full_name": "starkware.cairo.common.uint256.Uint256",
+        "members": {
+          "high": { "cairo_type": "felt", "offset": 1 },
+          "low": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.cairo.common.uint256.assert_in_range": {
+        "destination": "starkware.cairo.common.math.assert_in_range",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.assert_le": {
+        "destination": "starkware.cairo.common.math.assert_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.assert_nn_le": {
+        "destination": "starkware.cairo.common.math.assert_nn_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.assert_not_zero": {
+        "destination": "starkware.cairo.common.math.assert_not_zero",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.bitwise_and": {
+        "destination": "starkware.cairo.common.bitwise.bitwise_and",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.bitwise_or": {
+        "destination": "starkware.cairo.common.bitwise.bitwise_or",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.bitwise_xor": {
+        "destination": "starkware.cairo.common.bitwise.bitwise_xor",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.get_ap": {
+        "destination": "starkware.cairo.common.registers.get_ap",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.get_fp_and_pc": {
+        "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.is_le": {
+        "destination": "starkware.cairo.common.math_cmp.is_le",
+        "type": "alias"
+      },
+      "starkware.cairo.common.uint256.pow": {
+        "destination": "starkware.cairo.common.pow.pow",
+        "type": "alias"
+      },
+      "starkware.starknet.common.storage.ADDR_BOUND": {
+        "type": "const",
+        "value": -106710729501573572985208420194530329073740042555888586719489
+      },
+      "starkware.starknet.common.storage.MAX_STORAGE_ITEM_SIZE": { "type": "const", "value": 256 },
+      "starkware.starknet.common.storage.assert_250_bit": {
+        "destination": "starkware.cairo.common.math.assert_250_bit",
+        "type": "alias"
+      },
+      "starkware.starknet.common.syscalls.CALL_CONTRACT_SELECTOR": {
+        "type": "const",
+        "value": 20853273475220472486191784820
+      },
+      "starkware.starknet.common.syscalls.CallContract": {
+        "full_name": "starkware.starknet.common.syscalls.CallContract",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.CallContractRequest": {
+        "full_name": "starkware.starknet.common.syscalls.CallContractRequest",
+        "members": {
+          "calldata": { "cairo_type": "felt*", "offset": 4 },
+          "calldata_size": { "cairo_type": "felt", "offset": 3 },
+          "contract_address": { "cairo_type": "felt", "offset": 1 },
+          "function_selector": { "cairo_type": "felt", "offset": 2 },
+          "selector": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.CallContractResponse": {
+        "full_name": "starkware.starknet.common.syscalls.CallContractResponse",
+        "members": {
+          "retdata": { "cairo_type": "felt*", "offset": 1 },
+          "retdata_size": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DELEGATE_CALL_SELECTOR": {
+        "type": "const",
+        "value": 21167594061783206823196716140
+      },
+      "starkware.starknet.common.syscalls.DELEGATE_L1_HANDLER_SELECTOR": {
+        "type": "const",
+        "value": 23274015802972845247556842986379118667122
+      },
+      "starkware.starknet.common.syscalls.DEPLOY_SELECTOR": {
+        "type": "const",
+        "value": 75202468540281
+      },
+      "starkware.starknet.common.syscalls.Deploy": {
+        "full_name": "starkware.starknet.common.syscalls.Deploy",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.DeployRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.DeployResponse",
+            "offset": 6
+          }
+        },
+        "size": 9,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DeployRequest": {
+        "full_name": "starkware.starknet.common.syscalls.DeployRequest",
+        "members": {
+          "class_hash": { "cairo_type": "felt", "offset": 1 },
+          "constructor_calldata": { "cairo_type": "felt*", "offset": 4 },
+          "constructor_calldata_size": { "cairo_type": "felt", "offset": 3 },
+          "contract_address_salt": { "cairo_type": "felt", "offset": 2 },
+          "deploy_from_zero": { "cairo_type": "felt", "offset": 5 },
+          "selector": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 6,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DeployResponse": {
+        "full_name": "starkware.starknet.common.syscalls.DeployResponse",
+        "members": {
+          "constructor_retdata": { "cairo_type": "felt*", "offset": 2 },
+          "constructor_retdata_size": { "cairo_type": "felt", "offset": 1 },
+          "contract_address": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.DictAccess": {
+        "destination": "starkware.cairo.common.dict_access.DictAccess",
+        "type": "alias"
+      },
+      "starkware.starknet.common.syscalls.EMIT_EVENT_SELECTOR": {
+        "type": "const",
+        "value": 1280709301550335749748
+      },
+      "starkware.starknet.common.syscalls.EmitEvent": {
+        "full_name": "starkware.starknet.common.syscalls.EmitEvent",
+        "members": {
+          "data": { "cairo_type": "felt*", "offset": 4 },
+          "data_len": { "cairo_type": "felt", "offset": 3 },
+          "keys": { "cairo_type": "felt*", "offset": 2 },
+          "keys_len": { "cairo_type": "felt", "offset": 1 },
+          "selector": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GET_BLOCK_NUMBER_SELECTOR": {
+        "type": "const",
+        "value": 1448089106835523001438702345020786
+      },
+      "starkware.starknet.common.syscalls.GET_BLOCK_TIMESTAMP_SELECTOR": {
+        "type": "const",
+        "value": 24294903732626645868215235778792757751152
+      },
+      "starkware.starknet.common.syscalls.GET_CALLER_ADDRESS_SELECTOR": {
+        "type": "const",
+        "value": 94901967781393078444254803017658102643
+      },
+      "starkware.starknet.common.syscalls.GET_CONTRACT_ADDRESS_SELECTOR": {
+        "type": "const",
+        "value": 6219495360805491471215297013070624192820083
+      },
+      "starkware.starknet.common.syscalls.GET_SEQUENCER_ADDRESS_SELECTOR": {
+        "type": "const",
+        "value": 1592190833581991703053805829594610833820054387
+      },
+      "starkware.starknet.common.syscalls.GET_TX_INFO_SELECTOR": {
+        "type": "const",
+        "value": 1317029390204112103023
+      },
+      "starkware.starknet.common.syscalls.GET_TX_SIGNATURE_SELECTOR": {
+        "type": "const",
+        "value": 1448089128652340074717162277007973
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumber": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumber",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumberRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockNumberResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+        "members": { "block_number": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestamp": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestamp",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestampRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetBlockTimestampResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+        "members": { "block_timestamp": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetCallerAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+        "members": { "caller_address": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetContractAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+        "members": { "contract_address": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddress": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddress",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddressRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetSequencerAddressResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+        "members": { "sequencer_address": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfo": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfo",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+            "offset": 1
+          }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfoRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxInfoResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+        "members": {
+          "tx_info": { "cairo_type": "starkware.starknet.common.syscalls.TxInfo*", "offset": 0 }
+        },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignature": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignature",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+            "offset": 1
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignatureRequest": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+        "members": { "selector": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.GetTxSignatureResponse": {
+        "full_name": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+        "members": {
+          "signature": { "cairo_type": "felt*", "offset": 1 },
+          "signature_len": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.LIBRARY_CALL_L1_HANDLER_SELECTOR": {
+        "type": "const",
+        "value": 436233452754198157705746250789557519228244616562
+      },
+      "starkware.starknet.common.syscalls.LIBRARY_CALL_SELECTOR": {
+        "type": "const",
+        "value": 92376026794327011772951660
+      },
+      "starkware.starknet.common.syscalls.LibraryCall": {
+        "full_name": "starkware.starknet.common.syscalls.LibraryCall",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.LibraryCallRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+            "offset": 5
+          }
+        },
+        "size": 7,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.LibraryCallRequest": {
+        "full_name": "starkware.starknet.common.syscalls.LibraryCallRequest",
+        "members": {
+          "calldata": { "cairo_type": "felt*", "offset": 4 },
+          "calldata_size": { "cairo_type": "felt", "offset": 3 },
+          "class_hash": { "cairo_type": "felt", "offset": 1 },
+          "function_selector": { "cairo_type": "felt", "offset": 2 },
+          "selector": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 5,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.SEND_MESSAGE_TO_L1_SELECTOR": {
+        "type": "const",
+        "value": 433017908768303439907196859243777073
+      },
+      "starkware.starknet.common.syscalls.STORAGE_READ_SELECTOR": {
+        "type": "const",
+        "value": 100890693370601760042082660
+      },
+      "starkware.starknet.common.syscalls.STORAGE_WRITE_SELECTOR": {
+        "type": "const",
+        "value": 25828017502874050592466629733
+      },
+      "starkware.starknet.common.syscalls.SendMessageToL1SysCall": {
+        "full_name": "starkware.starknet.common.syscalls.SendMessageToL1SysCall",
+        "members": {
+          "payload_ptr": { "cairo_type": "felt*", "offset": 3 },
+          "payload_size": { "cairo_type": "felt", "offset": 2 },
+          "selector": { "cairo_type": "felt", "offset": 0 },
+          "to_address": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageRead": {
+        "full_name": "starkware.starknet.common.syscalls.StorageRead",
+        "members": {
+          "request": {
+            "cairo_type": "starkware.starknet.common.syscalls.StorageReadRequest",
+            "offset": 0
+          },
+          "response": {
+            "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+            "offset": 2
+          }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageReadRequest": {
+        "full_name": "starkware.starknet.common.syscalls.StorageReadRequest",
+        "members": {
+          "address": { "cairo_type": "felt", "offset": 1 },
+          "selector": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageReadResponse": {
+        "full_name": "starkware.starknet.common.syscalls.StorageReadResponse",
+        "members": { "value": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.StorageWrite": {
+        "full_name": "starkware.starknet.common.syscalls.StorageWrite",
+        "members": {
+          "address": { "cairo_type": "felt", "offset": 1 },
+          "selector": { "cairo_type": "felt", "offset": 0 },
+          "value": { "cairo_type": "felt", "offset": 2 }
+        },
+        "size": 3,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.TxInfo": {
+        "full_name": "starkware.starknet.common.syscalls.TxInfo",
+        "members": {
+          "account_contract_address": { "cairo_type": "felt", "offset": 1 },
+          "chain_id": { "cairo_type": "felt", "offset": 6 },
+          "max_fee": { "cairo_type": "felt", "offset": 2 },
+          "nonce": { "cairo_type": "felt", "offset": 7 },
+          "signature": { "cairo_type": "felt*", "offset": 4 },
+          "signature_len": { "cairo_type": "felt", "offset": 3 },
+          "transaction_hash": { "cairo_type": "felt", "offset": 5 },
+          "version": { "cairo_type": "felt", "offset": 0 }
+        },
+        "size": 8,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.call_contract": {
+        "decorators": [],
+        "pc": 74,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.call_contract.Args": {
+        "full_name": "starkware.starknet.common.syscalls.call_contract.Args",
+        "members": {
+          "calldata": { "cairo_type": "felt*", "offset": 3 },
+          "calldata_size": { "cairo_type": "felt", "offset": 2 },
+          "contract_address": { "cairo_type": "felt", "offset": 0 },
+          "function_selector": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 4,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.call_contract.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.call_contract.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.call_contract.Return": {
+        "cairo_type": "(retdata_size: felt, retdata: felt*)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.call_contract.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.call_contract.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.call_contract.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 4, "offset": 0 },
+            "pc": 74,
+            "value": "[cast(fp + (-7), felt**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 4, "offset": 1 },
+            "pc": 81,
+            "value": "cast([fp + (-7)] + 7, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.get_caller_address": {
+        "decorators": [],
+        "pc": 86,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.get_caller_address.Args": {
+        "full_name": "starkware.starknet.common.syscalls.get_caller_address.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.get_caller_address.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.get_caller_address.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.get_caller_address.Return": {
+        "cairo_type": "(caller_address: felt)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.get_caller_address.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.get_caller_address.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 5, "offset": 0 },
+            "pc": 86,
+            "value": "[cast(fp + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 5, "offset": 1 },
+            "pc": 89,
+            "value": "cast([fp + (-3)] + 2, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.get_contract_address": {
+        "decorators": [],
+        "pc": 93,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.get_contract_address.Args": {
+        "full_name": "starkware.starknet.common.syscalls.get_contract_address.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.get_contract_address.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.get_contract_address.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.get_contract_address.Return": {
+        "cairo_type": "(contract_address: felt)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.get_contract_address.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.get_contract_address.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.get_contract_address.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 6, "offset": 0 },
+            "pc": 93,
+            "value": "[cast(fp + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 6, "offset": 1 },
+            "pc": 96,
+            "value": "cast([fp + (-3)] + 2, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.get_tx_info": {
+        "decorators": [],
+        "pc": 116,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.get_tx_info.Args": {
+        "full_name": "starkware.starknet.common.syscalls.get_tx_info.Args",
+        "members": {},
+        "size": 0,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.get_tx_info.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.get_tx_info.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.get_tx_info.Return": {
+        "cairo_type": "(tx_info: starkware.starknet.common.syscalls.TxInfo*)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.get_tx_info.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.get_tx_info.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.get_tx_info.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 9, "offset": 0 },
+            "pc": 116,
+            "value": "[cast(fp + (-3), felt**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 9, "offset": 1 },
+            "pc": 119,
+            "value": "cast([fp + (-3)] + 2, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_read": {
+        "decorators": [],
+        "pc": 100,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.storage_read.Args": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.Args",
+        "members": { "address": { "cairo_type": "felt", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.storage_read.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_read.Return": {
+        "cairo_type": "(value: felt)",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.storage_read.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.storage_read.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.storage_read.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 7, "offset": 0 },
+            "pc": 100,
+            "value": "[cast(fp + (-4), felt**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 7, "offset": 1 },
+            "pc": 104,
+            "value": "cast([fp + (-4)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      },
+      "starkware.starknet.common.syscalls.storage_write": {
+        "decorators": [],
+        "pc": 108,
+        "type": "function"
+      },
+      "starkware.starknet.common.syscalls.storage_write.Args": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.Args",
+        "members": {
+          "address": { "cairo_type": "felt", "offset": 0 },
+          "value": { "cairo_type": "felt", "offset": 1 }
+        },
+        "size": 2,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_write.ImplicitArgs": {
+        "full_name": "starkware.starknet.common.syscalls.storage_write.ImplicitArgs",
+        "members": { "syscall_ptr": { "cairo_type": "felt*", "offset": 0 } },
+        "size": 1,
+        "type": "struct"
+      },
+      "starkware.starknet.common.syscalls.storage_write.Return": {
+        "cairo_type": "()",
+        "type": "type_definition"
+      },
+      "starkware.starknet.common.syscalls.storage_write.SIZEOF_LOCALS": {
+        "type": "const",
+        "value": 0
+      },
+      "starkware.starknet.common.syscalls.storage_write.syscall_ptr": {
+        "cairo_type": "felt*",
+        "full_name": "starkware.starknet.common.syscalls.storage_write.syscall_ptr",
+        "references": [
+          {
+            "ap_tracking_data": { "group": 8, "offset": 0 },
+            "pc": 108,
+            "value": "[cast(fp + (-5), felt**)]"
+          },
+          {
+            "ap_tracking_data": { "group": 8, "offset": 1 },
+            "pc": 113,
+            "value": "cast([fp + (-5)] + 3, felt*)"
+          }
+        ],
+        "type": "reference"
+      }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+      "references": [
+        {
+          "ap_tracking_data": { "group": 1, "offset": 0 },
+          "pc": 3,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        { "ap_tracking_data": { "group": 1, "offset": 3 }, "pc": 10, "value": "[cast(ap, felt*)]" },
+        {
+          "ap_tracking_data": { "group": 2, "offset": 0 },
+          "pc": 18,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 2, "offset": 0 },
+          "pc": 18,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 2, "offset": 0 },
+          "pc": 18,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 3, "offset": 0 },
+          "pc": 63,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 3, "offset": 0 },
+          "pc": 63,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 4, "offset": 0 },
+          "pc": 74,
+          "value": "[cast(fp + (-7), felt**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 5, "offset": 0 },
+          "pc": 86,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 6, "offset": 0 },
+          "pc": 93,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 7, "offset": 0 },
+          "pc": 100,
+          "value": "[cast(fp + (-4), felt**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 8, "offset": 0 },
+          "pc": 108,
+          "value": "[cast(fp + (-5), felt**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 9, "offset": 0 },
+          "pc": 116,
+          "value": "[cast(fp + (-3), felt**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 10, "offset": 0 },
+          "pc": 123,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 10, "offset": 0 },
+          "pc": 123,
+          "value": "[cast(fp + (-3), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 10, "offset": 0 },
+          "pc": 123,
+          "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.SignatureBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": { "group": 11, "offset": 0 },
+          "pc": 128,
+          "value": "[cast(fp + (-4), felt*)]"
+        },
+        {
+          "ap_tracking_data": { "group": 11, "offset": 0 },
+          "pc": 128,
+          "value": "[cast(fp + (-3), felt*)]"
+        }
+      ]
+    }
+  }
+}

--- a/www/docs/guides/compiled_contracts/Account_0_5_1_abi.json
+++ b/www/docs/guides/compiled_contracts/Account_0_5_1_abi.json
@@ -1,0 +1,91 @@
+[
+  {
+    "members": [
+      { "name": "to", "offset": 0, "type": "felt" },
+      { "name": "selector", "offset": 1, "type": "felt" },
+      { "name": "data_offset", "offset": 2, "type": "felt" },
+      { "name": "data_len", "offset": 3, "type": "felt" }
+    ],
+    "name": "AccountCallArray",
+    "size": 4,
+    "type": "struct"
+  },
+  {
+    "inputs": [{ "name": "publicKey", "type": "felt" }],
+    "name": "constructor",
+    "outputs": [],
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "getPublicKey",
+    "outputs": [{ "name": "publicKey", "type": "felt" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "name": "interfaceId", "type": "felt" }],
+    "name": "supportsInterface",
+    "outputs": [{ "name": "success", "type": "felt" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "name": "newPublicKey", "type": "felt" }],
+    "name": "setPublicKey",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "hash", "type": "felt" },
+      { "name": "signature_len", "type": "felt" },
+      { "name": "signature", "type": "felt*" }
+    ],
+    "name": "isValidSignature",
+    "outputs": [{ "name": "isValid", "type": "felt" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "call_array_len", "type": "felt" },
+      { "name": "call_array", "type": "AccountCallArray*" },
+      { "name": "calldata_len", "type": "felt" },
+      { "name": "calldata", "type": "felt*" }
+    ],
+    "name": "__validate__",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "inputs": [{ "name": "class_hash", "type": "felt" }],
+    "name": "__validate_declare__",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "class_hash", "type": "felt" },
+      { "name": "salt", "type": "felt" },
+      { "name": "publicKey", "type": "felt" }
+    ],
+    "name": "__validate_deploy__",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "call_array_len", "type": "felt" },
+      { "name": "call_array", "type": "AccountCallArray*" },
+      { "name": "calldata_len", "type": "felt" },
+      { "name": "calldata", "type": "felt*" }
+    ],
+    "name": "__execute__",
+    "outputs": [
+      { "name": "response_len", "type": "felt" },
+      { "name": "response", "type": "felt*" }
+    ],
+    "type": "function"
+  }
+]

--- a/www/docs/guides/signature.md
+++ b/www/docs/guides/signature.md
@@ -6,6 +6,9 @@ sidebar_position: 14
 
 You can use Starknet.js to sign a message outside of the network, using the standard methods of hash and sign of Starknet. In this way, in some cases, you can avoid paying fees to store data in-chain; you transfer the signed message off-chain, and the recipient can verify (without fee) on-chain the validity of the message.
 
+> From Starknet.js V5.0, a new and way more faster crypto library is available. Nevertheless, the API is significantly modified.  
+> The crypto V4 API are still available, for ascending compatibility purpose, but do not use them anymore for your new code.
+
 ## Sign and send a message
 
 Your message has to be an array of `BigNumberish`. First calculate the hash of this message, then calculate the signature.
@@ -13,24 +16,24 @@ Your message has to be an array of `BigNumberish`. First calculate the hash of t
 > If the message does not respect some safety rules of composition, this method could be a way of attack of your smart contract. If you have any doubts, prefer the [EIP712 like method](#sign-and-verify-following-eip712), which is safe, but is also more complicated.
 
 ```typescript
-import {ec, hash, num, json, Contract } from "starknet";
+import {ec, hash, number, json, Contract } from "starknet";
 
-const privateKey = "0x1234567890987654321";
-const starkKeyPair = ec.getKeyPair(privateKey);
-const starknetPublicKey = ec.getStarkKey(starkKeyPair);
-const fullPublicKey=starkKeyPair.getPublic("hex");
+const privateKey = '0x5b7d4f8710b3581ebb2b8b74efaa23d25ab0ffea2a4f3e269bf91bf9f63d633';
+const starknetPubKey = ec.starkCurve.getStarkKey(privateKey);
 
-const message : BigNumberish[] = [1, 128, 18, 14];
+const message : number.BigNumberish[] = [1, 128, 18, 14];
 
 const msgHash = hash.computeHashOnElements(message);
-const signature = ec.sign(starkKeyPair, msgHash);
+const signature = ec.starkCurve.sign(msgHash, privateKey);
 ```
 
 Then you can send, by any means, to the recipient of the message:
 
 - the message.
 - the signature.
-- the full public key (or a wallet address).
+- the Starknet public key, or the address of the wallet related to this private key.
+
+> You can perform a multi-signature of a message. You have just to create an array of (signatures + public keys), and then to verify all these pairs.
 
 ## Receive and verify a message
 
@@ -41,44 +44,22 @@ On receiver side, you can verify that:
 
 2 ways to perform this verification:
 
-- off-chain, using the full public key (very fast, but only for standard Starknet hash & sign).
+- off-chain, using the Starknet public key (very fast, but only for standard Starknet hash & sign).
 - on-chain, using the account address (slow, add workload to the node/sequencer, but can manage exotic account abstraction about hash or sign).
 
 ### Verify outside of Starknet:
 
-The sender provides the message, the signature and the full public key. Verification:
+The sender provides the message, the signature and the Starknet public key. Verification:
 
 ```typescript
-const starkKeyPair1 = ec.getKeyPairFromPublicKey(fullPublicKey);
 const msgHash1 = hash.computeHashOnElements(message);
-const result1 = ec.verify(starkKeyPair1, msgHash1, signature);
+const result1 = ec.starkCurve.verify(signature, msgHash, starknetPubKey);
 console.log("Result (boolean) =", result1);
-```
-
-> The sender can also provide their account address. Then you can check that this full public key is linked to this account. The pubKey that you can read in the account contract is part (part X) of the full pubKey (parts X & Y):
-
-Read the pubKey of the account :
-
-```typescript
-const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } }); //devnet
-const compiledAccount = json.parse(fs.readFileSync("./compiled_contracts/Account_0_5_1.json").toString("ascii"));
-const accountAddress ="0x...."; // account of sender
-const contractAccount = new Contract(compiledAccount.abi, accountAddress, provider);
-const pubKey3 = await contractAccount.call("getPublicKey");
-```
-
-Check that the pubKey of the account is part of the full pubKey:
-
-```typescript
-const isFullPubKeyRelatedToAccount: boolean =
-    BigInt(pubKey3.publicKey.toString()) ==
-    BigInt(encode.addHexPrefix(fullPublicKey.slice(4, 68)));
-console.log("Result (boolean)=", isFullPubKeyRelatedToAccount);
 ```
 
 ### Verify in Starknet network, with the account:
 
-The sender can provide an account address, in spite of a full public key.
+The sender can provide an account address, in spite of a Starknet public key.
 
 ```typescript
 const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } }); //devnet
@@ -185,7 +166,7 @@ const msgHash5 = typedData.getMessageHash(typedDataValidate, accountAddress);
 // The call of isValidSignature will generate an error if not valid
 let result5: boolean;
 try {
-    await contractAccount.call("isValidSignature", [msgHash5, signature5]);
+    await contractAccount.call("isValidSignature", [msgHash5, signature4]);
     result5 = true;
 } catch {
     result5 = false;

--- a/www/versioned_docs/version-4.22.0/guides/signature.md
+++ b/www/versioned_docs/version-4.22.0/guides/signature.md
@@ -30,7 +30,7 @@ Then you can send, by any means, to the recipient of the message:
 
 - the message.
 - the signature.
-- the full public key (or a wallet address).
+- the full public key, or the Starknet public key, or a wallet address.
 
 ## Receive and verify a message
 
@@ -41,12 +41,15 @@ On receiver side, you can verify that:
 
 2 ways to perform this verification:
 
-- off-chain, using the full public key (very fast, but only for standard Starknet hash & sign).
+- off-chain, using the full public key or the Starknet public key (very fast, but only for standard Starknet hash & sign).
 - on-chain, using the account address (slow, add workload to the node/sequencer, but can manage exotic account abstraction about hash or sign).
 
 ### Verify outside of Starknet:
 
-The sender provides the message, the signature and the full public key. Verification:
+#### With the full public key:
+
+The sender provides the message, the signature and the full public key.  
+Verification:
 
 ```typescript
 const starkKeyPair1 = ec.getKeyPairFromPublicKey(fullPublicKey);
@@ -76,9 +79,14 @@ const isFullPubKeyRelatedToAccount: boolean =
 console.log("Result (boolean)=", isFullPubKeyRelatedToAccount);
 ```
 
+#### With the starknet public key:
+
+The sender provides the message, the signature and the Starknet public key.  
+With the Starknet public key, it's a bit more complicated. Use the code [here](https://github.com/0xs34n/starknet.js/issues/479) to proceed.
+
 ### Verify in Starknet network, with the account:
 
-The sender can provide an account address, in spite of a full public key.
+The sender can provide an account address, in spite of a public key.
 
 ```typescript
 const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } }); //devnet


### PR DESCRIPTION
## Motivation and Resolution
- resolve #479 for starknet.js V5 (with noble library). Message verification wasn't possible with Starknet public key.
After discussions with [Paul Miller]( https://github.com/paulmillr/noble-curves/issues/15 ) , a solution is implemented.
resolve #539 item 1, for ascending compatibility V4->V5 for ec/hash/number. Several V4 interfaces have disappeared in V5. Keep back these interfaces.


## Usage related changes
- message verification can be made with a Starknet public key
- Most common V4 interfaces of ec,hash,number are operational in V5, with deprecated tag.
- Added in guide a compiled contract, requested by users in Discord.

## Details of changes in ec : 
### genKeyPair :

| V4                | current V5 | will be                       |
| :---------------- | :--------- | :---------------------------- |
| `ec.genKeyPair()` |            | `@deprecated ec.genKeyPair()` |

## getKeyPair :

| V4                                      | current V5 | will be                                             |
| :-------------------------------------- | :--------- | :-------------------------------------------------- |
| `getKeyPair(pk: BigNumberish): KeyPair` |            | `@deprecated getKeyPair(pk: BigNumberish): KeyPair` |

### KeyPair.getPublic :

| V4                    | current V5                                                                   | will be                                                                           |
| :-------------------- | :--------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
| `keyPair.getPublic()` | `ec.StarkCurve.getPublicKey(privKey: Hex, isCompressed = false): Uint8Array` | `@deprecated keyPair.getPublic()`                                                 |
|                       |                                                                              | `ec.StarkCurve.getPublicKey(privKey: BigNumberish, isCompressed = false): string` |

Current V5 output is **Uint8Array**.  
Will be **Hex string**.

### KeyPair.getPrivate :

| V4                     | current V5 | will be                            |
| :--------------------- | :--------- | :--------------------------------- |
| `keyPair.getPrivate()` |            | `@deprecated keyPair.getPrivate()` |

### getStarkKey :

| V4                                         | current V5                                           | will be                                                |
| :----------------------------------------- | :--------------------------------------------------- | :----------------------------------------------------- |
| `ec.getStarkKey(keyPair: KeyPair): string` | `ec.starkCurve.getStarkKey(privateKey: Hex): string` | `ec.starkCurve.getStarkKey(privateKey: Hex): string`   |
|                                            |                                                      | `@deprecated ec.getStarkKey(keyPair: KeyPair): string` |

### getKeyPairFromPublicKey :

| V4                                                             | current V5 | will be                                                                    |
| :------------------------------------------------------------- | :--------- | :------------------------------------------------------------------------- |
| `ec.getKeyPairFromPublicKey(publicKey: BigNumberish): KeyPair` |            | `@deprecated ec.getKeyPairFromPublicKey(publicKey: BigNumberish): KeyPair` |

### sign :

| V4                                                   | current V5                                                                  | will be                                                                     |
| :--------------------------------------------------- | :-------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
| `ec.sign(keyPair: KeyPair, msgHash: string): string` | `ec.starkCurve.sign(msgHash: Hex, privKey: Hex, opts?: any): SignatureType` | `ec.starkCurve.sign(msgHash: Hex, privKey: Hex, opts?: any): SignatureType` |
|                                                      |                                                                             | `@deprecated ec.sign(keyPair: KeyPair, msgHash: string): string`            |

### verify :

| V4                                                                                   | current V5                                                                         | will be                                                                                          |
| :----------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
| `ec.verify(keyPair: KeyPair \| KeyPair[], msgHash: string, sig: Signature): boolean` | `ec.starkCurve.verify(signature: SignatureType \| Hex, msgHash: Hex, pubKey: Hex)` | `ec.starkCurve.verify(signature: SignatureType \| Hex, msgHash: Hex, pubKey: Hex)`               |
|                                                                                      |                                                                                    | `@deprecated ec.verify(keyPair: KeyPair \| KeyPair[], msgHash: string, sig: Signature): boolean` |

V4 `ec.verify` do not handle starknet public key, **only** full public key.  
Same thing with V5 `ec.verify`  
V5 `ec.starkCurve.verify` will handles full **and** Starknet public keys

### ec :

| V4      | current V5            | will be               |
| :------ | :-------------------- | :-------------------- |
| `ec.ec` | `ec.starkCurve.CURVE` | `ec.starkCurve.CURVE` |

ec.ec is not documented in API and is not migrated to V5 (too complex).

### other :

The following Noble constants/methods/interfaces about `ec` are rexeported without modification, and have no equivalence in V4 :

- getSharedSecret,
- ProjectivePoint,
- Signature,
- utils,
- grindKey,
- ethSigToPrivate,
- getAccountPath,

There is no tests for these functions.

## Details of changes in hash : 

### pedersen :

| V4                                                       | current V5                                                        | will be                                                  |
| :------------------------------------------------------- | :---------------------------------------------------------------- | :------------------------------------------------------- |
| `hash.pedersen(x: PedersenArg, y: PedersenArg): string ` | `ec.starkCurve.pedersen(x: PedersenArg, y: PedersenArg): string ` | `hash.pedersen(x: PedersenArg, y: PedersenArg): string ` |

Keep back pedersen() to hash.

### keccak :

| V4               | current V5       | will be                                    |
| :--------------- | :--------------- | :----------------------------------------- |
| `hash.keccakBn`  | `hash.keccakBn`  | `hash.keccakBn` (\*)                       |
| `hash.keccakHex` | `hash.keccakHex` | `hash.keccakHex` (\*)                      |
|                  |                  | `hash.keccak = (data: Uint8Array): bigint` |

(\*) In V4 & current V5, `keccakBn` & `keccakHex` uses 'ethereum-cryptography/keccak.js'.  
With this PR, they are using Noble lib, and `ethereum-cryptography` lib is removed.

### hashChain :

| V4  | current V5                                                    | will be                                              |
| :-- | :------------------------------------------------------------ | :--------------------------------------------------- |
|     | `ec.starkCurve.hashChain(data: PedersenArg[], fn = pedersen)` | `hash.hashChain(data: PedersenArg[], fn = pedersen)` |

new hashChain moved from `ec` to `hash`. No test for this function.

### poseidon hash :

Add export of utils for Poseidon (currently not imported in V5) :
`export * as poseidon from '@noble/curves/abstract/poseidon'`  
The following Noble new constants/methods/interfaces for poseidon hash are in current V5 in `ec`. This PR move them to `hash` :

- Fp251,
- Fp253,
- \_poseidonMDS,
- PoseidonOpts,
- poseidonBasic,
- poseidonCreate,
- poseidonHash,

## Details of changes in number :

- Keep back a V4 number.toFelt (tagged as deprecated), using felt from Cairo.ts.
- new `hexToBytes()` in number, to be able to adapt the noble methods requesting Uint8Array as input.
 
## Development related changes

- Use of `noble` lib v0.7.3
- Remove `ethereum-cryptography` lib, as `Keccak` is available in noble lib.
- export cairo.ts (team request)
- Added testing of message verification with full pubkKey and with Starknet PubKey
- Added testing of  deprecated V4 interfaces
- some hash and ec tests where in the wrong file. Cleaned up.
- No new tests for new Noble methods (Poseidon,...)

## Checklist:

- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Linked the issues which this PR resolves
- [X] Documented the changes
- [X] Updated the docs (www): JSdoc & guide
- [X] Updated the tests
- [X] All tests are passing
