### PR TITLE
Remove ethereum cryptography v5.2.0

### DIFF
--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,9 +1,7 @@
+import { sort } from 'json-keys-sort';
 /* eslint-disable no-param-reassign */
 /* eslint-disable import/extensions */
-import { keccak256 } from 'ethereum-cryptography/keccak.js';
-import { hexToBytes } from 'ethereum-cryptography/utils.js';
-import { sort } from 'json-keys-sort';
-import { poseidonHashMany } from 'micro-starknet';
+import { keccak, poseidonHashMany } from 'micro-starknet';
 
 import { API_VERSION, MASK_250, StarknetChainId, TransactionHashPrefix } from '../constants';
 import {
@@ -18,9 +16,17 @@ import {
 } from '../types/lib';
 import { felt } from './calldata/cairo';
 import { starkCurve } from './ec';
-import { addHexPrefix, buf2hex, removeHexPrefix, utf8ToArray } from './encode';
+import { addHexPrefix, removeHexPrefix, utf8ToArray } from './encode';
 import { parse, stringify } from './json';
-import { BigNumberish, isHex, isStringWholeNumber, toBigInt, toHex, toHexString } from './num';
+import {
+  BigNumberish,
+  hexToBytes,
+  isHex,
+  isStringWholeNumber,
+  toBigInt,
+  toHex,
+  toHexString,
+} from './num';
 import { encodeShortString } from './shortString';
 
 export * as poseidon from '@noble/curves/abstract/poseidon';
@@ -31,11 +37,11 @@ export const feeTransactionVersion = 2n ** 128n + transactionVersion;
 export function keccakBn(value: BigNumberish): string {
   const hexWithoutPrefix = removeHexPrefix(toHex(BigInt(value)));
   const evenHex = hexWithoutPrefix.length % 2 === 0 ? hexWithoutPrefix : `0${hexWithoutPrefix}`;
-  return addHexPrefix(buf2hex(keccak256(hexToBytes(evenHex))));
+  return addHexPrefix(keccak(hexToBytes(addHexPrefix(evenHex))).toString(16));
 }
 
 function keccakHex(value: string): string {
-  return addHexPrefix(buf2hex(keccak256(utf8ToArray(value))));
+  return addHexPrefix(keccak(utf8ToArray(value)).toString(16));
 }
 
 /**

--- a/src/utils/num.ts
+++ b/src/utils/num.ts
@@ -1,5 +1,7 @@
+import { hexToBytes as hexToBytesNoble } from '@noble/curves/abstract/utils';
+
 import assert from './assert';
-import { addHexPrefix } from './encode';
+import { addHexPrefix, removeHexPrefix } from './encode';
 
 export type BigNumberish = string | number | bigint;
 
@@ -88,3 +90,18 @@ export function getHexStringArray(value: Array<string>) {
 }
 
 export const toCairoBool = (value: boolean): string => (+value).toString();
+
+/**
+ * Convert a hex string to an array of Bytes (Uint8Array)
+ * @param value hex string
+ * @returns an array of Bytes
+ */
+export function hexToBytes(value: string): Uint8Array {
+  if (!isHex(value)) throw new Error(`${value} need to be a hex-string`);
+
+  let adaptedValue: string = removeHexPrefix(value);
+  if (adaptedValue.length % 2 !== 0) {
+    adaptedValue = `0${adaptedValue}`;
+  }
+  return hexToBytesNoble(adaptedValue);
+}


### PR DESCRIPTION
## Motivation and Resolution
Solve #554 
`ethereum-cryptography` lib is still used, for the following functions : `keccak256` and `hexToBytes`.
These functions are also available in `micro-starknet` and `noble/curves`.

## Usage related changes

No changes for users.

## Development related changes

`ethereum-cryptography` lib removed.

`num.hexToBytes` has been created ; it verifies and adapt the input, prior to send to noble lib. It avoids possible failures of noble lib.
(for information, reverse function exists already in `encode.buf2hex`).

## Checklist:

- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Linked the issues which this PR resolves
- [X] Updated the docs (www) : JS code of `num.hexToBytes` created.
- [X] All tests are passing
