### PR TITLE
feat: isCairo1?

### DIFF
--- a/__tests__/cairo1.test.ts
+++ b/__tests__/cairo1.test.ts
@@ -16,6 +16,7 @@ import {
   shortString,
   stark,
 } from '../src';
+import { isCairo1Abi } from '../src/utils/calldata/cairo';
 import { starknetKeccak } from '../src/utils/selector';
 import {
   compiledC1Account,
@@ -69,6 +70,13 @@ describeIfDevnet('Cairo 1 Devnet', () => {
     test('GetClassAt', async () => {
       const classResponse = await provider.getClassAt(dd.deploy.contract_address);
       expect(classResponse).toMatchSchemaRef('SierraContractClass');
+    });
+
+    test('isCairo1', async () => {
+      const isContractCairo1 = cairo1Contract.isCairo1();
+      expect(isContractCairo1).toBe(true);
+      const isAbiCairo1 = isCairo1Abi(cairo1Contract.abi);
+      expect(isAbiCairo1).toBe(true);
     });
 
     test('Cairo 1 Contract Interaction - skip invoke validation & call parsing', async () => {

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -1,6 +1,6 @@
 import { BigNumberish, Contract, ContractFactory, RawArgs, json, stark } from '../src';
 import { CallData } from '../src/utils/calldata';
-import { felt, tuple, uint256 } from '../src/utils/calldata/cairo';
+import { felt, isCairo1Abi, tuple, uint256 } from '../src/utils/calldata/cairo';
 import { getSelectorFromName } from '../src/utils/hash';
 import { hexToDecimalString, toBigInt } from '../src/utils/num';
 import { encodeShortString } from '../src/utils/shortString';
@@ -48,6 +48,13 @@ describe('contract module', () => {
           multicallDeploy.contract_address!,
           provider
         );
+      });
+
+      test('isCairo1', async () => {
+        const isContractCairo1: boolean = erc20Contract.isCairo1();
+        expect(isContractCairo1).toBe(false);
+        const isAbiCairo1: boolean = isCairo1Abi(erc20Contract.abi);
+        expect(isAbiCairo1).toBe(false);
       });
 
       test('populate transaction for initial balance of that account', async () => {

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -19,7 +19,7 @@ import {
   StructAbi,
 } from '../types';
 import assert from '../utils/assert';
-import { CallData } from '../utils/calldata';
+import { CallData, cairo } from '../utils/calldata';
 import { ContractInterface } from './interface';
 
 export const splitArgsAndOptions = (args: ArgsOrCalldataWithOptions) => {
@@ -319,5 +319,9 @@ export class Contract implements ContractInterface {
       entrypoint: method,
       calldata,
     };
+  }
+
+  public isCairo1(): boolean {
+    return cairo.isCairo1Abi(this.abi);
   }
 }

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -106,4 +106,15 @@ export abstract class ContractInterface {
    * @returns Invocation object
    */
   public abstract populate(method: string, args?: ArgsOrCalldata): Invocation;
+
+  /**
+   * tells if the contract comes from a Cairo 1 contract
+   *
+   * @returns TRUE if the contract comes from a Cairo1 contract
+   * @example
+   * ```typescript
+   * const isCairo1: boolean = myContract.isCairo1();
+   * ```
+   */
+  public abstract isCairo1(): boolean;
 }

--- a/src/utils/calldata/cairo.ts
+++ b/src/utils/calldata/cairo.ts
@@ -1,4 +1,4 @@
-import { AbiStructs, BigNumberish, Uint256 } from '../../types';
+import { Abi, AbiStructs, BigNumberish, Uint256 } from '../../types';
 import { isBigInt, isHex, isStringWholeNumber } from '../num';
 import { encodeShortString, isShortString, isText } from '../shortString';
 import { UINT_128_MAX, isUint256 } from '../uint256';
@@ -32,6 +32,30 @@ export const getArrayType = (type: string) => {
   }
   return type.replace('*', '');
 };
+
+/**
+ * tells if an ABI comes from a Cairo 1 contract
+ *
+ * @param abi representing the interface of a Cairo contract
+ * @returns TRUE if it is an ABI from a Cairo1 contract
+ * @example
+ * ```typescript
+ * const isCairo1: boolean = isCairo1Abi(myAbi: Abi);
+ * ```
+ */
+export function isCairo1Abi(abi: Abi): boolean {
+  const firstFunction = abi.find((entry) => entry.type === 'function');
+  if (!firstFunction) {
+    throw new Error(`Error in ABI. No function in ABI.`);
+  }
+  if (firstFunction.inputs.length) {
+    return isCairo1Type(firstFunction.inputs[0].type);
+  }
+  if (firstFunction.outputs.length) {
+    return isCairo1Type(firstFunction.outputs[0].type);
+  }
+  throw new Error(`Error in ABI. No input/output in function ${firstFunction.name}`);
+}
 
 /**
  * named tuple are described as js object {}

--- a/www/docs/guides/define_call_message.md
+++ b/www/docs/guides/define_call_message.md
@@ -436,6 +436,14 @@ const amount = myContract.call(...);
 | Struct                                                    | ` func get_v() -> MyStruct`        | MyStruct = { account: bigint, amount: bigint} | `const res: MyStruct = myContract.call(...`                                                                                                                          |
 | complex array                                             | `func get_v() -> Array<fMyStruct>` | MyStruct[]                                    | `const res: MyStruct[] = myContract.call(...`                                                                                                                        |
 
+If you don't know if your Contract object is interacting with a Cairo 0 or a Cairo 1 contract, you have these methods:
+
+```typescript
+import { cairo } from "starknet";
+const isCairo1: boolean = myContract.isCairo1();
+const isAbiCairo1: boolean = cairo.isCairo1Abi(myAbi);
+```
+
 ## Parse configuration
 
 ### parseRequest


### PR DESCRIPTION
## Motivation and Resolution

The way to construct the calldata, and the way to read the answer of a contract function, are not the same for Cairo 0 and Cairo 1.
That's why it's useful to have a method to have the origin of a Contract object, or of an abi variable.

## Usage related changes

Users have now : 

```typescript
import { cairo } from "starknet";
const isCairo1: boolean = myContract.isCairo1();
const isAbiCairo1: boolean = cairo.isCairo1abi(myAbi);
```

## Development related changes

function `isCairo1abi` added in `utils/calldata/cairo/`.

## Checklist:

- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
