### PR TITLE
fix: use BigNumberish for u256 in .populate & myCallData.compile

### DIFF
--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -163,7 +163,9 @@ describe('Cairo 1 Devnet', () => {
       const myCall0 = cairo1Contract.populate('test_u256', functionParameters);
       const res0 = await cairo1Contract.test_u256(myCall0.calldata);
       expect(res0).toBe(16n);
-
+      const myCall0a = cairo1Contract.populate('test_u256', { p1: 15 });
+      const res0a = await cairo1Contract.test_u256(myCall0a.calldata);
+      expect(res0a).toBe(16n);
       // using myCallData.compile result in meta-class
       const contractCallData: CallData = new CallData(cairo1Contract.abi);
       const myCalldata: Calldata = contractCallData.compile('test_u256', functionParameters);

--- a/src/utils/calldata/propertyOrder.ts
+++ b/src/utils/calldata/propertyOrder.ts
@@ -47,11 +47,6 @@ export default function orderPropsByAbi(
     if (isTypeEthAddress(abiType)) {
       return unorderedItem;
     }
-    if (isTypeStruct(abiType, structs)) {
-      const abiOfStruct = structs[abiType].members;
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      return orderStruct(unorderedItem, abiOfStruct);
-    }
     if (isTypeUint256(abiType)) {
       const u256 = unorderedItem;
       if (typeof u256 !== 'object') {
@@ -62,6 +57,11 @@ export default function orderPropsByAbi(
         throw errorU256(abiType);
       }
       return { low: u256.low, high: u256.high };
+    }
+    if (isTypeStruct(abiType, structs)) {
+      const abiOfStruct = structs[abiType].members;
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      return orderStruct(unorderedItem, abiOfStruct);
     }
     // litterals
     return unorderedItem;


### PR DESCRIPTION
## Motivation and Resolution

One small bug when using a Bignumberish to represent a u256 in myContract.populate or myCallData.compile : the code fails.
The test for u256 has to be made before the test of struct. Just changed the order of the tests.

To reproduce :
```typescript
const myCall = cairo1Contract.populate('test_u256', { p1: 15 });
```



## Usage related changes

Behavior conform to documentation.

## Development related changes

This case was not tested. Test added


## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing
