### PR TITLE
feat: Calldata result can be used as input in Contract meta-class

### DIFF
--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -141,6 +141,23 @@ describe('Cairo 1 Devnet', () => {
       // defined as struct
       const result1 = await cairo1Contract.test_u256(uint256(2n ** 256n - 2n));
       expect(result1).toBe(2n ** 256n - 1n);
+
+      // using Contract.populate result in meta-class
+      const functionParameters: RawArgsObject = { p1: cairo.uint256(15) };
+      const myCall0 = cairo1Contract.populate('test_u256', functionParameters);
+      const res0 = await cairo1Contract.test_u256(myCall0.calldata);
+      expect(res0).toBe(16n);
+
+      // using myCallData.compile result in meta-class
+      const contractCallData: CallData = new CallData(cairo1Contract.abi);
+      const myCalldata: Calldata = contractCallData.compile('test_u256', functionParameters);
+      const res1 = await cairo1Contract.test_u256(myCalldata);
+      expect(res1).toBe(16n);
+
+      // using CallData.compile result in meta-class
+      const contractCallData2: Calldata = CallData.compile(functionParameters);
+      const res2 = await cairo1Contract.test_u256(contractCallData2);
+      expect(res2).toBe(16n);
     });
 
     test('Cairo 1 Contract Interaction - bool', async () => {
@@ -290,8 +307,8 @@ describe('Cairo 1 Devnet', () => {
         [1, 2],
         [3, 4],
       ]);
-      const tx1 = await cairo1Contract.array2d_ex(cd);
       await account.waitForTransaction(tx.transaction_hash);
+      const tx1 = await cairo1Contract.array2d_ex(cd);
       await account.waitForTransaction(tx1.transaction_hash);
 
       const result0 = await cairo1Contract.array2d_felt([

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -315,8 +315,7 @@ export class Contract implements ContractInterface {
   }
 
   public populate(method: string, args: RawArgs = []): Call {
-    const calldata = getCalldata(args, () => this.callData.compile(method, args));
-
+    const calldata: Calldata = getCalldata(args, () => this.callData.compile(method, args));
     return {
       contractAddress: this.address,
       entrypoint: method,

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, BlockIdentifier, RawArgsArray, Signature } from './lib';
+import { BigNumberish, BlockIdentifier, Calldata, RawArgsArray, Signature } from './lib';
 
 export type AsyncContractFunction<T = any> = (...args: ArgsOrCalldataWithOptions) => Promise<T>;
 export type ContractFunction = (...args: ArgsOrCalldataWithOptions) => any;
@@ -10,12 +10,6 @@ export type Result =
   | bigint
   | string
   | boolean;
-
-/**
- * Compiled calldata ready to be sent
- * decimal-string array
- */
-export type Calldata = string[] & { readonly __compiled__?: boolean };
 
 export type ArgsOrCalldata = RawArgsArray | [Calldata] | Calldata;
 export type ArgsOrCalldataWithOptions = ArgsOrCalldata & ContractOptions;

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -9,6 +9,12 @@ export type Signature = ArraySignatureType | WeierstrassSignatureType;
 export type BigNumberish = string | number | bigint;
 
 /**
+ * Compiled calldata ready to be sent
+ * decimal-string array
+ */
+export type Calldata = string[] & { readonly __compiled__?: boolean };
+
+/**
  * Represents an integer in the range [0, 2^256)
  */
 export interface Uint256 {
@@ -90,7 +96,7 @@ export type DeclareContractTransaction = {
 
 export type CallDetails = {
   contractAddress: string;
-  calldata?: RawArgs;
+  calldata?: RawArgs | Calldata;
   entrypoint?: string; // TODO: check if required
 };
 

--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -110,11 +110,20 @@ export class CallData {
     }
 
     const argsIterator = args[Symbol.iterator]();
-    return abiMethod.inputs.reduce(
+
+    const callArray = abiMethod.inputs.reduce(
       (acc, input) =>
         isLen(input.name) ? acc : acc.concat(parseCalldataField(argsIterator, input, this.structs)),
       [] as Calldata
     );
+
+    // add compiled property to array object
+    Object.defineProperty(callArray, '__compiled__', {
+      enumerable: false,
+      writable: false,
+      value: true,
+    });
+    return callArray;
   }
 
   /**

--- a/www/docs/guides/define_call_message.md
+++ b/www/docs/guides/define_call_message.md
@@ -318,7 +318,7 @@ const myCall: Call = myContract.populate("setup_elements", functionParameters);
 const tx = await account0.execute(myCall);
 // or
 const myCall: Call = myContract.populate("get_elements", functionParameters);
-const res = await myContract.get_elements(...myCall.calldata);
+const res = await myContract.get_elements(myCall.calldata);
 ```
 
 It can be used only with methods that know the abi: `Contract.populate, myCallData.compile`.  
@@ -392,7 +392,7 @@ These types of arguments can't be used at your convenience everywhere. Here is a
 
 |                                                    Function | array of parameters | ordered object  | non ordered object |       Call & MultiCall       | list of parameters | array of strings (\*) | array of strings (\*\*) |
 | ----------------------------------------------------------: | :-----------------: | :-------------: | :----------------: | :--------------------------: | :----------------: | :-------------------: | :---------------------: |
-|                                         **Typescript type** | [] <br /> Calldata  | {} RawArgsArray |  {} RawArgsObject  |        Call & Call[]         |    ...Calldata     |       string[]        |        string[]         |
+|                                         **Typescript type** |         N/A         | {} RawArgsArray |  {} RawArgsObject  |        Call & Call[]         |       ...[]        |       string[]        |        string[]         |
 |                 contract.metaClass() contract\[metaclass]() |                     |                 |                    |                              |         ✔️         |          ✔️           |           ✔️            |
 |                             contract.call / contract.invoke |         ✔️          |                 |                    |                              |                    |          ✔️           |           ✔️            |
 | account.execute <br /><br />(with 3 params, incl. calldata) |   <br /><br /> ✔️   | <br /><br /> ✔️ |                    | ✔️ <br /><br /><br /> <br /> |                    |                       |     <br /><br /> ✔️     |

--- a/www/docs/guides/use_ERC20.md
+++ b/www/docs/guides/use_ERC20.md
@@ -115,10 +115,10 @@ console.log("account0 has a balance of:", uint256.uint256ToBN(balanceBeforeTrans
 console.log(`Invoke Tx - Transfer 10 tokens back to erc20 contract...`);
 const toTransferTk: Uint256 = cairo.uint256(10);
 const transferCallData: Call = erc20.populate("transfer", {
-        recipient: erc20Address,
-        amount: toTransferTk // with Cairo 1 contract, 'toTransferTk' can be replaced by '10n'
+    recipient: erc20Address,
+    amount: toTransferTk // with Cairo 1 contract, 'toTransferTk' can be replaced by '10n'
 });
-     const { transaction_hash: transferTxHash } = await erc20.transfer( ...transferCallData.calldata);
+    const { transaction_hash: transferTxHash } = await erc20.transfer( transferCallData.calldata);
 
 // Wait for the invoke transaction to be accepted on Starknet
 console.log(`Waiting for Tx to be Accepted on Starknet - Transfer...`);


### PR DESCRIPTION
## Motivation and Resolution
Solve issue #684 

Contract meta-class now accepts as input the result of the following functions :

- `myContract.populate().calldata`
- `myCallData.compile()`
- `Calldata.compile()`

## Usage related changes
This code now works for all cases, including u256 :
```typescript
const functionParameters: RawArgsObject = {
        val1: 1,
        amount: cairo.uint256(15),
    }
    const myCall0: Call = myTestContract.populate("test9", functionParameters);
    const res17 = await myTestContract.test9(myCall0.calldata);

    const contractCallData: CallData = new CallData(compiledTest.abi);
    const myCalldata: Calldata = contractCallData.compile("test9", functionParameters);
    const res19 = await myTestContract.test9(myCalldata);

    const contractCallData2: Calldata = CallData.compile(functionParameters);
    const res20 = await myTestContract.test9(contractCallData2);
   ```


## Development related changes

All Populate/Compile functions now returns `Calldata` type, tagged with `__compiled__` key with value `true`.


## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
