### PR TITLE
fix: calldata.compile ordering problem

### DIFF
--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -437,6 +437,21 @@ describe('Complex interaction', () => {
     )}","10","20","48","40","1","2","10","20","22","33","1","2","3","4","22","33","1","33","1415934836","123333333","0","1","2","3","1","321","322","33","0","2","123","291","3","1","2","10","20","100","200","2","111","112","121","122","211","212","221","222"]`;
     expect(json.stringify(compiled)).toBe(reference);
     expect(json.stringify(doubleCompiled)).toBe(reference);
+
+    // mix of complex and litteral
+    const mySetArgs = {
+      validators: [234, 235],
+      powers: { a1: 562, a2: 567 },
+      valsetNonce: uint256(49),
+    };
+    const compiledArr = CallData.compile([mySetArgs, 456789]);
+    const compiledObj = CallData.compile({
+      currentValset: mySetArgs,
+      relayerRouterAddress: 456789,
+    });
+    const expectedResult = ['2', '234', '235', '562', '567', '49', '0', '456789'];
+    expect(compiledArr).toStrictEqual(expectedResult);
+    expect(compiledObj).toStrictEqual(expectedResult);
   });
 
   describe('Composed and nested data types (felt, array, struct, tuples), formatter', () => {

--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -160,7 +160,7 @@ export class CallData {
    */
   static compile(rawArgs: RawArgs): Calldata {
     const createTree = (obj: object) => {
-      const getEntries = (o: object, prefix = ''): any => {
+      const getEntries = (o: object, prefix = '.'): any => {
         const oe = Array.isArray(o) ? [o.length.toString(), ...o] : o;
         return Object.entries(oe).flatMap(([k, v]) => {
           let value = v;


### PR DESCRIPTION
## Motivation and Resolution
Solve #700 

## Usage related changes

CallData.compile can now handle a mix of litterals and complex inputs.

## Development related changes

A test added to test this specific case

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
