### PR TITLE
chore: fix call response type & Signature type

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -1,3 +1,5 @@
+import { Signature } from 'micro-starknet';
+
 import typedDataExample from '../__mocks__/typedDataExample.json';
 import { Account, Contract, Provider, TransactionStatus, ec, stark } from '../src';
 import { uint256 } from '../src/utils/calldata/cairo';
@@ -184,7 +186,7 @@ describe('deploy and test Wallet', () => {
     // change the signature to make it invalid
     const r2 = toBigInt(r) + 123n;
 
-    const signature2 = stark.parseSignature([r2.toString(), s]);
+    const signature2 = new Signature(toBigInt(r2.toString()), toBigInt(s));
 
     if (!signature2) return;
 

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -41,9 +41,14 @@ import {
   transactionVersion,
   transactionVersion_2,
 } from '../utils/hash';
-import { BigNumberish, toBigInt, toCairoBool, toHex } from '../utils/num';
+import { BigNumberish, toBigInt, toCairoBool } from '../utils/num';
 import { parseContract } from '../utils/provider';
-import { compileCalldata, estimatedFeeToMaxFee, randomAddress } from '../utils/stark';
+import {
+  compileCalldata,
+  estimatedFeeToMaxFee,
+  formatSignature,
+  randomAddress,
+} from '../utils/stark';
 import { fromCallsToExecuteCalldata } from '../utils/transaction';
 import { TypedData, getMessageHash } from '../utils/typedData';
 import { AccountInterface } from './interface';
@@ -470,7 +475,7 @@ export class Account extends Provider implements AccountInterface {
         entrypoint: 'isValidSignature',
         calldata: compileCalldata({
           hash: toBigInt(hash).toString(),
-          signature: [toHex(signature.r), toHex(signature.s)],
+          signature: formatSignature(signature),
         }),
       });
       return true;

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -8,6 +8,7 @@ import {
   FunctionAbi,
   InvokeFunctionResponse,
   Overrides,
+  Result,
   StructAbi,
 } from '../types';
 import assert from '../utils/assert';
@@ -190,7 +191,7 @@ export class Contract implements ContractInterface {
     method: string,
     args: Array<any> = [],
     options: CallOptions = { parseRequest: true, parseResponse: true, formatResponse: undefined }
-  ): Promise<object> {
+  ): Promise<Result> {
     assert(this.address !== null, 'contract is not connected to an address');
     const blockIdentifier = options?.blockIdentifier || undefined;
     let calldata = args[0];

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,2 +1,5 @@
 export type AsyncContractFunction<T = any> = (...args: Array<any>) => Promise<T>;
 export type ContractFunction = (...args: Array<any>) => any;
+export type Result = {
+  [key: string]: any;
+};

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -3,10 +3,10 @@ import { weierstrass } from '../../utils/ec';
 import type { BigNumberish } from '../../utils/num';
 import { CompiledContract, CompiledSierraCasm, ContractClass } from './contract';
 
-// Common Signature Type which needs to be imported from weierstrass
-// and imported at many places
-// This is because stark.ts doesn't export SignatureType
-export type Signature = weierstrass.SignatureType;
+export type WeierstrassSignatureType = weierstrass.SignatureType;
+export type ArraySignatureType = string[];
+export type AnySignatureType = string | number | ArraySignatureType | WeierstrassSignatureType;
+export type Signature = ArraySignatureType | WeierstrassSignatureType;
 
 export type RawCalldata = BigNumberish[];
 export type AllowArray<T> = T | T[];

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -5,7 +5,6 @@ import { CompiledContract, CompiledSierraCasm, ContractClass } from './contract'
 
 export type WeierstrassSignatureType = weierstrass.SignatureType;
 export type ArraySignatureType = string[];
-export type AnySignatureType = string | number | ArraySignatureType | WeierstrassSignatureType;
 export type Signature = ArraySignatureType | WeierstrassSignatureType;
 
 export type RawCalldata = BigNumberish[];

--- a/src/utils/responseParser/sequencer.ts
+++ b/src/utils/responseParser/sequencer.ts
@@ -17,7 +17,6 @@ import {
   TransactionSimulationResponse,
 } from '../../types';
 import { toBigInt } from '../num';
-import { parseSignature } from '../stark';
 import { ResponseParser } from '.';
 
 export class SequencerAPIResponseParser extends ResponseParser {
@@ -50,8 +49,7 @@ export class SequencerAPIResponseParser extends ResponseParser {
         'sender_address' in res.transaction
           ? (res.transaction.sender_address as string)
           : undefined,
-      signature:
-        'signature' in res.transaction ? parseSignature(res.transaction.signature) : undefined,
+      signature: 'signature' in res.transaction ? res.transaction.signature : undefined,
       transaction_hash:
         'transaction_hash' in res.transaction ? res.transaction.transaction_hash : undefined,
       version: 'version' in res.transaction ? (res.transaction.version as string) : undefined,

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -1,14 +1,13 @@
-import { Signature, getStarkKey, utils } from 'micro-starknet';
+import { getStarkKey, utils } from 'micro-starknet';
 import { gzip } from 'pako';
 
 import {
-  AnySignatureType,
   ArraySignatureType,
   Calldata,
   CompressedProgram,
   Program,
   RawArgs,
-  WeierstrassSignatureType,
+  Signature,
 } from '../types';
 import { addHexPrefix, btoaUniversal } from './encode';
 import { stringify } from './json';
@@ -42,11 +41,8 @@ export function makeAddress(input: string): string {
   return addHexPrefix(input).toLowerCase();
 }
 
-export function formatSignature(sig?: AnySignatureType): ArraySignatureType {
+export function formatSignature(sig?: Signature): ArraySignatureType {
   if (!sig) throw Error('formatSignature: provided signature is undefined');
-  if (typeof sig === 'string' || typeof sig === 'number') {
-    return [toHex(sig)];
-  }
   if (Array.isArray(sig)) {
     return sig.map((it) => toHex(it));
   }
@@ -54,23 +50,16 @@ export function formatSignature(sig?: AnySignatureType): ArraySignatureType {
     const { r, s } = sig;
     return [toHex(r), toHex(s)];
   } catch (e) {
-    throw new Error('Signature need to be WeierstrassSignatureType or an array');
+    throw new Error('Signature need to be weierstrass.SignatureType or an array for custom');
   }
 }
 
-export function signatureToDecimalArray(sig?: AnySignatureType): ArraySignatureType {
+export function signatureToDecimalArray(sig?: Signature): ArraySignatureType {
   return bigNumberishArrayToDecimalStringArray(formatSignature(sig));
 }
 
-export function signatureToHexArray(sig?: AnySignatureType): ArraySignatureType {
+export function signatureToHexArray(sig?: Signature): ArraySignatureType {
   return bigNumberishArrayToHexadecimalStringArray(formatSignature(sig));
-}
-
-export function parseSignature(sig?: ArraySignatureType): WeierstrassSignatureType {
-  if (!sig) throw Error('parseSignature: provided signature is undefined');
-
-  const [r, s] = sig;
-  return new Signature(toBigInt(r), toBigInt(s));
 }
 
 /**

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -2,11 +2,13 @@ import { Signature, getStarkKey, utils } from 'micro-starknet';
 import { gzip } from 'pako';
 
 import {
+  AnySignatureType,
+  ArraySignatureType,
   Calldata,
   CompressedProgram,
   Program,
   RawArgs,
-  Signature as SignatureType,
+  WeierstrassSignatureType,
 } from '../types';
 import { addHexPrefix, btoaUniversal } from './encode';
 import { stringify } from './json';
@@ -40,26 +42,32 @@ export function makeAddress(input: string): string {
   return addHexPrefix(input).toLowerCase();
 }
 
-export function formatSignature(sig?: SignatureType): string[] {
-  if (!sig) return [];
+export function formatSignature(sig?: AnySignatureType): ArraySignatureType {
+  if (!sig) throw Error('formatSignature: provided signature is undefined');
+  if (typeof sig === 'string' || typeof sig === 'number') {
+    return [toHex(sig)];
+  }
+  if (Array.isArray(sig)) {
+    return sig.map((it) => toHex(it));
+  }
   try {
     const { r, s } = sig;
     return [toHex(r), toHex(s)];
   } catch (e) {
-    return [];
+    throw new Error('Signature need to be WeierstrassSignatureType or an array');
   }
 }
 
-export function signatureToDecimalArray(sig?: SignatureType): string[] {
+export function signatureToDecimalArray(sig?: AnySignatureType): ArraySignatureType {
   return bigNumberishArrayToDecimalStringArray(formatSignature(sig));
 }
 
-export function signatureToHexArray(sig?: SignatureType): string[] {
+export function signatureToHexArray(sig?: AnySignatureType): ArraySignatureType {
   return bigNumberishArrayToHexadecimalStringArray(formatSignature(sig));
 }
 
-export function parseSignature(sig?: string[]) {
-  if (!sig) return undefined;
+export function parseSignature(sig?: ArraySignatureType): WeierstrassSignatureType {
+  if (!sig) throw Error('parseSignature: provided signature is undefined');
 
   const [r, s] = sig;
   return new Signature(toBigInt(r), toBigInt(s));


### PR DESCRIPTION
## Motivation and Resolution
Fix TS issue with contract.call response
Signature https://github.com/0xs34n/starknet.js/discussions/565

## Usage related changes
Type-defined but more flexible Signature:
If used as string[] it can be any implementation and default implementation use WeierstrassSignatureType 

## Development-related changes
No interface changes just redefined types
```ts
export type WeierstrassSignatureType = weierstrass.SignatureType;
export type ArraySignatureType = string[];
export type AnySignatureType = string | number | ArraySignatureType | WeierstrassSignatureType;
export type Signature = ArraySignatureType | WeierstrassSignatureType;
```

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes
- [ ] Updated the docs (www)
- [ ] Updated the tests
- [ ] All tests are passing
