### PR TITLE
docs: update events guide

### DIFF
--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -78,18 +78,12 @@ const responseEstimateMessageFee = await provider.estimateMessageFee(.....)
 
 ### Specific RPC methods
 
-For example, if you want to read the events recorded in a range of blocks, you need to use a method available from an RPC node. The class `RpcProvider` is available for this case:
+For example, if you want to read the list of pending transactions, you need to use a method available from an RPC node. The class `RpcProvider` is available for this case:
 
 ```typescript
 import { RpcProvider } from "starknet";
 const providerRPC = new RpcProvider({ nodeUrl: "http://192.168.1.99:9545" }); // for a pathfinder node located in a PC in the local network
-const lastBlock = await providerRPC.getBlock('latest');
-let eventsList = await providerRPC.getEvents({
-    address: myContractAddress,
-    from_block: {block_number: lastBlock.block_number-2},
-    to_block: {block_number: lastBlock.block_number},
-    chunk_size: 400
-});
+const pendingTx = await providerRPC.getPendingTransactions();
 ```
 
 RPC providers are for example Infura, Alchemy, Chainstack... Or you can spin up your own Pathfinder node!

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -2,104 +2,182 @@
 sidebar_position: 12
 ---
 
-# Reading emitted events
-
-## Starknet events
+# Events
 
 A contract may emit events throughout its execution. Each event contains the following fields:
 
-    from_address: address of the contract emitting the events
-    keys: a list of field elements
-    data: a list of field elements
+- from_address: address of the contract emitting the events
+- keys: a list of field elements
+- data: a list of field elements
 
-The events are stored in a block on the blockchain.
+The keys can be used for indexing the events, while the data may contain any information that we wish to log.
 
-## Events in the Cairo code
+The events are recorded in the blocks of the blockchain.
 
-You have to analyze the Cairo code of your smart contract, to recover the list of data emitted by the event.
-An example in Cairo 0:
+Example of Cairo code for an event :
 
-```cairo
-@event
-func log_data(d1: felt, d2: felt, d3: felt) {
-}
-
-@external
-func my_func{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    ...
-    log_data.emit(start_field, high_range, status_prog);
-    ...
-    return ();
-}
+```rust
+#[derive(Drop, starknet::Event)]
+    struct EventPanic {
+        #[key]
+        errorType: u8,
+        errorDescription: felt252,
+    }
 ```
 
-Here, we can see that the event will store 3 felts.
+Here an event called `EventPanic`, with an u8 stored in keys, and a felt252 (text) in data.
 
-Once compiled, this code will generate an abi file containing:
+## Why events ?
+
+Events are a useful tool for logging and notifying external entities about specific occurrences within a contract, with a timestamp (the block number). They emit data that can be accessed by everybody.
+
+Some cases :
+
+- When a specific value is reached in a contract, an event can be created to store the fact that this value has been reached at a specific block number.
+- When the L1 network has triggered the execution of a L2 contract, you can store in the event some results and when it occurs.
+
+An event can be useful also when you invoke a contract. When you invoke a Cairo function (meaning to write in the network), the API do not authorize any response (only call functions can provide an answer). To generate an event in the code is a way to provide a response (for example for the creation of an account, an event is generated to return the account address).
+
+## With the Transaction hash
+
+If you use Starknet.js to invoke a Cairo function that will trigger a new event, you will have as response the transaction hash. Keep it preciously ; it will be easy to read the event with it.
+
+Example of invocation :
 
 ```typescript
-{
-    "data": [
-        {"name": "d1", "type": "felt"},
-        {"name": "d2", "type": "felt"},
-        {"name": "d3", "type": "felt"},
-    ],
-    "keys": [],
-    "name": "log_data",
-    "type": "event",
-}
+const transactionHash = myContract.invoke("emitEventPanic", [8, "Mega Panic."])
 ```
 
-## Recover the event data
-
-Once the `my_func` is invoked, the event is stored in the blockchain and you get in return the transaction hash.
+Then get the transaction receipt :
 
 ```typescript
-import { InvokeTransactionReceiptResponse } from "starknet";
-
-const resu = await myTestContract.my_func();
-const txReceiptDeployTest: InvokeTransactionReceiptResponse = await provider.waitForTransaction(resu.transaction_hash);
-console.log("events =",txReceiptDeployTest.events);
+const txReceipt = await provider.waitForTransaction(transactionHash);
 ```
 
-Now, you have all the events of the block. Here, we have 2 events - the last one contains our data:
+### Raw response
+
+You can recover all the events related to this transaction hash :
+
+```typescript
+const listEvents = txReceipt.events;
+```
+
+The result is an array of events (here only one event):
 
 ```typescript
 [
-  [Object: null prototype] {
-    data: [
-      '0x2345b8cdd1eb333ac0959f7d908394b6540234345590e83367ae2a6cfbd4107'
-    ],
-    from_address: '0x465e68294995849bd00ac9f6ad4ee12be3cec963d8fe27172a1eadda608c110',
-    keys: [
-      '0x28f911b08eb032a94e35f766f1310b2df2267eb9d25bb069a1e3a6754e4206d'
-    ]
-  },
-  [Object: null prototype] {
-    data: [
-      '0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a',
-      '0x3711666a3506c99c9d78c4d4013409a87a962b7a0880a1c24af9fe193dafc01',
-      '0x1d3d81545c000'
-    ],
-    from_address: '0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
-    keys: [
-      '0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9'
-    ]
-  }
+    {
+        from_address: '0x47cb13bf174043adde61f7bea49ab2d9ebc575b0431f85bcbfa113a6f93fc4',
+        keys: [
+        '0x3ba972537cb2f8e811809bba7623a2119f4f1133ac9e955a53d5a605af72bf2',
+        '0x8'
+        ],
+        data: [ '0x4d6567612050616e69632e' ]
+    }
 ]
-
 ```
 
-Use the contract deployment address `testContractAddress`, to filter the events and read the data from your smart contract:
+The first parameter in the `keys` array is a hash of the name of the event, calculated this way :
 
 ```typescript
-const event = txReceiptDeployTest.events.find(
-  (it) => num.cleanHex(it.from_address) === num.cleanHex(testContractAddress)
-) || {data: []};
-
-const eventD1 = event.data[0];
-const eventD2 = event.data[1];
-const eventD3 = event.data[2];
+const nameHash = num.toHex( hash.starknetKeccak("EventPanic"));
 ```
 
-If you do not have the transaction hash, you have to search in the blocks of Starknet. See an example [here](connect_network#specific-rpc-methods).
+The second parameter is the `errorType` variable content (stored in keys array because of the `#[key]`flag in the Cairo code).
+
+The `data` array contains the `errorDescription` variable content (`'0x4d6567612050616e69632e'` corresponds to the encoded value of "Mega Panic.")
+
+You can decode it with :
+
+```typescript
+const ErrorMessage =  shortString.decodeShortString("0x4d6567612050616e69632e")
+```
+
+### parsed response
+
+Once you have the transaction receipt, you can parse the events to have something easier to process.  
+We will perform this parse this way :
+
+```typescript
+const events = myTestContract.parseEvents(txReceipt);
+```
+
+The result is an array of parsed events (here only one event):
+
+```typescript
+events = [
+  {
+    EventPanic: { errorType: 8n, errorDescription: 93566154138418073030976302n }
+  },
+]
+```
+
+Easier to read and process, isn't it?
+
+## Without transaction hash
+
+If you don't have the transaction Hash of the contract execution that created the event, it will be necessary to search inside the blocks of the Starknet blockchain.
+
+In this example, if you want to read the events recorded in the last 10 blocks, you need to use a method available only from an RPC node. The class `RpcProvider` is available for this case:
+
+```typescript
+import { RpcProvider } from "starknet";
+const providerRPC = new RpcProvider({ nodeUrl: "{ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey }" }); // for an Infura node on Testnet
+const lastBlock = await providerRPC.getBlock('latest');
+const keyFilter = [num.toHex(hash.starknetKeccak("EventPanic")), "0x8"]
+const eventsList = await providerRPC.getEvents({
+    address: myContractAddress,
+    from_block: {block_number: lastBlock.block_number-9},
+    to_block: {block_number: lastBlock.block_number},
+    keys:[keyFilter],
+    chunk_size: 10
+});
+```
+
+> `address, from_block, to_block, keys` are all optional parameters.
+
+> If you don't want to filter by key, you can either remove the `keys` parameter, or affect it this way : `[[]]` .
+
+Here we have only one event. You can easily read this event :
+
+```typescript
+const event = eventsList.events[0];
+console.log("data length =", event.data.length, "key length =", event.keys.length, ":");
+console.log("\nkeys =", event.keys, "data =", event.data);
+```
+
+To limit the workload of the node, the parameter `chunk_size` defines a size of chunk to read. If the request need an additional chunk, the response includes a key `continuation_token` containing a string to use in the next request.  
+Hereunder a code to read all the chunks of a request :
+
+```typescript
+const keyFilter = [num.toHex(hash.starknetKeccak("EventPanic")), "0x8"]
+let block = await provider.getBlock('latest');
+console.log("bloc #", block.block_number);
+
+let continuationToken: string | undefined = "0";
+let chunkNum: number = 1;
+while (continuationToken) {
+    const eventsRes = await providerRPC.getEvents({
+        from_block: {
+            block_number: block.block_number - 30
+        },
+        to_block: {
+            block_number: block.block_number
+        },
+        address: myContractAddress,
+        keys: [keyFilter],
+        chunk_size: 5,
+        continuation_token: continuationToken
+    });
+    const nbEvents = eventsRes.events.length;
+    continuationToken=eventsRes.continuation_token;
+    console.log("chunk nb =",chunkNum,".",nbEvents, "events recovered.");
+    console.log("continuation_token =",continuationToken );
+    for (let i = 0; i < nbEvents; i++) {
+        const event = eventsRes.events[i];
+        console.log("event #", i, "data length =", event.data.length, "key length =", event.keys.length, ":");
+        console.log("\nkeys =", event.keys, "data =", event.data)
+    }
+    chunkNum++;
+}
+```


### PR DESCRIPTION
## Motivation and Resolution

Solve issue #718 

### RPC version (if applicable)



## Usage related changes

Events guide has been rewritten, and includes : 
- myContract.parseEvent()
- explanation for raw reading
- detailed examples for getEvents()

`getEvents` has been removed from `connect_network.md`  and replaced by `getPendingTransactions`.

## Development related changes

N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] All tests are passing
