### PR TITLE
fix: use of array of uint256 in myCallData.compile

### DIFF
--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -101,6 +101,15 @@ function parseCalldataValue(
       return acc.concat(parsedData);
     }, [] as string[]);
   }
+  // check if u256
+  if (isTypeUint256(type)) {
+    if (typeof element === 'object') {
+      const { low, high } = element;
+      return [felt(low as BigNumberish), felt(high as BigNumberish)];
+    }
+    const el_uint256 = uint256(element);
+    return [felt(el_uint256.low), felt(el_uint256.high)];
+  }
   if (typeof element === 'object') {
     throw Error(`Parameter ${element} do not align with abi parameter ${type}`);
   }


### PR DESCRIPTION
## Motivation and Resolution

Solve issue #616 
myCallData.compile() accepts as input an array of BigNumberish, but do not accept an array of Uint256.
Code was missing in utils/calldata/parseRequest/parseCalldataValue

## Usage related changes

Array of Uint256 will be possible in myCallData.compile().

## Development related changes

No tests are added in this PR. It will be made in a future PR about RawArgsObjects in myCallData.compile().

## Checklist:

- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Linked the issues which this PR resolves
- [X] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [X] All tests are passing
