### PR TITLE
fix: implement custom ts error localy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "lossless-json": "^2.0.8",
         "micro-starknet": "^0.2.1",
         "pako": "^2.0.4",
-        "ts-custom-error": "^3.3.1",
         "url-join": "^4.0.1"
       },
       "devDependencies": {
@@ -20075,14 +20074,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ts-custom-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
-      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "lossless-json": "^2.0.8",
     "micro-starknet": "^0.2.1",
     "pako": "^2.0.4",
-    "ts-custom-error": "^3.3.1",
     "url-join": "^4.0.1"
   },
   "lint-staged": {

--- a/src/provider/errors.ts
+++ b/src/provider/errors.ts
@@ -1,5 +1,38 @@
+// eslint-disable-next-line max-classes-per-file
+export function fixStack(target: Error, fn: Function = target.constructor) {
+  const { captureStackTrace } = Error as any;
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  captureStackTrace && captureStackTrace(target, fn);
+}
+
+export function fixProto(target: Error, prototype: {}) {
+  const { setPrototypeOf } = Object as any;
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions, no-proto, no-param-reassign
+  setPrototypeOf ? setPrototypeOf(target, prototype) : ((target as any).__proto__ = prototype);
+}
+
 /* eslint-disable max-classes-per-file */
-import { CustomError } from 'ts-custom-error/dist/custom-error';
+export class CustomError extends Error {
+  name!: string;
+
+  constructor(message?: string) {
+    super(message);
+    // set error name as constructor name, make it not enumerable to keep native Error behavior
+    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
+    // see https://github.com/adriengibrat/ts-custom-error/issues/30
+    Object.defineProperty(this, 'name', {
+      value: new.target.name,
+      enumerable: false,
+      configurable: true,
+    });
+    // fix the extended error prototype chain
+    // because typescript __extends implementation can't
+    // see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    fixProto(this, new.target.prototype);
+    // try to remove contructor from stack trace
+    fixStack(this);
+  }
+}
 
 export class LibraryError extends CustomError {}
 


### PR DESCRIPTION
Due to the bundling issue, reimplemented custom-ts-errors locally.
Please test for chrome ext. @dhruvkelawala, on node imp., this works fine.