### PR TITLE
fix: waitForTransaction for Infura

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -457,12 +457,8 @@ export class RpcProvider implements ProviderInterface {
         txReceipt = await this.getTransactionReceipt(txHash);
 
         // TODO: Hotfix until Pathfinder release fixed casing
-        let executionStatus = txReceipt.execution_status;
-        let finalityStatus = txReceipt.finality_status;
-        if (/[a-z]/.test(txReceipt.execution_status)) {
-          executionStatus = pascalToSnake(txReceipt.execution_status);
-          finalityStatus = pascalToSnake(txReceipt.finality_status);
-        }
+        const executionStatus = pascalToSnake(txReceipt.execution_status);
+        const finalityStatus = pascalToSnake(txReceipt.finality_status);
 
         if (!executionStatus || !finalityStatus) {
           // Transaction is potentially REJECTED or NOT_RECEIVED but RPC doesn't have dose statuses

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -457,8 +457,12 @@ export class RpcProvider implements ProviderInterface {
         txReceipt = await this.getTransactionReceipt(txHash);
 
         // TODO: Hotfix until Pathfinder release fixed casing
-        const executionStatus = pascalToSnake(txReceipt.execution_status);
-        const finalityStatus = pascalToSnake(txReceipt.finality_status);
+        let executionStatus = txReceipt.execution_status;
+        let finalityStatus = txReceipt.finality_status;
+        if (/[a-z]/.test(txReceipt.execution_status)) {
+          executionStatus = pascalToSnake(txReceipt.execution_status);
+          finalityStatus = pascalToSnake(txReceipt.finality_status);
+        }
 
         if (!executionStatus || !finalityStatus) {
           // Transaction is potentially REJECTED or NOT_RECEIVED but RPC doesn't have dose statuses

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -80,7 +80,9 @@ export function utf8ToArray(str: string): Uint8Array {
  * @returns string
  */
 export const pascalToSnake = (text: string) =>
-  text
-    .split(/(?=[A-Z])/)
-    .join('_')
-    .toUpperCase();
+  !/[a-z]/.test(text)
+    ? text
+        .split(/(?=[A-Z])/)
+        .join('_')
+        .toUpperCase()
+    : text;


### PR DESCRIPTION
## Motivation and Resolution

Several people have reported a frozen code at `provider.waitForTransaction()` (see issue #730 for example).

### RPC version (if applicable)

I made many tests with v5,17.0, v5.19.2, Testnet 1, Tesnet 2, Pathfinder rpc 0.4.0, Infura, Alchemy
The problem is with Infura, whatever Starknet.js version and network.
After investigation, I discovered that Infura just bumped to rpc 0.4.0, with full respect of the specification concerning Status (in Upper Case).
So,
- Starknet.js v5.17.0 is not able to handle rpc 0.4.0
- Starknet.js v5.19.2 is not able to handle status in UpperCase (due to the fact that Pathfinder is in lowerCase, and a fix has been implemented in Starknet.js)

## Usage related changes

Now, Starknet.js will be compatible with a strict respect of rpc 0.4.0 (UpperCase status), and with Pathfinder "nearly" respect of rpc 0.4.0  (lowerCase status).

## Development related changes

Just added a check of lowercase, with a correction if necessary.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] All tests are passing (see hereunder). 

As starknet-devnet isn't compatible with rpc 0.4.0, I made the tests outside of the project :
Starknet.js v5.17.0 + Alchemy ➡️ OK (do not work with later versions)
Starknet.js v5.17.0 + Pathfinder rpc 0.3.0 ➡️ OK  (do not work with later versions)
Starknet.js v5.19.3 + Pathfinder rpc 0.4.0 ➡️ OK
Starknet.js v5.19.4 + Infura ➡️ OK
Starknet.js v5.19.4 + Pathfinder rpc 0.4.0  ➡️ OK

In summary :
- Alchemy & Pathfinder rpc 0.3.0   ➡️ Starknet.js v5.17.0
- Infura & Pathfinder rpc 0.4.0   ➡️  Starknet.js v5.19.4