### PR TITLE
docs: account made of cairo 1 contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.19.4](https://github.com/0xs34n/starknet.js/compare/v5.19.3...v5.19.4) (2023-08-29)
+
+### Bug Fixes
+
+- use BigNumberish for u256 ([3a7be10](https://github.com/0xs34n/starknet.js/commit/3a7be1075b0ca4f217cf28aabaa870c93c08f6d1))
+- waitForTransaction for Infura ([c871fe6](https://github.com/0xs34n/starknet.js/commit/c871fe65a0b08e368218f51327cd64591f2b7f49))
+
 ## [5.19.3](https://github.com/0xs34n/starknet.js/compare/v5.19.2...v5.19.3) (2023-08-22)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.19.5](https://github.com/0xs34n/starknet.js/compare/v5.19.4...v5.19.5) (2023-08-29)
+
+### Bug Fixes
+
+- status case ([5ba7983](https://github.com/0xs34n/starknet.js/commit/5ba798309d2c8567840b8f6a6031ec0e6b582d53))
+
 ## [5.19.4](https://github.com/0xs34n/starknet.js/compare/v5.19.3...v5.19.4) (2023-08-29)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet",
-  "version": "5.19.3",
+  "version": "5.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet",
-      "version": "5.19.3",
+      "version": "5.19.4",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet",
-  "version": "5.19.4",
+  "version": "5.19.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet",
-      "version": "5.19.4",
+      "version": "5.19.5",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet",
-  "version": "5.19.3",
+  "version": "5.19.4",
   "description": "JavaScript library for Starknet",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet",
-  "version": "5.19.4",
+  "version": "5.19.5",
   "description": "JavaScript library for Starknet",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -45,6 +45,14 @@ const account = new Account(provider, accountAddress, privateKey);
 
 Your account is now connected, and you can use it.
 
+> **IMPORTANT :** If this account is based on a Cairo v2 contract (for example OpenZeppelin account 0.7.0 or later), do not forget to add the parameter "1" after the privateKey parameter :
+
+```typescript
+const account = new Account(provider, accountAddress, privateKey, "1");
+```
+
+> Take care that this added parameter is a string, NOT a number.
+
 ## 👛 Connect to an existing account (in any network)
 
 The code is the same, you just have to:
@@ -66,4 +74,6 @@ const privateKey = process.env.OZ_NEW_ACCOUNT_PRIVKEY;
 const accountAddress = "0x051158d244c7636dde39ec822873b29e6c9a758c6a9812d005b6287564908667";
 
 const account = new Account(provider, accountAddress, privateKey);
+// add ,"1" after privateKey if this account is not a Cairo 0 contract
+
 ```

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -85,6 +85,14 @@ await provider.waitForTransaction(transaction_hash);
 console.log('✅ New OpenZeppelin account created.\n   address =', contract_address);
 ```
 
+> **IMPORTANT :** If this account is based on a Cairo v2 contract (for example OpenZeppelin account 0.7.0 or later), do not forget to add the parameter "1" after the privateKey parameter :
+
+```typescript
+const OZaccount = new Account(provider, OZcontractAddress, privateKey, "1");
+```
+
+> Take care that this added parameter is a string, NOT a number.
+
 ## Create an Argent account
 
 > Level: medium.
@@ -264,6 +272,7 @@ const provider = new Provider({ sequencer: { network: "http://127.0.0.1:5050" } 
 const privateKey0 = "0xe3e70682c2094cac629f6fbed82c07cd";
 const accountAddress0 = "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a";
 const account0 = new Account(provider, accountAddress0, privateKey0);
+// add ,"1" after privateKey0 if this account is not a Cairo 0 contract
 
 // new account abstraction
 // Generate public and private key pair.
@@ -298,6 +307,7 @@ console.log('Answer mint =', answer);
 
 // deploy account
 const AAaccount = new Account(provider, AAcontractAddress, AAprivateKey);
+// add ,"1" after AAprivateKey if this account is not a Cairo 0 contract
 const { transaction_hash, contract_address } = await AAaccount.deployAccount({
     classHash: AAaccountClassHash,
     constructorCalldata: AAaccountConstructorCallData,

--- a/www/docs/guides/create_contract.md
+++ b/www/docs/guides/create_contract.md
@@ -43,6 +43,7 @@ const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } 
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";
 const account0 = new Account(provider, account0Address, privateKey0);
+// add ,"1" after privateKey0 if this account is not a Cairo 0 contract
 
 // Declare & deploy Test contract in devnet
 const compiledTestSierra = json.parse(fs.readFileSync( "./compiledContracts/test.sierra").toString( "ascii"));
@@ -67,6 +68,7 @@ const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";
 
 const account0 = new Account(provider, account0Address, privateKey0);
+// add ,"1" after privateKey0 if this account is not a Cairo 0 contract
 
 // Deploy Test contract in devnet
 // ClassHash of the already declared contract
@@ -165,7 +167,8 @@ const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } 
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";
 
-const account0 = new Account(provider, account0Address, starkKeyPair0);
+const account0 = new Account(provider, account0Address, privateKey0);
+// add ,"1" after privateKey0 if this account is not a Cairo 0 contract
 
 // Declare Test contract in devnet
 const compiledTestSierra = json.parse(fs.readFileSync( "./compiledContracts/test.sierra").toString("ascii"));

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -72,6 +72,7 @@ const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address = "0x123....789";
 
 const account0 = new Account(provider, account0Address, privateKey0);
+// add ,"1" after privateKey0 if this account is not a Cairo 0 contract
 
 // Connect the deployed Test contract in Tesnet
 const testAddress = "0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd";


### PR DESCRIPTION
## Motivation and Resolution

Solve #686 .
First accounts coded with Cairo v2 language are now arriving in Starknet. It's time to alert that the creation of a such Account object needs a specific optional parameter :
A "1" string has to be added as last parameter  :
```typescript
const OZaccount = new Account(provider, OZcontractAddress, privateKey, "1");
```

The documentation has been updated to alert about this subject.

The community has already been alerted on Discord : [Discord message]( https://discord.com/channels/793094838509764618/927918707613786162/1145015291944906824)



## Usage related changes

N/A

## Development related changes

N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] All tests are passing
