### PR TITLE
fix: Uint256 type is not handle by mata-class functions

### DIFF
--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -144,6 +144,15 @@ export function parseCalldataField(
     case isTypeStruct(type, structs) || isTypeTuple(type):
       return parseCalldataValue(value as ParsedStruct | BigNumberish[], type, structs);
 
+    // Uint256 (object or num)
+    case isTypeUint256(type):
+      if (typeof value === 'object') {
+        return [felt(value.low), felt(value.high)];
+      }
+      // eslint-disable-next-line no-case-declarations
+      const el_uint256 = uint256(value);
+      return [felt(el_uint256.low), felt(el_uint256.high)];
+
     // Felt or unhandled
     default:
       return parseBaseTypes(type, value);

--- a/src/utils/calldata/validate.ts
+++ b/src/utils/calldata/validate.ts
@@ -6,6 +6,7 @@ import { AbiEntry, AbiStructs, FunctionAbi } from '../../types';
 import assert from '../assert';
 import { BigNumberish, toBigInt } from '../num';
 import { isLongText } from '../shortString';
+import { uint256ToBN } from '../uint256';
 import {
   Uint,
   getArrayType,
@@ -33,12 +34,14 @@ const validateUint = (parameter: any, input: AbiEntry) => {
       `Validation: Parameter is to large to be typed as Number use (BigInt or String)`
     );
   }
-
   assert(
-    typeof parameter === 'string' || typeof parameter === 'number' || typeof parameter === 'bigint',
-    `Validate: arg ${input.name} of cairo type ${input.type} should be type (String, Number or BigInt)`
+    typeof parameter === 'string' ||
+      typeof parameter === 'number' ||
+      typeof parameter === 'bigint' ||
+      (typeof parameter === 'object' && 'low' in parameter && 'high' in parameter),
+    `Validate: arg ${input.name} of cairo ZORG type ${input.type} should be type (String, Number or BigInt)`
   );
-  const param = toBigInt(parameter);
+  const param = typeof parameter === 'object' ? uint256ToBN(parameter) : toBigInt(parameter);
 
   switch (input.type) {
     case Uint.u8:


### PR DESCRIPTION
## Motivation and Resolution

Solve #601 
In v5.9.0, if I use meta-class, and if I have to send an uint256,  it fails if I provide a Uint256 variable.

## Usage related changes

User will be able to use meta-class with all types listed in `MultiType` type.

## Development related changes

N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] All tests are passing
