### PR TITLE
feat: add RawArgs in Account.populate

### DIFF
--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -731,6 +731,7 @@ describe('Complex interaction', () => {
       const calldata = CallData.compile(request);
       const populated4 = erc20Echo20Contract.populateTransaction.echo(calldata);
       const populated5 = erc20Echo20Contract.populate('echo', calldata);
+      const populated6 = erc20Echo20Contract.populate('echo', request);
       const expected =
         '["474107654995566025798705","123","8","135049554883004558383340439742929429255072943744440858662311072577337126766","203887170123222058415354283980421533276985178030994883159827760142323294308","196343614134218459150194337625778954700414868493373034945803514629145850912","191491606203201332235940470946533476219373216944002683254566549675726417440","150983476482645969577707455338206408996455974968365254240526141964709732462","196916864427988120570407658938236398782031728400132565646592333804118761826","196909666192589839125749789377187946419246316474617716408635151520594095469","2259304674248048077001042434290734","1","1","2","3","4","5","6","1","2","3","4","5","6","7","8","9","10","11","5000","0","1","2","1","2","200","1","2","6","1","2","3","4","5","6","4","1000","0","2000","0","3000","0","4000","0","2","10","11","20","22","2","1","2","3","4","1","2","3","4","3","1","2","3","4","1","2","3","4","1","2","3","4"]';
       expect(expected).toBe(json.stringify(populated1.calldata));
@@ -738,6 +739,7 @@ describe('Complex interaction', () => {
       expect(expected).toBe(json.stringify(populated3.calldata));
       expect(expected).toBe(json.stringify(populated4.calldata));
       expect(expected).toBe(json.stringify(populated5.calldata));
+      expect(expected).toBe(json.stringify(populated6.calldata));
 
       // mark data as compiled (it can be also done manually check defineProperty compiled in CallData.compile)
       const compiledCallData = CallData.compile(populated4.calldata);

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -14,6 +14,7 @@ import {
   FunctionAbi,
   InvokeFunctionResponse,
   InvokeOptions,
+  RawArgs,
   Result,
   StructAbi,
 } from '../types';
@@ -94,10 +95,11 @@ function buildEstimate(contract: Contract, functionAbi: FunctionAbi): ContractFu
   };
 }
 
-export function getCalldata(args: ArgsOrCalldata, callback: Function): Calldata {
+export function getCalldata(args: RawArgs, callback: Function): Calldata {
   // Check if Calldata in args or args[0] else compile
-  if ('__compiled__' in args) return args as Calldata;
-  if (Array.isArray(args[0]) && '__compiled__' in args[0]) return args[0] as Calldata;
+  if (Array.isArray(args) && '__compiled__' in args) return args as Calldata;
+  if (Array.isArray(args) && Array.isArray(args[0]) && '__compiled__' in args[0])
+    return args[0] as Calldata;
   return callback();
 }
 
@@ -309,7 +311,7 @@ export class Contract implements ContractInterface {
     throw Error('Contract must be connected to the account contract to estimate');
   }
 
-  public populate(method: string, args: ArgsOrCalldata = []): Call {
+  public populate(method: string, args: RawArgs = []): Call {
     const calldata = getCalldata(args, () => this.callData.compile(method, args));
 
     return {


### PR DESCRIPTION
## Motivation and Resolution
Solve #632 
Add RawArgsObject type to Account.populate

## Usage related changes

Users can now use both :
```typescript
const calldata6: Call = myTestContract.populate("test_multi1", [
      200, 
      234567897n, 
      "865423"]);
const calldata7: Call = myTestContract.populate("test_multi1", {
        p1: 200, 
        p2: 234567897n, 
        p3: "865423"});
```
Unordered object is accepted.

## Development related changes

No

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically) : soon in guides
- [x] Updated the tests
- [x] All tests are passing
